### PR TITLE
Apply optimistic move updates to Basic Library views

### DIFF
--- a/src/iPhoto/gui/ui/controllers/main_controller.py
+++ b/src/iPhoto/gui/ui/controllers/main_controller.py
@@ -727,8 +727,13 @@ class MainController(QObject):
             return
 
         source_model = self._asset_model.source_model()
-        is_all_photos_move = self._navigation.is_all_photos_view()
-        if is_all_photos_move:
+        is_virtual_view_move = self._navigation.is_basic_library_virtual_view()
+        if is_virtual_view_move:
+            # Moving items from any Basic Library virtual collection (All Photos,
+            # Videos, Live Photos, Favorites) should behave like a read-only view
+            # over the master index.  Apply the optimistic update path so the
+            # thumbnails remain visible while the worker performs the actual
+            # filesystem updates.
             rels = [index.data(Roles.REL) for index in selected_indexes if index.isValid()]
             source_model.update_rows_for_move([rel for rel in rels if isinstance(rel, str)], target)
         elif selected_indexes:

--- a/src/iPhoto/gui/ui/controllers/navigation_controller.py
+++ b/src/iPhoto/gui/ui/controllers/navigation_controller.py
@@ -231,6 +231,25 @@ class NavigationController:
     def clear_static_selection(self) -> None:
         self._static_selection = None
 
+    def is_basic_library_virtual_view(self) -> bool:
+        """Return ``True`` when a Basic Library virtual collection is active."""
+
+        # ``_static_selection`` mirrors the last virtual node triggered from the
+        # sidebar.  Whenever one of the built-in Basic Library collections is
+        # active we want move operations to keep their optimistic updates, so
+        # normalise the title and compare it against the known set of virtual
+        # albums.
+        if not self._static_selection:
+            return False
+        normalized_title = self._static_selection.casefold()
+        virtual_views = {
+            AlbumSidebar.ALL_PHOTOS_TITLE.casefold(),
+            "videos",
+            "live photos",
+            "favorites",
+        }
+        return normalized_title in virtual_views
+
     def is_all_photos_view(self) -> bool:
         """Return ``True`` when the "All Photos" virtual collection is active."""
 


### PR DESCRIPTION
## Summary
- add a navigation controller helper that recognises Basic Library virtual views
- ensure move operations from those virtual collections keep their optimistic UI updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f385993bcc832f9441c8929aff2716