### PR TITLE
Refactor album sidebar into modular components

### DIFF
--- a/src/iPhoto/gui/ui/delegates/__init__.py
+++ b/src/iPhoto/gui/ui/delegates/__init__.py
@@ -1,0 +1,5 @@
+"""Delegate utilities for GUI widgets."""
+
+from .album_sidebar_delegate import AlbumSidebarDelegate, BranchIndicatorController
+
+__all__ = ["AlbumSidebarDelegate", "BranchIndicatorController"]

--- a/src/iPhoto/gui/ui/delegates/album_sidebar_delegate.py
+++ b/src/iPhoto/gui/ui/delegates/album_sidebar_delegate.py
@@ -1,0 +1,303 @@
+"""Custom delegate and animations for the album sidebar tree."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from PySide6.QtCore import (
+    QEasingCurve,
+    QModelIndex,
+    QObject,
+    QRect,
+    QSize,
+    Qt,
+    QVariantAnimation,
+    QPersistentModelIndex,
+)
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QPainter, QPainterPath, QPen
+from PySide6.QtWidgets import QStyledItemDelegate, QStyle, QStyleOptionViewItem, QTreeView
+
+from ..models.album_tree_model import AlbumTreeRole, NodeType
+
+BG_COLOR = QColor("#eef3f6")
+TEXT_COLOR = QColor("#2b2b2b")
+ICON_COLOR = QColor("#1e73ff")
+HOVER_BG = QColor(0, 0, 0, 24)
+SELECT_BG = QColor(0, 0, 0, 56)
+DISABLED_TEXT = QColor(0, 0, 0, 90)
+SECTION_TEXT = QColor(0, 0, 0, 160)
+SEPARATOR_COLOR = QColor(0, 0, 0, 40)
+
+ROW_HEIGHT = 36
+ROW_RADIUS = 10
+LEFT_PADDING = 14
+ICON_TEXT_GAP = 10
+INDENT_PER_LEVEL = 22
+INDICATOR_SLOT_WIDTH = 22
+INDICATOR_SIZE = 16
+
+
+@dataclass(slots=True)
+class _IndicatorState:
+    """Track the rendering state for a branch indicator."""
+
+    angle: float = 0.0
+    animation: QVariantAnimation | None = None
+
+
+class BranchIndicatorController(QObject):
+    """Animate branch indicators in sync with the tree view state."""
+
+    def __init__(self, tree: QTreeView) -> None:
+        super().__init__(tree)
+        self._tree = tree
+        self._states: dict[QPersistentModelIndex, _IndicatorState] = {}
+        self._duration = 180
+
+        self._tree.expanded.connect(self._on_expanded)
+        self._tree.collapsed.connect(self._on_collapsed)
+
+        model = tree.model()
+        if model is not None:
+            model.modelAboutToBeReset.connect(self._clear_states)
+
+    def angle_for_index(self, index: QModelIndex) -> float:
+        """Return the current angle associated with *index*."""
+
+        self._cleanup_invalid_states()
+        if not index.isValid():
+            return 0.0
+        key = QPersistentModelIndex(index)
+        state = self._states.get(key)
+        if state is None:
+            angle = 90.0 if self._tree.isExpanded(index) else 0.0
+            state = _IndicatorState(angle=angle)
+            self._states[key] = state
+        return state.angle
+
+    def _start_animation(self, index: QModelIndex, target_angle: float) -> None:
+        self._cleanup_invalid_states()
+        if not index.isValid():
+            return
+        key = QPersistentModelIndex(index)
+        state = self._states.get(key)
+        if state is None:
+            state = _IndicatorState(angle=target_angle)
+            self._states[key] = state
+
+        if math.isclose(state.angle, target_angle, abs_tol=0.5):
+            state.angle = target_angle
+            return
+
+        if state.animation is not None:
+            state.animation.stop()
+
+        animation = QVariantAnimation(self)
+        animation.setStartValue(state.angle)
+        animation.setEndValue(target_angle)
+        animation.setDuration(self._duration)
+        animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+
+        index_copy = QModelIndex(index)
+
+        def _on_value_changed(value: float) -> None:
+            state.angle = float(value)
+            self._tree.viewport().update(self._tree.visualRect(index_copy))
+
+        def _on_finished() -> None:
+            state.animation = None
+            state.angle = target_angle
+            self._tree.viewport().update(self._tree.visualRect(index_copy))
+
+        animation.valueChanged.connect(_on_value_changed)
+        animation.finished.connect(_on_finished)
+        state.animation = animation
+        animation.start()
+
+    def _on_expanded(self, index: QModelIndex) -> None:
+        self._start_animation(index, 90.0)
+
+    def _on_collapsed(self, index: QModelIndex) -> None:
+        self._start_animation(index, 0.0)
+
+    def _clear_states(self) -> None:
+        for state in self._states.values():
+            if state.animation is not None:
+                state.animation.stop()
+        self._states.clear()
+
+    def _cleanup_invalid_states(self) -> None:
+        invalid = [key for key in self._states.keys() if not key.isValid()]
+        for key in invalid:
+            state = self._states.pop(key)
+            if state.animation is not None:
+                state.animation.stop()
+
+
+class AlbumSidebarDelegate(QStyledItemDelegate):
+    """Custom delegate painting the sidebar with a macOS inspired style."""
+
+    def sizeHint(  # noqa: D401 - inherited docstring
+        self, option: QStyleOptionViewItem, _index: QModelIndex
+    ) -> QSize:
+        width = option.rect.width()
+        if width <= 0:
+            width = 200
+        return QSize(width, ROW_HEIGHT)
+
+    def paint(
+        self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex
+    ) -> None:
+        painter.save()
+        rect = option.rect
+        node_type = index.data(AlbumTreeRole.NODE_TYPE) or NodeType.ALBUM
+
+        tree_view: QTreeView | None = None
+        if isinstance(option.widget, QTreeView):
+            tree_view = option.widget
+        elif isinstance(self.parent(), QTreeView):
+            tree_view = self.parent()
+
+        if node_type == NodeType.SEPARATOR:
+            pen = QPen(SEPARATOR_COLOR)
+            pen.setWidth(1)
+            painter.setPen(pen)
+            y = rect.center().y()
+            painter.drawLine(rect.left() + LEFT_PADDING, y, rect.right() - LEFT_PADDING, y)
+            painter.restore()
+            return
+
+        is_enabled = bool(option.state & QStyle.StateFlag.State_Enabled)
+        is_selected = bool(option.state & QStyle.StateFlag.State_Selected)
+        is_hover = bool(option.state & QStyle.StateFlag.State_MouseOver)
+
+        highlight_color = None
+        if node_type not in {NodeType.SECTION, NodeType.SEPARATOR}:
+            if is_selected:
+                highlight_color = SELECT_BG
+            elif is_hover and is_enabled:
+                highlight_color = HOVER_BG
+
+        if highlight_color is not None:
+            background_rect = rect.adjusted(6, 4, -6, -4)
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(highlight_color)
+            painter.drawRoundedRect(background_rect, ROW_RADIUS, ROW_RADIUS)
+
+        font = QFont(option.font)
+        if node_type == NodeType.HEADER:
+            font.setPointSizeF(font.pointSizeF() + 1.0)
+            font.setBold(True)
+        elif node_type == NodeType.SECTION:
+            font.setPointSizeF(font.pointSizeF() - 0.5)
+            font.setCapitalization(QFont.Capitalization.SmallCaps)
+        if node_type == NodeType.ACTION:
+            font.setItalic(True)
+        painter.setFont(font)
+
+        text_color = TEXT_COLOR if is_enabled else DISABLED_TEXT
+        if node_type == NodeType.SECTION:
+            text_color = SECTION_TEXT
+        elif node_type == NodeType.ACTION:
+            text_color = ICON_COLOR
+
+        text = index.data(Qt.ItemDataRole.DisplayRole) or ""
+        icon = index.data(Qt.ItemDataRole.DecorationRole)
+
+        depth = self._depth_for_index(index)
+        indentation = depth * INDENT_PER_LEVEL
+        x = rect.left() + LEFT_PADDING + indentation
+
+        model = index.model()
+        has_children = bool(model is not None and model.hasChildren(index))
+
+        if tree_view is not None and has_children:
+            branch_rect = QRect(
+                x,
+                rect.top() + (rect.height() - INDICATOR_SIZE) // 2,
+                INDICATOR_SIZE,
+                INDICATOR_SIZE,
+            )
+
+            controller = getattr(tree_view, "branch_indicator_controller", None)
+            angle = (
+                controller.angle_for_index(index)
+                if controller is not None
+                else (90.0 if tree_view.isExpanded(index) else 0.0)
+            )
+
+            painter.save()
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+            indicator_color = TEXT_COLOR if is_enabled else DISABLED_TEXT
+            pen = QPen(indicator_color)
+            pen.setWidth(2)
+            pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+            painter.setPen(pen)
+
+            painter.translate(branch_rect.center())
+            painter.rotate(angle)
+
+            path = QPainterPath()
+            path.moveTo(-2, -4)
+            path.lineTo(2, 0)
+            path.lineTo(-2, 4)
+            painter.drawPath(path)
+
+            painter.restore()
+
+            x = branch_rect.right() + 6
+        elif depth > 0:
+            x += INDICATOR_SLOT_WIDTH
+
+        if icon is not None and not icon.isNull():
+            icon_size = 18
+            icon_rect = QRect(
+                x,
+                rect.top() + (rect.height() - icon_size) // 2,
+                icon_size,
+                icon_size,
+            )
+            icon.paint(
+                painter,
+                icon_rect,
+                Qt.AlignmentFlag.AlignCenter,
+            )
+            x = icon_rect.right() + ICON_TEXT_GAP
+
+        painter.setPen(text_color)
+        metrics = QFontMetrics(font)
+        text_rect = rect.adjusted(x - rect.left(), 0, -8, 0)
+        elided = metrics.elidedText(text, Qt.TextElideMode.ElideRight, text_rect.width())
+        painter.drawText(
+            text_rect,
+            Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
+            elided,
+        )
+
+        painter.restore()
+
+    @staticmethod
+    def _depth_for_index(index: QModelIndex) -> int:
+        depth = 0
+        parent = index.parent()
+        while parent.isValid():
+            depth += 1
+            parent = parent.parent()
+        return depth
+
+
+__all__ = [
+    "AlbumSidebarDelegate",
+    "BranchIndicatorController",
+    "BG_COLOR",
+    "TEXT_COLOR",
+    "ICON_COLOR",
+    "HOVER_BG",
+    "SELECT_BG",
+    "DISABLED_TEXT",
+    "LEFT_PADDING",
+    "INDENT_PER_LEVEL",
+    "INDICATOR_SIZE",
+]

--- a/src/iPhoto/gui/ui/menus/__init__.py
+++ b/src/iPhoto/gui/ui/menus/__init__.py
@@ -1,0 +1,5 @@
+"""Context menu helpers for GUI widgets."""
+
+from .album_sidebar_menu import AlbumSidebarContextMenu, show_context_menu
+
+__all__ = ["AlbumSidebarContextMenu", "show_context_menu"]

--- a/src/iPhoto/gui/ui/menus/album_sidebar_menu.py
+++ b/src/iPhoto/gui/ui/menus/album_sidebar_menu.py
@@ -1,0 +1,163 @@
+"""Context menu helpers for the album sidebar widget."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+from PySide6.QtCore import QPoint, QUrl
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtWidgets import QInputDialog, QMenu, QMessageBox, QWidget, QTreeView
+
+from ....errors import LibraryError
+from ....library.manager import LibraryManager
+from ....library.tree import AlbumNode
+from ..models.album_tree_model import AlbumTreeItem, NodeType, AlbumTreeModel
+
+
+class AlbumSidebarContextMenu(QMenu):
+    """Context menu providing album management actions."""
+
+    def __init__(
+        self,
+        parent: QWidget,
+        tree: QTreeView,
+        model: AlbumTreeModel,
+        library: LibraryManager,
+        item: AlbumTreeItem,
+        set_pending_selection: Callable[[Path | None], None],
+        on_bind_library: Callable[[], None],
+    ) -> None:
+        super().__init__(parent)
+        self._tree = tree
+        self._model = model
+        self._library = library
+        self._item = item
+        self._set_pending_selection = set_pending_selection
+        self._on_bind_library = on_bind_library
+        self._build_menu()
+
+    def _build_menu(self) -> None:
+        if self._item.node_type in {NodeType.HEADER, NodeType.SECTION}:
+            self.addAction("New Album…", self._prompt_new_album)
+        if self._item.node_type == NodeType.ALBUM:
+            self.addAction(
+                "New Sub-Album…",
+                lambda: self._prompt_new_album(self._item),
+            )
+            self.addAction(
+                "Rename Album…",
+                lambda: self._prompt_rename_album(self._item),
+            )
+            self.addSeparator()
+            self.addAction(
+                "Show in File Manager",
+                lambda: self._reveal_path(self._item.album),
+            )
+        if self._item.node_type == NodeType.SUBALBUM:
+            self.addAction(
+                "Rename Album…",
+                lambda: self._prompt_rename_album(self._item),
+            )
+            self.addSeparator()
+            self.addAction(
+                "Show in File Manager",
+                lambda: self._reveal_path(self._item.album),
+            )
+        if self._item.node_type == NodeType.ACTION:
+            self.addAction("Set Basic Library…", self._on_bind_library)
+
+    def _prompt_new_album(self, parent_item: Optional[AlbumTreeItem] = None) -> None:
+        base_item = parent_item
+        if base_item is None:
+            index = self._tree.currentIndex()
+            base_item = self._model.item_from_index(index)
+
+        if base_item is None:
+            return
+
+        name, ok = QInputDialog.getText(self.parentWidget(), "New Album", "Album name:")
+        if not ok:
+            return
+        target_name = name.strip()
+        if not target_name:
+            QMessageBox.warning(self.parentWidget(), "iPhoto", "Album name cannot be empty.")
+            return
+        try:
+            if base_item.node_type == NodeType.ALBUM and base_item.album is not None:
+                node = self._library.create_subalbum(base_item.album, target_name)
+            else:
+                node = self._library.create_album(target_name)
+        except LibraryError as exc:  # pragma: no cover - GUI feedback
+            QMessageBox.warning(self.parentWidget(), "iPhoto", str(exc))
+            return
+        self._set_pending_selection(node.path)
+
+    def _prompt_rename_album(self, item: AlbumTreeItem) -> None:
+        if item.album is None:
+            return
+        current_title = item.album.title
+        name, ok = QInputDialog.getText(
+            self.parentWidget(),
+            "Rename Album",
+            "New album name:",
+            text=current_title,
+        )
+        if not ok:
+            return
+        target_name = name.strip()
+        if not target_name:
+            QMessageBox.warning(self.parentWidget(), "iPhoto", "Album name cannot be empty.")
+            return
+        try:
+            self._library.rename_album(item.album, target_name)
+        except LibraryError as exc:  # pragma: no cover - GUI feedback
+            QMessageBox.warning(self.parentWidget(), "iPhoto", str(exc))
+            return
+        self._set_pending_selection(item.album.path.parent / target_name)
+
+    @staticmethod
+    def _reveal_path(album: Optional[AlbumNode]) -> None:
+        if album is None:
+            return
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(album.path)))
+
+
+def show_context_menu(
+    parent: QWidget,
+    point: QPoint,
+    tree: QTreeView,
+    model: AlbumTreeModel,
+    library: LibraryManager,
+    set_pending_selection: Callable[[Path | None], None],
+    on_bind_library: Callable[[], None],
+) -> None:
+    """Display the context menu for the album sidebar."""
+
+    index = tree.indexAt(point)
+    global_pos = tree.viewport().mapToGlobal(point)
+
+    if not index.isValid():
+        menu = QMenu(parent)
+        menu.addAction("Set Basic Library…", on_bind_library)
+        menu.exec(global_pos)
+        return
+
+    item = model.item_from_index(index)
+    if item is None:
+        return
+
+    menu = AlbumSidebarContextMenu(
+        parent,
+        tree,
+        model,
+        library,
+        item,
+        set_pending_selection,
+        on_bind_library,
+    )
+    if not menu.isEmpty():
+        menu.exec(global_pos)
+
+
+__all__ = ["AlbumSidebarContextMenu", "show_context_menu"]

--- a/src/iPhoto/gui/ui/widgets/album_sidebar.py
+++ b/src/iPhoto/gui/ui/widgets/album_sidebar.py
@@ -2,321 +2,31 @@
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
-from PySide6.QtCore import (
-    QEasingCurve,
-    QModelIndex,
-    QObject,
-    QPoint,
-    QRect,
-    QSize,
-    Qt,
-    Signal,
-    QVariantAnimation,
-    QPersistentModelIndex,
-)
-from PySide6.QtGui import (
-    QColor,
-    QCursor,
-    QFont,
-    QFontMetrics,
-    QPainter,
-    QPainterPath,
-    QPalette,
-    QPen,
-)
+from PySide6.QtCore import QModelIndex, QPoint, QRect, QSize, Qt, Signal
+from PySide6.QtGui import QCursor, QFont, QPalette
 from PySide6.QtWidgets import (
     QFrame,
-    QInputDialog,
     QLabel,
-    QMenu,
-    QMessageBox,
     QSizePolicy,
-    QStyledItemDelegate,
-    QStyleOptionViewItem,
     QTreeView,
     QVBoxLayout,
-    QWidget, QStyle,
+    QWidget,
 )
 
-from ....errors import LibraryError
 from ....library.manager import LibraryManager
-from ....library.tree import AlbumNode
-from ..models.album_tree_model import AlbumTreeModel, AlbumTreeRole, NodeType, AlbumTreeItem
-
-# ---------------------------------------------------------------------------
-# Sidebar styling helpers
-# ---------------------------------------------------------------------------
-
-BG_COLOR = QColor("#eef3f6")
-TEXT_COLOR = QColor("#2b2b2b")
-ICON_COLOR = QColor("#1e73ff")
-HOVER_BG = QColor(0, 0, 0, 24)
-SELECT_BG = QColor(0, 0, 0, 56)
-DISABLED_TEXT = QColor(0, 0, 0, 90)
-SECTION_TEXT = QColor(0, 0, 0, 160)
-SEPARATOR_COLOR = QColor(0, 0, 0, 40)
-
-ROW_HEIGHT = 36
-ROW_RADIUS = 10
-LEFT_PADDING = 14
-ICON_TEXT_GAP = 10
-INDENT_PER_LEVEL = 22
-INDICATOR_SLOT_WIDTH = 22
-INDICATOR_SIZE = 16
-
-@dataclass(slots=True)
-class _IndicatorState:
-    """Track the rendering state for a branch indicator."""
-
-    angle: float = 0.0
-    animation: QVariantAnimation | None = None
-
-
-class BranchIndicatorController(QObject):
-    """Animate branch indicators in sync with the tree view state."""
-
-    def __init__(self, tree: QTreeView) -> None:
-        super().__init__(tree)
-        self._tree = tree
-        self._states: dict[QPersistentModelIndex, _IndicatorState] = {}
-        self._duration = 180
-
-        self._tree.expanded.connect(self._on_expanded)
-        self._tree.collapsed.connect(self._on_collapsed)
-
-        model = tree.model()
-        if model is not None:
-            model.modelAboutToBeReset.connect(self._clear_states)
-
-    def angle_for_index(self, index: QModelIndex) -> float:
-        """Return the current angle associated with *index*."""
-
-        self._cleanup_invalid_states()
-        if not index.isValid():
-            return 0.0
-        key = QPersistentModelIndex(index)
-        state = self._states.get(key)
-        if state is None:
-            angle = 90.0 if self._tree.isExpanded(index) else 0.0
-            state = _IndicatorState(angle=angle)
-            self._states[key] = state
-        return state.angle
-
-    def _start_animation(self, index: QModelIndex, target_angle: float) -> None:
-        self._cleanup_invalid_states()
-        if not index.isValid():
-            return
-        key = QPersistentModelIndex(index)
-        state = self._states.get(key)
-        if state is None:
-            state = _IndicatorState(angle=target_angle)
-            self._states[key] = state
-
-        if math.isclose(state.angle, target_angle, abs_tol=0.5):
-            state.angle = target_angle
-            return
-
-        if state.animation is not None:
-            state.animation.stop()
-
-        animation = QVariantAnimation(self)
-        animation.setStartValue(state.angle)
-        animation.setEndValue(target_angle)
-        animation.setDuration(self._duration)
-        animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
-
-        index_copy = QModelIndex(index)
-
-        def _on_value_changed(value: float) -> None:
-            state.angle = float(value)
-            self._tree.viewport().update(self._tree.visualRect(index_copy))
-
-        def _on_finished() -> None:
-            state.animation = None
-            state.angle = target_angle
-            self._tree.viewport().update(self._tree.visualRect(index_copy))
-
-        animation.valueChanged.connect(_on_value_changed)
-        animation.finished.connect(_on_finished)
-        state.animation = animation
-        animation.start()
-
-    def _on_expanded(self, index: QModelIndex) -> None:
-        self._start_animation(index, 90.0)
-
-    def _on_collapsed(self, index: QModelIndex) -> None:
-        self._start_animation(index, 0.0)
-
-    def _clear_states(self) -> None:
-        for state in self._states.values():
-            if state.animation is not None:
-                state.animation.stop()
-        self._states.clear()
-
-    def _cleanup_invalid_states(self) -> None:
-        invalid = [key for key in self._states.keys() if not key.isValid()]
-        for key in invalid:
-            state = self._states.pop(key)
-            if state.animation is not None:
-                state.animation.stop()
-
-
-class AlbumSidebarDelegate(QStyledItemDelegate):
-    """Custom delegate painting the sidebar with a macOS inspired style."""
-
-    def sizeHint(  # noqa: D401 - inherited docstring
-        self, option: QStyleOptionViewItem, _index: QModelIndex
-    ) -> QSize:
-        width = option.rect.width()
-        if width <= 0:
-            width = 200
-        return QSize(width, ROW_HEIGHT)
-
-    def paint(
-        self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex
-    ) -> None:
-        painter.save()
-        rect = option.rect
-        node_type = index.data(AlbumTreeRole.NODE_TYPE) or NodeType.ALBUM
-
-        tree_view: QTreeView | None = None
-        if isinstance(option.widget, QTreeView):
-            tree_view = option.widget
-        elif isinstance(self.parent(), QTreeView):
-            tree_view = self.parent()
-
-        if node_type == NodeType.SEPARATOR:
-            pen = QPen(SEPARATOR_COLOR)
-            pen.setWidth(1)
-            painter.setPen(pen)
-            y = rect.center().y()
-            painter.drawLine(rect.left() + LEFT_PADDING, y, rect.right() - LEFT_PADDING, y)
-            painter.restore()
-            return
-
-        is_enabled = bool(option.state & QStyle.StateFlag.State_Enabled)
-        is_selected = bool(option.state & QStyle.StateFlag.State_Selected)
-        is_hover = bool(option.state & QStyle.StateFlag.State_MouseOver)
-
-        highlight_color = None
-        if node_type not in {NodeType.SECTION, NodeType.SEPARATOR}:
-            if is_selected:
-                highlight_color = SELECT_BG
-            elif is_hover and is_enabled:
-                highlight_color = HOVER_BG
-
-        if highlight_color is not None:
-            background_rect = rect.adjusted(6, 4, -6, -4)
-            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-            painter.setPen(Qt.PenStyle.NoPen)
-            painter.setBrush(highlight_color)
-            painter.drawRoundedRect(background_rect, ROW_RADIUS, ROW_RADIUS)
-
-        font = QFont(option.font)
-        if node_type == NodeType.HEADER:
-            font.setPointSizeF(font.pointSizeF() + 1.0)
-            font.setBold(True)
-        elif node_type == NodeType.SECTION:
-            font.setPointSizeF(font.pointSizeF() - 0.5)
-            font.setCapitalization(QFont.Capitalization.SmallCaps)
-        if node_type == NodeType.ACTION:
-            font.setItalic(True)
-        painter.setFont(font)
-
-        text_color = TEXT_COLOR if is_enabled else DISABLED_TEXT
-        if node_type == NodeType.SECTION:
-            text_color = SECTION_TEXT
-        elif node_type == NodeType.ACTION:
-            text_color = ICON_COLOR
-
-        text = index.data(Qt.ItemDataRole.DisplayRole) or ""
-        icon = index.data(Qt.ItemDataRole.DecorationRole)
-
-        depth = self._depth_for_index(index)
-        indentation = depth * INDENT_PER_LEVEL
-        x = rect.left() + LEFT_PADDING + indentation
-
-        model = index.model()
-        has_children = bool(model is not None and model.hasChildren(index))
-
-        if tree_view is not None and has_children:
-            branch_rect = QRect(
-                x,
-                rect.top() + (rect.height() - INDICATOR_SIZE) // 2,
-                INDICATOR_SIZE,
-                INDICATOR_SIZE,
-            )
-
-            controller = getattr(tree_view, "branch_indicator_controller", None)
-            angle = (
-                controller.angle_for_index(index)
-                if controller is not None
-                else (90.0 if tree_view.isExpanded(index) else 0.0)
-            )
-
-            painter.save()
-            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-            indicator_color = TEXT_COLOR if is_enabled else DISABLED_TEXT
-            pen = QPen(indicator_color)
-            pen.setWidth(2)
-            pen.setCapStyle(Qt.PenCapStyle.RoundCap)
-            painter.setPen(pen)
-
-            painter.translate(branch_rect.center())
-            painter.rotate(angle)
-
-            path = QPainterPath()
-            path.moveTo(-2, -4)
-            path.lineTo(2, 0)
-            path.lineTo(-2, 4)
-            painter.drawPath(path)
-
-            painter.restore()
-
-            x = branch_rect.right() + 6
-        elif depth > 0:
-            x += INDICATOR_SLOT_WIDTH
-
-        if icon is not None and not icon.isNull():
-            icon_size = 18
-            icon_rect = QRect(
-                x,
-                rect.top() + (rect.height() - icon_size) // 2,
-                icon_size,
-                icon_size,
-            )
-            icon.paint(
-                painter,
-                icon_rect,
-                Qt.AlignmentFlag.AlignCenter,
-            )
-            x = icon_rect.right() + ICON_TEXT_GAP
-
-        painter.setPen(text_color)
-        metrics = QFontMetrics(font)
-        text_rect = rect.adjusted(x - rect.left(), 0, -8, 0)
-        elided = metrics.elidedText(text, Qt.TextElideMode.ElideRight, text_rect.width())
-        painter.drawText(
-            text_rect,
-            Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
-            elided,
-        )
-
-        painter.restore()
-
-    @staticmethod
-    def _depth_for_index(index: QModelIndex) -> int:
-        depth = 0
-        parent = index.parent()
-        while parent.isValid():
-            depth += 1
-            parent = parent.parent()
-        return depth
+from ..models.album_tree_model import AlbumTreeModel, NodeType
+from ..delegates.album_sidebar_delegate import (
+    AlbumSidebarDelegate,
+    BranchIndicatorController,
+    BG_COLOR,
+    TEXT_COLOR,
+    LEFT_PADDING,
+    INDENT_PER_LEVEL,
+    INDICATOR_SIZE,
+)
+from ..menus.album_sidebar_menu import show_context_menu
 
 
 class AlbumSidebar(QWidget):
@@ -384,7 +94,7 @@ class AlbumSidebar(QWidget):
         tree_palette = self._tree.palette()
         tree_palette.setColor(QPalette.ColorRole.Base, BG_COLOR)
         tree_palette.setColor(QPalette.ColorRole.Window, BG_COLOR)
-        tree_palette.setColor(QPalette.ColorRole.Highlight, QColor(Qt.GlobalColor.transparent))
+        tree_palette.setColor(QPalette.ColorRole.Highlight, Qt.GlobalColor.transparent)
         tree_palette.setColor(QPalette.ColorRole.HighlightedText, TEXT_COLOR)
         self._tree.setPalette(tree_palette)
         self._tree.setAutoFillBackground(True)
@@ -533,90 +243,18 @@ class AlbumSidebar(QWidget):
         self._tree.scrollTo(index)
 
     def _show_context_menu(self, point: QPoint) -> None:
-        index = self._tree.indexAt(point)
-        global_pos = self._tree.viewport().mapToGlobal(point)
-        if not index.isValid():
-            menu = QMenu(self)
-            menu.addAction("Set Basic Library…", self.bindLibraryRequested.emit)
-            menu.exec(global_pos)
-            return
-        item = self._model.item_from_index(index)
-        if item is None:
-            return
-        menu = QMenu(self)
-        if item.node_type in {NodeType.HEADER, NodeType.SECTION}:
-            menu.addAction("New Album…", self._prompt_new_album)
-        if item.node_type == NodeType.ALBUM:
-            menu.addAction("New Sub-Album…", lambda: self._prompt_new_album(item))
-            menu.addAction("Rename Album…", lambda: self._prompt_rename_album(item))
-            menu.addSeparator()
-            menu.addAction("Show in File Manager", lambda: self._reveal_path(item.album))
-        if item.node_type == NodeType.SUBALBUM:
-            menu.addAction("Rename Album…", lambda: self._prompt_rename_album(item))
-            menu.addSeparator()
-            menu.addAction("Show in File Manager", lambda: self._reveal_path(item.album))
-        if item.node_type == NodeType.ACTION:
-            menu.addAction("Set Basic Library…", self.bindLibraryRequested.emit)
-        if not menu.isEmpty():
-            menu.exec(global_pos)
-
-    def _prompt_new_album(self, parent_item: Optional[AlbumTreeItem] = None) -> None:
-        base_item = None
-        if parent_item is None:
-            index = self._tree.currentIndex()
-            base_item = self._model.item_from_index(index)
-        else:
-            base_item = parent_item
-
-        if base_item is None:
-            return
-        name, ok = QInputDialog.getText(self, "New Album", "Album name:")
-        if not ok:
-            return
-        target_name = name.strip()
-        if not target_name:
-            QMessageBox.warning(self, "iPhoto", "Album name cannot be empty.")
-            return
-        try:
-            if base_item.node_type == NodeType.ALBUM and base_item.album is not None:
-                node = self._library.create_subalbum(base_item.album, target_name)
-            else:
-                node = self._library.create_album(target_name)
-        except LibraryError as exc:  # pragma: no cover - GUI feedback
-            QMessageBox.warning(self, "iPhoto", str(exc))
-            return
-        self._pending_selection = node.path
-
-    def _prompt_rename_album(self, item) -> None:
-        if item.album is None:
-            return
-        current_title = item.album.title
-        name, ok = QInputDialog.getText(
-            self,
-            "Rename Album",
-            "New album name:",
-            text=current_title,
+        show_context_menu(
+            parent=self,
+            point=point,
+            tree=self._tree,
+            model=self._model,
+            library=self._library,
+            set_pending_selection=self._set_pending_selection,
+            on_bind_library=self.bindLibraryRequested.emit,
         )
-        if not ok:
-            return
-        target_name = name.strip()
-        if not target_name:
-            QMessageBox.warning(self, "iPhoto", "Album name cannot be empty.")
-            return
-        try:
-            self._library.rename_album(item.album, target_name)
-        except LibraryError as exc:  # pragma: no cover - GUI feedback
-            QMessageBox.warning(self, "iPhoto", str(exc))
-            return
-        self._pending_selection = item.album.path.parent / target_name
 
-    def _reveal_path(self, album: Optional[AlbumNode]) -> None:
-        if album is None:
-            return
-        from PySide6.QtGui import QDesktopServices
-        from PySide6.QtCore import QUrl
-
-        QDesktopServices.openUrl(QUrl.fromLocalFile(str(album.path)))
+    def _set_pending_selection(self, target: Path | None) -> None:
+        self._pending_selection = target
 
     def _find_static_index(self, title: str) -> QModelIndex:
         root_index = self._model.index(0, 0)


### PR DESCRIPTION
## Summary
- extract the album sidebar delegate and branch indicator animation into a dedicated module
- move context menu handling into a reusable helper class
- simplify the AlbumSidebar widget to focus on wiring UI state and signals

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8e3040490832f85b58369b1dd1d80