### PR TITLE
Refactor album sidebar rendering pipeline

### DIFF
--- a/src/iPhoto/gui/ui/widgets/album_sidebar.py
+++ b/src/iPhoto/gui/ui/widgets/album_sidebar.py
@@ -6,18 +6,13 @@ from pathlib import Path
 from typing import Optional
 
 from PySide6.QtCore import QModelIndex, QPoint, QSize, Qt, Signal
-from PySide6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPalette, QPen
+from PySide6.QtGui import QColor, QFont, QPalette
 from PySide6.QtWidgets import (
     QInputDialog,
     QLabel,
     QMenu,
     QMessageBox,
-    QFrame,
     QSizePolicy,
-    QStyledItemDelegate,
-    QStyle,
-    QStyleOptionViewItem,
-    QTreeView,
     QVBoxLayout,
     QWidget,
 )
@@ -28,117 +23,15 @@ from ....library.tree import AlbumNode
 from ..models.album_tree_model import (
     AlbumTreeItem,
     AlbumTreeModel,
-    AlbumTreeRole,
     NodeType,
 )
+from .album_sidebar_view import AlbumTreeView
 
 # ---------------------------------------------------------------------------
 # Sidebar styling helpers
 # ---------------------------------------------------------------------------
 
-BG_COLOR = QColor("#eef3f6")
-TEXT_COLOR = QColor("#2b2b2b")
-ICON_COLOR = QColor("#1e73ff")
-HOVER_BG = QColor(0, 0, 0, 24)
-SELECT_BG = QColor(0, 0, 0, 56)
-DISABLED_TEXT = QColor(0, 0, 0, 90)
-SECTION_TEXT = QColor(0, 0, 0, 160)
-SEPARATOR_COLOR = QColor(0, 0, 0, 40)
-
-ROW_HEIGHT = 36
-ROW_RADIUS = 10
-LEFT_PADDING = 14
-ICON_TEXT_GAP = 10
-
-
-class AlbumSidebarDelegate(QStyledItemDelegate):
-    """Custom delegate painting the sidebar with a macOS inspired style."""
-
-    def sizeHint(  # noqa: D401 - inherited docstring
-        self, option: QStyleOptionViewItem, _index: QModelIndex
-    ) -> QSize:
-        width = option.rect.width()
-        if width <= 0:
-            width = 200
-        return QSize(width, ROW_HEIGHT)
-
-    def paint(
-        self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex
-    ) -> None:
-        painter.save()
-        rect = option.rect
-        node_type = index.data(AlbumTreeRole.NODE_TYPE) or NodeType.ALBUM
-
-        # Draw separator rows as a thin line.
-        if node_type == NodeType.SEPARATOR:
-            pen = QPen(SEPARATOR_COLOR)
-            pen.setWidth(1)
-            painter.setPen(pen)
-            y = rect.center().y()
-            painter.drawLine(rect.left() + LEFT_PADDING, y, rect.right() - LEFT_PADDING, y)
-            painter.restore()
-            return
-
-        is_enabled = bool(option.state & QStyle.StateFlag.State_Enabled)
-        is_selected = bool(option.state & QStyle.StateFlag.State_Selected)
-        is_hover = bool(option.state & QStyle.StateFlag.State_MouseOver)
-
-        highlight = None
-        if is_selected:
-            highlight = SELECT_BG
-        elif is_hover and is_enabled:
-            highlight = HOVER_BG
-
-        if node_type in {NodeType.SECTION, NodeType.SEPARATOR}:
-            highlight = None
-
-        if highlight is not None:
-            background_rect = rect.adjusted(6, 4, -6, -4)
-            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-            painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(highlight)
-            painter.drawRoundedRect(background_rect, ROW_RADIUS, ROW_RADIUS)
-
-        text = index.data(Qt.ItemDataRole.DisplayRole) or ""
-        icon = index.data(Qt.ItemDataRole.DecorationRole)
-
-        font = QFont(option.font)
-        if node_type == NodeType.HEADER:
-            font.setPointSizeF(font.pointSizeF() + 1.0)
-            font.setBold(True)
-        elif node_type == NodeType.SECTION:
-            font.setPointSizeF(font.pointSizeF() - 0.5)
-            font.setCapitalization(QFont.Capitalization.SmallCaps)
-        if node_type == NodeType.ACTION:
-            font.setItalic(True)
-        painter.setFont(font)
-
-        color = TEXT_COLOR if is_enabled else DISABLED_TEXT
-        if node_type == NodeType.SECTION:
-            color = SECTION_TEXT
-        elif node_type == NodeType.ACTION:
-            color = ICON_COLOR
-        painter.setPen(color)
-
-        x = rect.left() + LEFT_PADDING
-        icon_size = 18
-        if icon is not None and not icon.isNull():
-            icon_rect = rect.adjusted(0, 0, 0, 0)
-            icon_rect.setLeft(x)
-            icon_rect.setWidth(icon_size)
-            icon.paint(
-                painter,
-                icon_rect,
-                Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignHCenter,
-            )
-            x += icon_size + ICON_TEXT_GAP
-
-        metrics = QFontMetrics(font)
-        text_rect = rect.adjusted(x - rect.left(), 0, -8, 0)
-        elided = metrics.elidedText(text, Qt.TextElideMode.ElideRight, text_rect.width())
-        painter.drawText(text_rect, Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft, elided)
-
-        painter.restore()
+SIDEBAR_BG_COLOR = QColor("#e8e8ea")
 
 
 class AlbumSidebar(QWidget):
@@ -164,8 +57,8 @@ class AlbumSidebar(QWidget):
         self._current_static_selection: str | None = None
 
         palette = self.palette()
-        palette.setColor(QPalette.ColorRole.Window, BG_COLOR)
-        palette.setColor(QPalette.ColorRole.Base, BG_COLOR)
+        palette.setColor(QPalette.ColorRole.Window, SIDEBAR_BG_COLOR)
+        palette.setColor(QPalette.ColorRole.Base, SIDEBAR_BG_COLOR)
         self.setPalette(palette)
         self.setAutoFillBackground(True)
 
@@ -179,38 +72,15 @@ class AlbumSidebar(QWidget):
         self._title.setFont(title_font)
         self._title.setStyleSheet("color: #1b1b1b;")
 
-        self._tree = QTreeView()
+        self._tree = AlbumTreeView(self)
         self._tree.setObjectName("albumSidebarTree")
         self._tree.setModel(self._model)
-        self._tree.setHeaderHidden(True)
-        self._tree.setRootIsDecorated(False)
-        self._tree.setUniformRowHeights(True)
-        self._tree.setEditTriggers(QTreeView.EditTrigger.NoEditTriggers)
         self._tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self._tree.customContextMenuRequested.connect(self._show_context_menu)
         self._tree.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self._tree.doubleClicked.connect(self._on_double_clicked)
         self._tree.setMinimumWidth(220)
-        self._tree.setIndentation(18)
         self._tree.setIconSize(QSize(18, 18))
-        self._tree.setMouseTracking(True)
-        self._tree.setAttribute(Qt.WidgetAttribute.WA_Hover, True)
-        self._tree.setItemDelegate(AlbumSidebarDelegate(self._tree))
-        self._tree.setFrameShape(QFrame.Shape.NoFrame)
-        self._tree.setAlternatingRowColors(False)
-        self._tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        self._tree.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        tree_palette = self._tree.palette()
-        tree_palette.setColor(QPalette.ColorRole.Base, BG_COLOR)
-        tree_palette.setColor(QPalette.ColorRole.Window, BG_COLOR)
-        self._tree.setPalette(tree_palette)
-        self._tree.setAutoFillBackground(True)
-        self._tree.setStyleSheet(
-            "QTreeView { background: transparent; }"
-            "QTreeView::item { border: 0px; padding: 0px; margin: 0px; }"
-            "QTreeView::item:selected { background: transparent; }"
-            "QTreeView::item:hover { background: transparent; }"
-        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)

--- a/src/iPhoto/gui/ui/widgets/album_sidebar_delegate.py
+++ b/src/iPhoto/gui/ui/widgets/album_sidebar_delegate.py
@@ -1,0 +1,138 @@
+"""Custom item delegate rendering the album sidebar with macOS inspired styling."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QModelIndex, QRect, QSize, Qt
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPen, QPixmap
+from PySide6.QtWidgets import QStyle, QStyleOptionViewItem, QStyledItemDelegate
+
+from ..models.album_tree_model import AlbumTreeRole, NodeType
+
+# ---------------------------------------------------------------------------
+# Sidebar styling constants
+# ---------------------------------------------------------------------------
+
+TEXT_COLOR = QColor("#1d1d1f")
+SECTION_TEXT_COLOR = QColor("#6e6e73")
+HOVER_BG_COLOR = QColor(0, 0, 0, 24)
+SELECT_BG_COLOR = QColor("#d1d1d6")
+ICON_COLOR = QColor("#6e6e73")
+ICON_SELECTED_COLOR = QColor("#007aff")
+DISABLED_ALPHA = 120
+
+ROW_HEIGHT = 32
+ROW_RADIUS = 6
+LEFT_PADDING = 14
+ICON_TEXT_GAP = 8
+ICON_SIZE = 18
+BACKGROUND_MARGIN = (6, 4, -6, -4)
+
+
+class AlbumSidebarDelegate(QStyledItemDelegate):
+    """Render sidebar rows by fully controlling state-dependent painting."""
+
+    def sizeHint(self, option: QStyleOptionViewItem, _index: QModelIndex) -> QSize:  # noqa: D401
+        width = option.rect.width() or 200
+        return QSize(width, ROW_HEIGHT)
+
+    def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+
+        rect = option.rect
+        node_type = index.data(AlbumTreeRole.NODE_TYPE) or NodeType.ALBUM
+
+        if node_type == NodeType.SEPARATOR:
+            pen = QPen(QColor(0, 0, 0, 40))
+            pen.setWidth(1)
+            painter.setPen(pen)
+            y = rect.center().y()
+            painter.drawLine(rect.left() + LEFT_PADDING, y, rect.right() - LEFT_PADDING, y)
+            painter.restore()
+            return
+
+        is_enabled = bool(option.state & QStyle.StateFlag.State_Enabled)
+        is_selected = bool(option.state & QStyle.StateFlag.State_Selected)
+        is_hover = bool(option.state & QStyle.StateFlag.State_MouseOver)
+
+        interactive_nodes = {
+            NodeType.STATIC,
+            NodeType.ALBUM,
+            NodeType.SUBALBUM,
+            NodeType.ACTION,
+        }
+        if node_type in interactive_nodes:
+            margin_left, margin_top, margin_right, margin_bottom = BACKGROUND_MARGIN
+            background_rect = rect.adjusted(
+                margin_left,
+                margin_top,
+                margin_right,
+                margin_bottom,
+            )
+            if is_selected:
+                painter.setBrush(SELECT_BG_COLOR)
+                painter.setPen(Qt.PenStyle.NoPen)
+                painter.drawRoundedRect(background_rect, ROW_RADIUS, ROW_RADIUS)
+            elif is_hover and is_enabled:
+                painter.setBrush(HOVER_BG_COLOR)
+                painter.setPen(Qt.PenStyle.NoPen)
+                painter.drawRoundedRect(background_rect, ROW_RADIUS, ROW_RADIUS)
+
+        text = index.data(Qt.ItemDataRole.DisplayRole) or ""
+        icon = index.data(Qt.ItemDataRole.DecorationRole)
+
+        font = QFont(option.font)
+        if node_type == NodeType.HEADER:
+            font.setPointSizeF(font.pointSizeF() + 1.0)
+            font.setBold(True)
+        elif node_type == NodeType.SECTION:
+            font.setPointSizeF(font.pointSizeF() - 0.5)
+            font.setCapitalization(QFont.Capitalization.AllUppercase)
+        if node_type == NodeType.ACTION:
+            font.setItalic(True)
+        painter.setFont(font)
+
+        text_color = TEXT_COLOR
+        icon_color = ICON_COLOR
+        if node_type == NodeType.SECTION:
+            text_color = SECTION_TEXT_COLOR
+        elif node_type == NodeType.ACTION:
+            text_color = ICON_SELECTED_COLOR
+        if is_selected:
+            icon_color = ICON_SELECTED_COLOR
+        if not is_enabled:
+            text_color = QColor(text_color)
+            icon_color = QColor(icon_color)
+            text_color.setAlpha(DISABLED_ALPHA)
+            icon_color.setAlpha(DISABLED_ALPHA)
+
+        x_offset = rect.left() + LEFT_PADDING
+        if icon is not None and not icon.isNull():
+            icon_rect = QRect(
+                x_offset,
+                rect.top() + (rect.height() - ICON_SIZE) // 2,
+                ICON_SIZE,
+                ICON_SIZE,
+            )
+            pixmap = icon.pixmap(ICON_SIZE, ICON_SIZE)
+            if not pixmap.isNull():
+                tinted = QPixmap(pixmap.size())
+                tinted.fill(Qt.GlobalColor.transparent)
+                mask_painter = QPainter(tinted)
+                mask_painter.drawPixmap(0, 0, pixmap)
+                mask_painter.setCompositionMode(QPainter.CompositionMode_SourceIn)
+                mask_painter.fillRect(tinted.rect(), icon_color)
+                mask_painter.end()
+                painter.drawPixmap(icon_rect.topLeft(), tinted)
+            x_offset += ICON_SIZE + ICON_TEXT_GAP
+
+        painter.setPen(text_color)
+        metrics = QFontMetrics(font)
+        text_rect = rect.adjusted(x_offset - rect.left(), 0, -8, 0)
+        elided = metrics.elidedText(text, Qt.TextElideMode.ElideRight, text_rect.width())
+        painter.drawText(text_rect, Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft, elided)
+
+        painter.restore()
+
+
+__all__ = ["AlbumSidebarDelegate"]

--- a/src/iPhoto/gui/ui/widgets/album_sidebar_view.py
+++ b/src/iPhoto/gui/ui/widgets/album_sidebar_view.py
@@ -1,0 +1,57 @@
+"""QTreeView subclass hosting the album sidebar presentation."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QTreeView
+
+from .album_sidebar_delegate import AlbumSidebarDelegate
+
+
+class AlbumTreeView(QTreeView):
+    """Configure a QTreeView dedicated to the album sidebar."""
+
+    def __init__(self, parent=None) -> None:  # type: ignore[override]
+        super().__init__(parent)
+
+        self.setItemDelegate(AlbumSidebarDelegate(self))
+
+        self.setHeaderHidden(True)
+        self.setRootIsDecorated(False)
+        self.setUniformRowHeights(True)
+        self.setEditTriggers(QTreeView.EditTrigger.NoEditTriggers)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.setIndentation(18)
+        self.setMouseTracking(True)
+        self.setAttribute(Qt.WidgetAttribute.WA_Hover, True)
+        self.setFrameShape(QTreeView.Shape.NoFrame)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
+        self.setStyleSheet(
+            """
+            QTreeView {
+                background-color: transparent;
+                border: none;
+            }
+            QTreeView::item {
+                background: transparent;
+                border: none;
+                padding: 0px;
+                margin: 0px;
+            }
+            QTreeView::item:selected {
+                background: transparent;
+                color: black;
+            }
+            QTreeView::item:hover {
+                background: transparent;
+            }
+            QTreeView::branch {
+                background: transparent;
+            }
+            """
+        )
+
+
+__all__ = ["AlbumTreeView"]


### PR DESCRIPTION
## Summary
- move the sidebar item painting logic into a dedicated `AlbumSidebarDelegate` for consistent macOS-inspired styling
- introduce an `AlbumTreeView` helper that configures the tree view and disables Qt default state rendering to prevent ghost highlights
- simplify `AlbumSidebar` to compose the new view/delegate while keeping signal and selection management intact

## Testing
- pytest tests/test_album_sidebar.py *(skipped: Qt widgets not available)*

------
https://chatgpt.com/codex/tasks/task_e_68e7f0171ba8832fb95de14b4cf62e02