### PR TITLE
Adjust sidebar icon sizing and weight

### DIFF
--- a/src/iPhoto/gui/ui/delegates/album_sidebar_delegate.py
+++ b/src/iPhoto/gui/ui/delegates/album_sidebar_delegate.py
@@ -335,7 +335,10 @@ class AlbumSidebarDelegate(QStyledItemDelegate):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         indicator_colour = SIDEBAR_TEXT_COLOR if state.is_enabled else SIDEBAR_DISABLED_TEXT_COLOR
         pen = QPen(indicator_colour)
-        pen.setWidth(2)
+        # The float-based width preserves the softened macOS aesthetic while
+        # making the disclosure triangle more legible next to the larger
+        # sidebar glyphs.
+        pen.setWidthF(2.5)
         pen.setCapStyle(Qt.PenCapStyle.RoundCap)
         painter.setPen(pen)
         painter.translate(branch_rect.center())

--- a/src/iPhoto/gui/ui/icon/livephoto.play.svg
+++ b/src/iPhoto/gui/ui/icon/livephoto.play.svg
@@ -3,7 +3,7 @@
 -->
 <svg width='51.00390625px' height='55.7734375px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-55.7734375)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 25.501953125,49.54296875
     C 25.05078125,49.54296875 24.685546875,49.15625 24.685546875,48.7265625
     C 24.685546875,48.296875 25.05078125,47.91015625 25.501953125,47.91015625

--- a/src/iPhoto/gui/ui/icon/livephoto.svg
+++ b/src/iPhoto/gui/ui/icon/livephoto.svg
@@ -3,7 +3,7 @@
 -->
 <svg width='51.00390625px' height='55.7734375px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-55.7734375)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 25.501953125,49.54296875
     C 25.05078125,49.54296875 24.685546875,49.15625 24.685546875,48.7265625
     C 24.685546875,48.296875 25.05078125,47.91015625 25.501953125,47.91015625

--- a/src/iPhoto/gui/ui/icon/mappin.and.ellipse.svg
+++ b/src/iPhoto/gui/ui/icon/mappin.and.ellipse.svg
@@ -1,6 +1,6 @@
 <svg width='45.095703125px' height='53.15234375px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-53.15234375)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 22.537109375,12.009765625
     C 22.7734375,12.009765625 23.03125,12.869140625 23.03125,14.845703125
     L 23.03125,36.22265625

--- a/src/iPhoto/gui/ui/icon/photo.on.rectangle.svg
+++ b/src/iPhoto/gui/ui/icon/photo.on.rectangle.svg
@@ -1,6 +1,6 @@
 <svg width='66.04296875px' height='55.4296875px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-55.4296875)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 11.0,15.08203125
     L 15.33984375,15.08203125
     L 15.33984375,11.55859375

--- a/src/iPhoto/gui/ui/icon/rectangle.stack.svg
+++ b/src/iPhoto/gui/ui/icon/rectangle.stack.svg
@@ -1,6 +1,6 @@
 <svg width='56.181640625px' height='58.48046875px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-58.48046875)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 14.201171875,50.23046875
     L 42.001953125,50.23046875
     C 42.001953125,50.7890625 41.59375,51.3046875 41.013671875,51.3046875

--- a/src/iPhoto/gui/ui/icon/suit.heart.svg
+++ b/src/iPhoto/gui/ui/icon/suit.heart.svg
@@ -1,6 +1,6 @@
 <svg width='49.564453125px' height='42.646484375px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-42.646484375)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 4.640625,27.779296875
     C 4.640625,19.20703125 12.783203125,10.828125 23.93359375,3.373046875
     C 24.19140625,3.22265625 24.513671875,3.09375 24.771484375,3.09375

--- a/src/iPhoto/gui/ui/icon/trash.svg
+++ b/src/iPhoto/gui/ui/icon/trash.svg
@@ -1,6 +1,6 @@
 <svg width='46.642578125px' height='58.802734375px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-58.802734375)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 36.953125,10.033203125
     L 38.736328125,43.763671875
     L 42.83984375,43.763671875

--- a/src/iPhoto/gui/ui/icon/video.svg
+++ b/src/iPhoto/gui/ui/icon/video.svg
@@ -3,7 +3,7 @@
 -->
 <svg width='62.240234375px' height='38.005859375px' direction='ltr' xmlns='http://www.w3.org/2000/svg' version='1.1'>
 <g fill-rule='nonzero' transform='scale(1,-1) translate(0,-38.005859375)'>
-<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='1.0' d='
+<path fill='black' stroke='black' fill-opacity='1.0' stroke-width='2.0' d='
     M 12.24609375,1.76171875
     L 36.39453125,1.76171875
     C 40.94921875,1.76171875 43.3984375,4.232421875 43.3984375,8.744140625

--- a/src/iPhoto/gui/ui/palette.py
+++ b/src/iPhoto/gui/ui/palette.py
@@ -34,7 +34,10 @@ SIDEBAR_INDICATOR_HOTZONE_MARGIN = 4
 SIDEBAR_INDENT_PER_LEVEL = 22
 SIDEBAR_INDICATOR_SLOT_WIDTH = 22
 SIDEBAR_INDICATOR_SIZE = 16
-SIDEBAR_ICON_SIZE = 18
+# Enlarging the icon size keeps the sidebar feeling balanced against the
+# macOS reference chrome while also giving the thicker SVG strokes room to
+# render crisply at standard display scale.
+SIDEBAR_ICON_SIZE = 22
 
 # Margins around the rounded selection pill.
 SIDEBAR_HIGHLIGHT_MARGIN_X = 6


### PR DESCRIPTION
## Summary
- enlarge the sidebar icon metric so glyphs have more breathing room
- thicken the branch indicator pen width to match the heavier icon strokes
- update frequently used sidebar SVG icons to a 2.0 stroke width for a bolder look

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f21bd55ab0832fb1d1dcb45bdff71d