### PR TITLE
Refactor album sidebar styling constants and delegate structure

### DIFF
--- a/src/iPhoto/gui/ui/palette.py
+++ b/src/iPhoto/gui/ui/palette.py
@@ -1,12 +1,56 @@
-"""Shared colour utilities for the Qt GUI layer."""
+"""Shared colour utilities and constants for the Qt GUI layer."""
 
 from __future__ import annotations
 
-from PySide6.QtGui import QPalette
+from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QWidget
 
+# --- Sidebar colour palette -------------------------------------------------
 # The macOS-inspired blue used for key sidebar affordances and icon tinting.
 SIDEBAR_ICON_COLOR_HEX = "#1e73ff"
+SIDEBAR_ICON_COLOR = QColor(SIDEBAR_ICON_COLOR_HEX)
+
+# Core structural colours that govern the sidebar look and feel.
+SIDEBAR_BACKGROUND_COLOR = QColor("#eef3f6")
+SIDEBAR_TEXT_COLOR = QColor("#2b2b2b")
+SIDEBAR_TITLE_COLOR_HEX = "#1b1b1b"
+SIDEBAR_SECTION_TEXT_COLOR = QColor(0, 0, 0, 160)
+SIDEBAR_DISABLED_TEXT_COLOR = QColor(0, 0, 0, 90)
+SIDEBAR_SEPARATOR_COLOR = QColor(0, 0, 0, 40)
+
+# Interaction feedback colours for hover, selection, and focus states.
+SIDEBAR_HOVER_BACKGROUND = QColor(0, 0, 0, 24)
+SIDEBAR_SELECTED_BACKGROUND = QColor(0, 0, 0, 56)
+
+# --- Sidebar metrics --------------------------------------------------------
+# These values ensure the delegate, tree view, and hit testing all share the
+# same geometry assumptions.
+SIDEBAR_ROW_HEIGHT = 36
+SIDEBAR_ROW_RADIUS = 10
+SIDEBAR_LEFT_PADDING = 14
+SIDEBAR_ICON_TEXT_GAP = 10
+SIDEBAR_BRANCH_CONTENT_GAP = 6
+SIDEBAR_INDICATOR_HOTZONE_MARGIN = 4
+SIDEBAR_INDENT_PER_LEVEL = 22
+SIDEBAR_INDICATOR_SLOT_WIDTH = 22
+SIDEBAR_INDICATOR_SIZE = 16
+SIDEBAR_ICON_SIZE = 18
+
+# Margins around the rounded selection pill.
+SIDEBAR_HIGHLIGHT_MARGIN_X = 6
+SIDEBAR_HIGHLIGHT_MARGIN_Y = 4
+
+# Tree level styling shared by the widget and delegate.
+SIDEBAR_TREE_MIN_WIDTH = 220
+SIDEBAR_TREE_STYLESHEET = (
+    "QTreeView { background: transparent; border: none; }"
+    "QTreeView::item { border: 0px; padding: 0px; margin: 0px; }"
+    "QTreeView::branch { image: none; }"
+)
+
+# Default layout chrome values for the sidebar wrapper widget.
+SIDEBAR_LAYOUT_MARGIN = (12, 12, 12, 12)
+SIDEBAR_LAYOUT_SPACING = 8
 
 
 def viewer_surface_color(widget: QWidget) -> str:
@@ -25,4 +69,32 @@ def viewer_surface_color(widget: QWidget) -> str:
     return widget.palette().color(background_role).name()
 
 
-__all__ = ["SIDEBAR_ICON_COLOR_HEX", "viewer_surface_color"]
+__all__ = [
+    "SIDEBAR_ICON_COLOR_HEX",
+    "SIDEBAR_ICON_COLOR",
+    "SIDEBAR_BACKGROUND_COLOR",
+    "SIDEBAR_TEXT_COLOR",
+    "SIDEBAR_TITLE_COLOR_HEX",
+    "SIDEBAR_SECTION_TEXT_COLOR",
+    "SIDEBAR_DISABLED_TEXT_COLOR",
+    "SIDEBAR_SEPARATOR_COLOR",
+    "SIDEBAR_HOVER_BACKGROUND",
+    "SIDEBAR_SELECTED_BACKGROUND",
+    "SIDEBAR_ROW_HEIGHT",
+    "SIDEBAR_ROW_RADIUS",
+    "SIDEBAR_LEFT_PADDING",
+    "SIDEBAR_ICON_TEXT_GAP",
+    "SIDEBAR_BRANCH_CONTENT_GAP",
+    "SIDEBAR_INDICATOR_HOTZONE_MARGIN",
+    "SIDEBAR_INDENT_PER_LEVEL",
+    "SIDEBAR_INDICATOR_SLOT_WIDTH",
+    "SIDEBAR_INDICATOR_SIZE",
+    "SIDEBAR_ICON_SIZE",
+    "SIDEBAR_HIGHLIGHT_MARGIN_X",
+    "SIDEBAR_HIGHLIGHT_MARGIN_Y",
+    "SIDEBAR_TREE_MIN_WIDTH",
+    "SIDEBAR_TREE_STYLESHEET",
+    "SIDEBAR_LAYOUT_MARGIN",
+    "SIDEBAR_LAYOUT_SPACING",
+    "viewer_surface_color",
+]

--- a/src/iPhoto/gui/ui/widgets/album_sidebar.py
+++ b/src/iPhoto/gui/ui/widgets/album_sidebar.py
@@ -21,13 +21,22 @@ from ..models.album_tree_model import AlbumTreeModel, NodeType
 from ..delegates.album_sidebar_delegate import (
     AlbumSidebarDelegate,
     BranchIndicatorController,
-    BG_COLOR,
-    TEXT_COLOR,
-    LEFT_PADDING,
-    INDENT_PER_LEVEL,
-    INDICATOR_SIZE,
 )
 from ..menus.album_sidebar_menu import show_context_menu
+from ..palette import (
+    SIDEBAR_BACKGROUND_COLOR,
+    SIDEBAR_ICON_SIZE,
+    SIDEBAR_INDENT_PER_LEVEL,
+    SIDEBAR_INDICATOR_HOTZONE_MARGIN,
+    SIDEBAR_INDICATOR_SIZE,
+    SIDEBAR_LEFT_PADDING,
+    SIDEBAR_LAYOUT_MARGIN,
+    SIDEBAR_LAYOUT_SPACING,
+    SIDEBAR_TEXT_COLOR,
+    SIDEBAR_TITLE_COLOR_HEX,
+    SIDEBAR_TREE_MIN_WIDTH,
+    SIDEBAR_TREE_STYLESHEET,
+)
 
 
 class _DropAwareTree(QTreeView):
@@ -151,8 +160,8 @@ class AlbumSidebar(QWidget):
         self._current_static_selection: str | None = None
 
         palette = self.palette()
-        palette.setColor(QPalette.ColorRole.Window, BG_COLOR)
-        palette.setColor(QPalette.ColorRole.Base, BG_COLOR)
+        palette.setColor(QPalette.ColorRole.Window, SIDEBAR_BACKGROUND_COLOR)
+        palette.setColor(QPalette.ColorRole.Base, SIDEBAR_BACKGROUND_COLOR)
         self.setPalette(palette)
         self.setAutoFillBackground(True)
 
@@ -164,7 +173,7 @@ class AlbumSidebar(QWidget):
         title_font.setPointSizeF(title_font.pointSizeF() + 0.5)
         title_font.setBold(True)
         self._title.setFont(title_font)
-        self._title.setStyleSheet("color: #1b1b1b;")
+        self._title.setStyleSheet(f"color: {SIDEBAR_TITLE_COLOR_HEX};")
 
         self._tree = _DropAwareTree(self)
         self._tree.setObjectName("albumSidebarTree")
@@ -178,9 +187,9 @@ class AlbumSidebar(QWidget):
         self._tree.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self._tree.doubleClicked.connect(self._on_double_clicked)
         self._tree.clicked.connect(self._on_clicked)
-        self._tree.setMinimumWidth(220)
+        self._tree.setMinimumWidth(SIDEBAR_TREE_MIN_WIDTH)
         self._tree.setIndentation(0)
-        self._tree.setIconSize(QSize(18, 18))
+        self._tree.setIconSize(QSize(SIDEBAR_ICON_SIZE, SIDEBAR_ICON_SIZE))
         self._tree.setMouseTracking(True)
         self._tree.setAttribute(Qt.WidgetAttribute.WA_Hover, True)
         self._tree.setItemDelegate(AlbumSidebarDelegate(self._tree))
@@ -191,21 +200,17 @@ class AlbumSidebar(QWidget):
         self._tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._tree.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         tree_palette = self._tree.palette()
-        tree_palette.setColor(QPalette.ColorRole.Base, BG_COLOR)
-        tree_palette.setColor(QPalette.ColorRole.Window, BG_COLOR)
+        tree_palette.setColor(QPalette.ColorRole.Base, SIDEBAR_BACKGROUND_COLOR)
+        tree_palette.setColor(QPalette.ColorRole.Window, SIDEBAR_BACKGROUND_COLOR)
         tree_palette.setColor(QPalette.ColorRole.Highlight, Qt.GlobalColor.transparent)
-        tree_palette.setColor(QPalette.ColorRole.HighlightedText, TEXT_COLOR)
+        tree_palette.setColor(QPalette.ColorRole.HighlightedText, SIDEBAR_TEXT_COLOR)
         self._tree.setPalette(tree_palette)
         self._tree.setAutoFillBackground(True)
-        self._tree.setStyleSheet(
-            "QTreeView { background: transparent; border: none; }"
-            "QTreeView::item { border: 0px; padding: 0px; margin: 0px; }"
-            "QTreeView::branch { image: none; }"
-        )
+        self._tree.setStyleSheet(SIDEBAR_TREE_STYLESHEET)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(8)
+        layout.setContentsMargins(*SIDEBAR_LAYOUT_MARGIN)
+        layout.setSpacing(SIDEBAR_LAYOUT_SPACING)
         layout.addWidget(self._title)
         layout.addWidget(self._tree, stretch=1)
 
@@ -296,16 +301,21 @@ class AlbumSidebar(QWidget):
             return
 
         depth = delegate._depth_for_index(index)
-        indentation = depth * INDENT_PER_LEVEL
-        indicator_left = item_rect.left() + LEFT_PADDING + indentation
+        indentation = depth * SIDEBAR_INDENT_PER_LEVEL
+        indicator_left = item_rect.left() + SIDEBAR_LEFT_PADDING + indentation
         indicator_rect = QRect(
             indicator_left,
-            item_rect.top() + (item_rect.height() - INDICATOR_SIZE) // 2,
-            INDICATOR_SIZE,
-            INDICATOR_SIZE,
+            item_rect.top() + (item_rect.height() - SIDEBAR_INDICATOR_SIZE) // 2,
+            SIDEBAR_INDICATOR_SIZE,
+            SIDEBAR_INDICATOR_SIZE,
         )
 
-        hot_zone = indicator_rect.adjusted(-4, -4, 4, 4)
+        hot_zone = indicator_rect.adjusted(
+            -SIDEBAR_INDICATOR_HOTZONE_MARGIN,
+            -SIDEBAR_INDICATOR_HOTZONE_MARGIN,
+            SIDEBAR_INDICATOR_HOTZONE_MARGIN,
+            SIDEBAR_INDICATOR_HOTZONE_MARGIN,
+        )
         cursor_pos = QCursor.pos()
         viewport_pos = self._tree.viewport().mapFromGlobal(cursor_pos)
         if not hot_zone.contains(viewport_pos):


### PR DESCRIPTION
## Summary
- move sidebar colours, metrics, and stylesheet definitions into the shared palette module
- refactor the album sidebar delegate to use helper methods and the shared palette constants
- update the album sidebar widget to consume the centralized styling constants

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2108f1a10832f8df4159c529445bc