### PR TITLE
Adjust album sidebar highlight indentation

### DIFF
--- a/src/iPhoto/gui/ui/widgets/album_sidebar.py
+++ b/src/iPhoto/gui/ui/widgets/album_sidebar.py
@@ -155,20 +155,6 @@ class AlbumTreeView(QTreeView):
 
         if has_children:
             super().drawBranches(painter, rect, index)
-            return
-
-        palette = self.palette()
-        use_alternate = self.alternatingRowColors() and index.row() % 2
-        base_brush = (
-            palette.brush(QPalette.ColorRole.AlternateBase)
-            if use_alternate
-            else palette.brush(QPalette.ColorRole.Base)
-        )
-        painter.save()
-        try:
-            painter.fillRect(rect, base_brush)
-        finally:
-            painter.restore()
 
 
 class AlbumSidebar(QWidget):
@@ -240,6 +226,9 @@ class AlbumSidebar(QWidget):
             "QTreeView::item { border: 0px; padding: 0px; margin: 0px; }"
             "QTreeView::item:selected { background: transparent; }"
             "QTreeView::item:hover { background: transparent; }"
+            "QTreeView::branch { background: transparent; }"
+            "QTreeView::branch:selected { background: transparent; }"
+            "QTreeView::branch:hover { background: transparent; }"
         )
 
         layout = QVBoxLayout(self)


### PR DESCRIPTION
## Summary
- ensure album and sub-album sidebar rows leave space for the disclosure arrow when painting the highlight
- keep highlight alignment consistent for nodes with or without children

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7cf5f7554832f9a4ccf44f7ba8527