### PR TITLE
Ensure filmstrip wheel scroll always navigates

### DIFF
--- a/src/iPhoto/gui/ui/controllers/main_controller.py
+++ b/src/iPhoto/gui/ui/controllers/main_controller.py
@@ -255,11 +255,15 @@ class MainController(QObject):
         self._apply_wheel_action(wheel_action)
 
     def _apply_wheel_action(self, action: str) -> None:
-        """Propagate the chosen wheel behaviour to the viewer and filmstrip widgets."""
+        """Update the main viewer's wheel behaviour based on the stored preference.
+
+        The filmstrip now always consumes wheel events to request navigation so users can quickly
+        browse adjacent assets. Only the full-sized image viewer still honours the zoom versus
+        navigate preference.
+        """
 
         mode = "zoom" if action == "zoom" else "navigate"
         self._window.ui.image_viewer.set_wheel_action(mode)
-        self._window.ui.filmstrip_view.set_wheel_action(mode)
 
     # -----------------------------------------------------------------
     # Signal wiring


### PR DESCRIPTION
## Summary
- ensure the filmstrip view always consumes wheel scrolling to request navigation and document the behaviour
- stop propagating the wheel preference to the filmstrip since it now always navigates regardless of the global setting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f35dd810a0832f98d45477c10bab18