### PR TITLE
Align OpenGL preview backend with map context defaults

### DIFF
--- a/src/iPhoto/core/color_resolver.py
+++ b/src/iPhoto/core/color_resolver.py
@@ -1,0 +1,331 @@
+"""Resolve Color adjustment values and analyse image statistics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping
+
+import math
+
+from PySide6.QtCore import Qt
+
+try:  # pragma: no cover - availability depends on runtime environment
+    from PySide6.QtGui import QImage
+    _QT_AVAILABLE = True
+except ImportError:  # pragma: no cover - allows non-Qt environments to import the module
+    QImage = Any  # type: ignore
+    _QT_AVAILABLE = False
+
+
+COLOR_KEYS = ("Saturation", "Vibrance", "Cast")
+"""Canonical order for fine-grained Color adjustments."""
+
+COLOR_RANGES: Mapping[str, tuple[float, float]] = {
+    "Saturation": (-1.0, 1.0),
+    "Vibrance": (-1.0, 1.0),
+    "Cast": (0.0, 1.0),
+}
+"""Inclusive ranges for each Color adjustment slider."""
+
+
+@dataclass(frozen=True)
+class ColorStats:
+    """Aggregate statistics describing the tonal distribution of an image."""
+
+    saturation_mean: float = 0.35
+    saturation_median: float = 0.30
+    highlight_ratio: float = 0.10
+    dark_ratio: float = 0.05
+    skin_ratio: float = 0.10
+    cast_magnitude: float = 0.0
+    white_balance_gain: tuple[float, float, float] = (1.0, 1.0, 1.0)
+
+    @classmethod
+    def ensure(cls, stats: ColorStats | Mapping[str, float] | None) -> ColorStats:
+        """Return *stats* as :class:`ColorStats`, falling back to defaults."""
+
+        if stats is None:
+            return cls()
+        if isinstance(stats, cls):
+            return stats
+        return cls(
+            saturation_mean=float(stats.get("saturation_mean", cls.saturation_mean)),
+            saturation_median=float(stats.get("saturation_median", cls.saturation_median)),
+            highlight_ratio=float(stats.get("highlight_ratio", cls.highlight_ratio)),
+            dark_ratio=float(stats.get("dark_ratio", cls.dark_ratio)),
+            skin_ratio=float(stats.get("skin_ratio", cls.skin_ratio)),
+            cast_magnitude=float(stats.get("cast_magnitude", cls.cast_magnitude)),
+            white_balance_gain=(
+                float(stats.get("white_balance_gain_r", cls.white_balance_gain[0])),
+                float(stats.get("white_balance_gain_g", cls.white_balance_gain[1])),
+                float(stats.get("white_balance_gain_b", cls.white_balance_gain[2])),
+            ),
+        )
+
+
+class ColorResolver:
+    """Resolve Color adjustment vectors using image statistics."""
+
+    @staticmethod
+    def distribute_master(
+        master: float,
+        stats: ColorStats | Mapping[str, float] | None = None,
+    ) -> dict[str, float]:
+        """Return fine adjustments derived from the Color master slider."""
+
+        stats_obj = ColorStats.ensure(stats)
+        master_clamped = _clamp(master, -1.0, 1.0)
+
+        k_hi = max(0.35, 1.0 - _smoothstep(0.02, 0.15, stats_obj.highlight_ratio))
+        k_skin = 0.6 + 0.4 * (1.0 - _clamp(stats_obj.skin_ratio, 0.0, 1.0))
+        k_sat0 = pow(max(0.0, 1.0 - stats_obj.saturation_median), 0.6)
+        k_vib0 = max(0.0, 1.0 - stats_obj.saturation_mean)
+
+        base_sat = 0.25 + 0.75 * k_sat0
+        base_vib = 0.25 + 0.75 * k_vib0
+
+        amp_sat, amp_vib = 1.6, 1.4
+        sat = amp_sat * 0.9 * master_clamped * base_sat * k_hi * k_skin
+        vib = amp_vib * 0.7 * master_clamped * base_vib * k_hi * k_skin
+
+        cast_scale = 0.8 * abs(master_clamped) * _clamp(stats_obj.cast_magnitude / 0.4, 0.0, 1.0)
+        cast = cast_scale
+
+        epsilon = 0.01 * abs(master_clamped)
+        if abs(sat) < epsilon:
+            sat = math.copysign(epsilon, master_clamped)
+        if abs(vib) < epsilon:
+            vib = math.copysign(epsilon, master_clamped)
+
+        return {
+            "Saturation": _clamp(sat, *COLOR_RANGES["Saturation"]),
+            "Vibrance": _clamp(vib, *COLOR_RANGES["Vibrance"]),
+            "Cast": _clamp(cast, *COLOR_RANGES["Cast"]),
+        }
+
+    @staticmethod
+    def calculate_master(
+        saturation: float,
+        vibrance: float,
+        cast: float,
+        *,
+        stats: ColorStats | Mapping[str, float] | None = None,
+    ) -> float:
+        """Estimate the master slider value from resolved fine adjustments."""
+
+        stats_obj = ColorStats.ensure(stats)
+        if abs(saturation) < 1e-6 and abs(vibrance) < 1e-6 and abs(cast) < 1e-6:
+            return 0.0
+
+        positive_reference = ColorResolver.distribute_master(1.0, stats_obj)
+        sat_ref = positive_reference.get("Saturation", 1.0)
+        vib_ref = positive_reference.get("Vibrance", 1.0)
+        cast_ref = max(positive_reference.get("Cast", 0.0), 1e-6)
+
+        candidates: list[float] = []
+        if abs(sat_ref) > 1e-6:
+            candidates.append(saturation / sat_ref)
+        if abs(vib_ref) > 1e-6:
+            candidates.append(vibrance / vib_ref)
+
+        sign_hint = sum(candidates)
+        if abs(cast) > 1e-6:
+            magnitude = abs(cast) / cast_ref
+            if abs(sign_hint) < 1e-6:
+                candidates.append(magnitude)
+            else:
+                candidates.append(math.copysign(magnitude, sign_hint))
+
+        if not candidates:
+            return 0.0
+
+        averaged = sum(candidates) / len(candidates)
+        return _clamp(averaged, -1.0, 1.0)
+
+    @staticmethod
+    def resolve_color_vector(
+        master: float,
+        overrides: Mapping[str, float] | None,
+        *,
+        stats: ColorStats | Mapping[str, float] | None = None,
+        mode: str = "delta",
+    ) -> dict[str, float]:
+        """Combine the Color master slider with fine adjustment overrides."""
+
+        stats_obj = ColorStats.ensure(stats)
+        base = ColorResolver.distribute_master(master, stats_obj)
+        overrides = overrides or {}
+        resolved: MutableMapping[str, float] = dict(base)
+
+        if mode == "delta":
+            for key, value in overrides.items():
+                if key in COLOR_KEYS:
+                    minimum, maximum = COLOR_RANGES[key]
+                    resolved[key] = _clamp(resolved.get(key, 0.0) + float(value), minimum, maximum)
+        elif mode == "absolute":
+            for key, value in overrides.items():
+                if key in COLOR_KEYS:
+                    minimum, maximum = COLOR_RANGES[key]
+                    resolved[key] = _clamp(float(value), minimum, maximum)
+        else:
+            raise ValueError("mode must be 'delta' or 'absolute'")
+
+        return dict(resolved)
+
+
+def compute_color_statistics(image: QImage, *, max_sample_size: int = 1024) -> ColorStats:
+    """Return :class:`ColorStats` describing *image*."""
+
+    if not _QT_AVAILABLE:
+        raise RuntimeError("Qt bindings are required to compute color statistics")
+
+    if image.isNull():
+        return ColorStats()
+
+    converted = image.convertToFormat(QImage.Format.Format_RGBA8888)
+    width = converted.width()
+    height = converted.height()
+
+    longest_edge = max(width, height)
+    if longest_edge > max_sample_size:
+        converted = converted.scaled(
+            max_sample_size,
+            max_sample_size,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.FastTransformation,
+        )
+        width = converted.width()
+        height = converted.height()
+
+    bytes_per_line = converted.bytesPerLine()
+    buffer = converted.bits()
+    buffer.setsize(converted.sizeInBytes())
+    view = memoryview(buffer)
+
+    hist = [0] * 64
+    count = 0
+    highlight_count = 0
+    dark_count = 0
+    skin_count = 0
+    sum_saturation = 0.0
+    sum_lin_r = 0.0
+    sum_lin_g = 0.0
+    sum_lin_b = 0.0
+
+    for y in range(height):
+        row_offset = y * bytes_per_line
+        for x in range(width):
+            offset = row_offset + x * 4
+            b = view[offset] / 255.0
+            g = view[offset + 1] / 255.0
+            r = view[offset + 2] / 255.0
+
+            max_c = max(r, g, b)
+            min_c = min(r, g, b)
+            delta = max_c - min_c
+            saturation = 0.0 if max_c <= 0.0 else delta / (max_c + 1e-8)
+            value = max_c
+
+            hue = 0.0
+            if delta > 1e-8:
+                if max_c == r:
+                    hue = ((g - b) / delta) % 6.0
+                elif max_c == g:
+                    hue = ((b - r) / delta) + 2.0
+                else:
+                    hue = ((r - g) / delta) + 4.0
+            hue_deg = (hue / 6.0) * 360.0
+
+            if value > 0.90:
+                highlight_count += 1
+            if value < 0.05:
+                dark_count += 1
+            if 10.0 < hue_deg < 50.0 and 0.1 < saturation < 0.6:
+                skin_count += 1
+
+            sum_saturation += saturation
+            bin_index = min(63, int(saturation * 64.0))
+            hist[bin_index] += 1
+
+            lin_r, lin_g, lin_b = _srgb_to_linear(r), _srgb_to_linear(g), _srgb_to_linear(b)
+            sum_lin_r += lin_r
+            sum_lin_g += lin_g
+            sum_lin_b += lin_b
+
+            count += 1
+
+    if count == 0:
+        return ColorStats()
+
+    mean_saturation = sum_saturation / count
+    cumulative = 0
+    median_target = count // 2
+    median_saturation = 0.0
+    for index, bin_count in enumerate(hist):
+        cumulative += bin_count
+        if cumulative >= median_target:
+            median_saturation = (index + 0.5) / 64.0
+            break
+
+    highlight_ratio = highlight_count / count
+    dark_ratio = dark_count / count
+    skin_ratio = skin_count / count
+
+    avg_lin_r = sum_lin_r / count
+    avg_lin_g = sum_lin_g / count
+    avg_lin_b = sum_lin_b / count
+    avg_lin = (avg_lin_r + avg_lin_g + avg_lin_b) / 3.0
+    cast_magnitude = max(
+        abs(avg_lin_r - avg_lin),
+        abs(avg_lin_g - avg_lin),
+        abs(avg_lin_b - avg_lin),
+    )
+
+    gain_r = avg_lin / avg_lin_r if avg_lin_r > 1e-6 else 1.0
+    gain_g = avg_lin / avg_lin_g if avg_lin_g > 1e-6 else 1.0
+    gain_b = avg_lin / avg_lin_b if avg_lin_b > 1e-6 else 1.0
+
+    gain_r = _clamp(gain_r, 0.5, 2.5)
+    gain_g = _clamp(gain_g, 0.5, 2.5)
+    gain_b = _clamp(gain_b, 0.5, 2.5)
+
+    return ColorStats(
+        saturation_mean=_clamp(mean_saturation, 0.0, 1.0),
+        saturation_median=_clamp(median_saturation, 0.0, 1.0),
+        highlight_ratio=_clamp(highlight_ratio, 0.0, 1.0),
+        dark_ratio=_clamp(dark_ratio, 0.0, 1.0),
+        skin_ratio=_clamp(skin_ratio, 0.0, 1.0),
+        cast_magnitude=_clamp(cast_magnitude, 0.0, 1.0),
+        white_balance_gain=(gain_r, gain_g, gain_b),
+    )
+
+
+def _smoothstep(edge0: float, edge1: float, x: float) -> float:
+    if edge1 <= edge0:
+        return 0.0
+    t = (x - edge0) / (edge1 - edge0)
+    t = _clamp(t, 0.0, 1.0)
+    return t * t * (3.0 - 2.0 * t)
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    if value < minimum:
+        return minimum
+    if value > maximum:
+        return maximum
+    return value
+
+
+def _srgb_to_linear(channel: float) -> float:
+    if channel <= 0.04045:
+        return channel / 12.92
+    return pow((channel + 0.055) / 1.055, 2.4)
+
+
+__all__ = [
+    "COLOR_KEYS",
+    "COLOR_RANGES",
+    "ColorResolver",
+    "ColorStats",
+    "compute_color_statistics",
+]

--- a/src/iPhoto/core/preview_backends.py
+++ b/src/iPhoto/core/preview_backends.py
@@ -9,14 +9,17 @@ from typing import Mapping, TYPE_CHECKING, cast
 
 from array import array
 import ctypes
+import struct
 
 from PySide6.QtGui import QImage
 
 from .image_filters import apply_adjustments
+from .color_resolver import ColorStats, compute_color_statistics
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from PySide6.QtGui import QOffscreenSurface
     from PySide6.QtGui import QOpenGLContext
+    from PySide6.QtGui import QSurfaceFormat
     from PySide6.QtOpenGL import (
         QOpenGLBuffer,
         QOpenGLFramebufferObject,
@@ -77,9 +80,10 @@ class PreviewBackend(ABC):
 
 @dataclass
 class _CpuPreviewSession(PreviewSession):
-    """Store the original image for the CPU fallback backend."""
+    """Store the original image and precomputed statistics for the CPU backend."""
 
     image: QImage
+    color_stats: ColorStats
 
     def dispose(self) -> None:  # pragma: no cover - nothing to free
         """Release held resources (no-op for pure CPU sessions)."""
@@ -97,11 +101,12 @@ class _CpuPreviewBackend(PreviewBackend):
     supports_realtime = False
 
     def create_session(self, image: QImage) -> PreviewSession:
-        return _CpuPreviewSession(image)
+        stats = compute_color_statistics(image) if not image.isNull() else ColorStats()
+        return _CpuPreviewSession(image, stats)
 
     def render(self, session: PreviewSession, adjustments: Mapping[str, float]) -> QImage:
         assert isinstance(session, _CpuPreviewSession)
-        return apply_adjustments(session.image, adjustments)
+        return apply_adjustments(session.image, adjustments, color_stats=session.color_stats)
 
 
 class _CudaPreviewBackend(PreviewBackend):
@@ -137,6 +142,143 @@ class _OpenGlPreviewBackend(PreviewBackend):
     tier_name = "OpenGL"
     supports_realtime = True
 
+    @staticmethod
+    def _candidate_formats(
+        surface_format_cls: type["QSurfaceFormat"],
+    ) -> list["QSurfaceFormat"]:
+        """Return potential context formats ordered by desirability.
+
+        The helper favours the process-wide default format first so that the
+        preview backend mirrors whichever OpenGL version the rest of the
+        application already requested.  Falling back to explicit versions keeps
+        legacy drivers in play when no default is configured.
+        """
+
+        candidates: list["QSurfaceFormat"] = []
+        default_format = surface_format_cls.defaultFormat()
+        if (
+            default_format.renderableType()
+            == surface_format_cls.RenderableType.OpenGL
+            and default_format.majorVersion() > 0
+        ):
+            # Copy the default format so adjustments performed later on do not
+            # mutate the process-wide configuration.
+            try:
+                candidates.append(surface_format_cls(default_format))
+            except TypeError:
+                # Some bindings lack the convenience copy constructor.  In that
+                # case manually mirror the relevant properties to preserve the
+                # process-wide defaults.
+                format_copy = surface_format_cls()
+                format_copy.setRenderableType(default_format.renderableType())
+                format_copy.setProfile(default_format.profile())
+                format_copy.setVersion(
+                    default_format.majorVersion(),
+                    default_format.minorVersion(),
+                )
+                format_copy.setSwapBehavior(default_format.swapBehavior())
+                format_copy.setSwapInterval(default_format.swapInterval())
+                format_copy.setDepthBufferSize(default_format.depthBufferSize())
+                format_copy.setStencilBufferSize(default_format.stencilBufferSize())
+                format_copy.setSamples(default_format.samples())
+                format_copy.setRedBufferSize(default_format.redBufferSize())
+                format_copy.setGreenBufferSize(default_format.greenBufferSize())
+                format_copy.setBlueBufferSize(default_format.blueBufferSize())
+                format_copy.setAlphaBufferSize(default_format.alphaBufferSize())
+                format_copy.setOption(
+                    surface_format_cls.FormatOption.DebugContext,
+                    default_format.testOption(
+                        surface_format_cls.FormatOption.DebugContext
+                    ),
+                )
+                candidates.append(format_copy)
+
+        for major, minor in ((4, 3), (3, 3)):
+            format_hint = surface_format_cls()
+            format_hint.setRenderableType(surface_format_cls.RenderableType.OpenGL)
+            format_hint.setProfile(surface_format_cls.OpenGLContextProfile.CoreProfile)
+            format_hint.setVersion(major, minor)
+            candidates.append(format_hint)
+
+        return candidates
+
+    @classmethod
+    def _initialise_context(
+        cls,
+        context_cls: type["QOpenGLContext"],
+        surface_format_cls: type["QSurfaceFormat"],
+    ) -> tuple["QOpenGLContext", "QSurfaceFormat"]:
+        """Create an OpenGL context matching the map view configuration.
+
+        Passing the Qt classes explicitly keeps the helper import-agnostic and
+        ensures that :meth:`is_available` can reuse the logic without eagerly
+        importing OpenGL modules at the top level.
+        """
+
+        share_context = context_cls.globalShareContext()
+        last_error: Exception | None = None
+        candidate_formats: list["QSurfaceFormat"] = []
+        if share_context is not None:
+            share_format = share_context.format()
+            if (
+                share_format.renderableType()
+                == surface_format_cls.RenderableType.OpenGL
+            ):
+                try:
+                    candidate_formats.append(surface_format_cls(share_format))
+                except TypeError:
+                    cloned = surface_format_cls()
+                    cloned.setRenderableType(share_format.renderableType())
+                    cloned.setProfile(share_format.profile())
+                    cloned.setVersion(
+                        share_format.majorVersion(),
+                        share_format.minorVersion(),
+                    )
+                    cloned.setSwapBehavior(share_format.swapBehavior())
+                    cloned.setSwapInterval(share_format.swapInterval())
+                    cloned.setDepthBufferSize(share_format.depthBufferSize())
+                    cloned.setStencilBufferSize(share_format.stencilBufferSize())
+                    cloned.setSamples(share_format.samples())
+                    cloned.setRedBufferSize(share_format.redBufferSize())
+                    cloned.setGreenBufferSize(share_format.greenBufferSize())
+                    cloned.setBlueBufferSize(share_format.blueBufferSize())
+                    cloned.setAlphaBufferSize(share_format.alphaBufferSize())
+                    cloned.setOption(
+                        surface_format_cls.FormatOption.DebugContext,
+                        share_format.testOption(
+                            surface_format_cls.FormatOption.DebugContext
+                        ),
+                    )
+                    candidate_formats.append(cloned)
+
+        candidate_formats.extend(cls._candidate_formats(surface_format_cls))
+
+        for format_hint in candidate_formats:
+            context = context_cls()
+            if share_context is not None:
+                context.setShareContext(share_context)
+            context.setFormat(format_hint)
+            try:
+                if not context.create():
+                    continue
+            except Exception as exc:  # pragma: no cover - platform specific
+                last_error = exc
+                continue
+
+            actual_format = context.format()
+            if (
+                actual_format.renderableType()
+                != surface_format_cls.RenderableType.OpenGL
+            ):
+                continue
+
+            return context, actual_format
+
+        message = "Failed to create OpenGL context"
+        if last_error is not None:
+            raise RuntimeError(message) from last_error
+        raise RuntimeError(message)
+
     def __init__(self) -> None:
         # Import OpenGL heavy modules lazily so environments without an OpenGL
         # stack (for example headless CI) can still import this module without
@@ -144,21 +286,26 @@ class _OpenGlPreviewBackend(PreviewBackend):
         # probing before the backend is constructed, so any ImportError raised
         # here indicates a configuration drift between the probe and the
         # initialiser.  Surfacing the error keeps the log output actionable.
-        from PySide6.QtGui import QOffscreenSurface
-        from PySide6.QtGui import QOpenGLContext, QSurfaceFormat
+        from PySide6.QtGui import (
+            QOffscreenSurface,
+            QOpenGLContext,
+            QOpenGLFunctions_4_3_Core,
+            QOpenGLVersionFunctionsFactory,
+            QSurfaceFormat,
+        )
         from PySide6.QtOpenGL import QOpenGLBuffer, QOpenGLShader, QOpenGLShaderProgram
 
         super().__init__()
 
-        self._context: QOpenGLContext = QOpenGLContext()
-        format_hint = QSurfaceFormat()
-        format_hint.setRenderableType(QSurfaceFormat.RenderableType.OpenGL)
-        self._context.setFormat(format_hint)
-        if not self._context.create():
-            raise RuntimeError("Failed to create OpenGL context")
+        context, format_used = self._initialise_context(QOpenGLContext, QSurfaceFormat)
+        self._context = context
+        self._context_version = (
+            format_used.majorVersion(),
+            format_used.minorVersion(),
+        )
 
         self._surface: QOffscreenSurface = QOffscreenSurface()
-        self._surface.setFormat(self._context.format())
+        self._surface.setFormat(format_used)
         self._surface.create()
         if not self._surface.isValid():
             raise RuntimeError("OpenGL offscreen surface is invalid")
@@ -169,6 +316,13 @@ class _OpenGlPreviewBackend(PreviewBackend):
         functions = self._context.functions()
         functions.initializeOpenGLFunctions()
         self._gl = functions
+        self._gl43: QOpenGLFunctions_4_3_Core | None = None
+        if self._context_version >= (4, 3):
+            self._gl43 = QOpenGLVersionFunctionsFactory.get(
+                self._context, QOpenGLFunctions_4_3_Core
+            )
+            if self._gl43 is not None:
+                self._gl43.initializeOpenGLFunctions()
 
         # Compile and link the shader program once.  The uniforms mirror the
         # tone-mapping helper in :mod:`iPhoto.core.image_filters` so both
@@ -202,6 +356,10 @@ class _OpenGlPreviewBackend(PreviewBackend):
         self._uniform_shadows = self._program.uniformLocation("uShadows")
         self._uniform_contrast = self._program.uniformLocation("uContrastFactor")
         self._uniform_black_point = self._program.uniformLocation("uBlackPoint")
+        self._uniform_saturation = self._program.uniformLocation("uSaturation")
+        self._uniform_vibrance = self._program.uniformLocation("uVibrance")
+        self._uniform_cast = self._program.uniformLocation("uCast")
+        self._uniform_gain = self._program.uniformLocation("uGain")
 
         # Prepare the vertex buffer containing a full screen triangle strip.
         vertices = array(
@@ -234,6 +392,19 @@ class _OpenGlPreviewBackend(PreviewBackend):
         self._vertex_buffer.allocate(raw_vertices, len(raw_vertices))
         self._vertex_buffer.release()
 
+        self._compute_program: QOpenGLShaderProgram | None = None
+        self._stats_buffer: QOpenGLBuffer | None = None
+        try:
+            self._compute_program = self._compile_compute_shader()
+            self._stats_buffer = QOpenGLBuffer(QOpenGLBuffer.Type.ShaderStorageBuffer)
+            if not self._stats_buffer.create():
+                self._stats_buffer = None
+        except Exception:
+            # Compute shader support is optional; gracefully fall back to CPU
+            # statistics on hardware that lacks OpenGL 4.3 features.
+            self._compute_program = None
+            self._stats_buffer = None
+
         self._context.doneCurrent()
 
     @staticmethod
@@ -241,10 +412,10 @@ class _OpenGlPreviewBackend(PreviewBackend):
         """Return the GLSL source code for the fullscreen quad vertex shader."""
 
         return (
-            "#version 120\n"
-            "attribute vec2 a_position;\n"
-            "attribute vec2 a_texcoord;\n"
-            "varying vec2 v_texcoord;\n"
+            "#version 330\n"
+            "in vec2 a_position;\n"
+            "in vec2 a_texcoord;\n"
+            "out vec2 v_texcoord;\n"
             "void main() {\n"
             "    gl_Position = vec4(a_position, 0.0, 1.0);\n"
             "    v_texcoord = a_texcoord;\n"
@@ -256,7 +427,7 @@ class _OpenGlPreviewBackend(PreviewBackend):
         """Return the GLSL source code mirroring ``_apply_channel_adjustments``."""
 
         return (
-            "#version 120\n"
+            "#version 330\n"
             "uniform sampler2D uSourceTexture;\n"
             "uniform float uExposureTerm;\n"
             "uniform float uBrightnessTerm;\n"
@@ -265,7 +436,12 @@ class _OpenGlPreviewBackend(PreviewBackend):
             "uniform float uShadows;\n"
             "uniform float uContrastFactor;\n"
             "uniform float uBlackPoint;\n"
-            "varying vec2 v_texcoord;\n"
+            "uniform float uSaturation;\n"
+            "uniform float uVibrance;\n"
+            "uniform float uCast;\n"
+            "uniform vec3 uGain;\n"
+            "in vec2 v_texcoord;\n"
+            "out vec4 FragColor;\n"
             "float clamp01(float value) {\n"
             "    return clamp(value, 0.0, 1.0);\n"
             "}\n"
@@ -290,11 +466,146 @@ class _OpenGlPreviewBackend(PreviewBackend):
             "    return clamp01(adjusted);\n"
             "}\n"
             "void main() {\n"
-            "    vec4 tex_color = texture2D(uSourceTexture, v_texcoord);\n"
+            "    vec4 tex_color = texture(uSourceTexture, v_texcoord);\n"
             "    tex_color.r = apply_channel(tex_color.r);\n"
             "    tex_color.g = apply_channel(tex_color.g);\n"
             "    tex_color.b = apply_channel(tex_color.b);\n"
-            "    gl_FragColor = tex_color;\n"
+            "    vec3 color = tex_color.rgb * mix(vec3(1.0), uGain, clamp(uCast, 0.0, 1.0));\n"
+            "    float luma = dot(color, vec3(0.299, 0.587, 0.114));\n"
+            "    vec3 chroma = color - vec3(luma);\n"
+            "    float satAmt = 1.0 + uSaturation;\n"
+            "    float vibAmt = 1.0 + uVibrance;\n"
+            "    float w = 1.0 - clamp(abs(luma - 0.5) * 2.0, 0.0, 1.0);\n"
+            "    chroma *= satAmt * mix(1.0, vibAmt, w);\n"
+            "    vec3 output_color = clamp(vec3(luma) + chroma, 0.0, 1.0);\n"
+            "    FragColor = vec4(output_color, tex_color.a);\n"
+            "}\n"
+        )
+
+    def _compile_compute_shader(self) -> "QOpenGLShaderProgram | None":
+        """Compile the compute shader used to gather Color statistics."""
+
+        if self._gl43 is None:
+            return None
+
+        from PySide6.QtOpenGL import QOpenGLShader, QOpenGLShaderProgram
+
+        program = QOpenGLShaderProgram()
+        shader = QOpenGLShader(QOpenGLShader.ShaderTypeBit.Compute)
+        if not shader.compileSourceCode(self._compute_shader_source()):
+            message = shader.log() or "unknown compute shader error"
+            raise RuntimeError(f"Failed to compile OpenGL compute shader: {message}")
+        program.addShader(shader)
+        if not program.link():
+            message = program.log() or "unknown compute shader link error"
+            raise RuntimeError(f"Failed to link OpenGL compute shader program: {message}")
+        return program
+
+    @staticmethod
+    def _compute_shader_source() -> str:
+        """Return the GLSL source mirroring the GPU statistics helper."""
+
+        return (
+            "#version 430\n"
+            "layout(local_size_x=16, local_size_y=16, local_size_z=1) in;\n"
+            "layout(binding=0) uniform sampler2D uTex;\n"
+            "struct GroupStats {\n"
+            "  float sumS;\n"
+            "  float sumLinR;\n"
+            "  float sumLinG;\n"
+            "  float sumLinB;\n"
+            "  uint countN;\n"
+            "  uint countVHi;\n"
+            "  uint countVLo;\n"
+            "  uint countSkin;\n"
+            "  uint hist[64];\n"
+            "};\n"
+            "layout(std430, binding=1) buffer StatsBuf { GroupStats gs[]; };\n"
+            "shared float s_sumS;\n"
+            "shared float s_sumLinR;\n"
+            "shared float s_sumLinG;\n"
+            "shared float s_sumLinB;\n"
+            "shared uint s_countN;\n"
+            "shared uint s_countVHi;\n"
+            "shared uint s_countVLo;\n"
+            "shared uint s_countSkin;\n"
+            "shared uint s_hist[64];\n"
+            "vec3 to_linear(vec3 x){\n"
+            "  const float a = 0.055;\n"
+            "  vec3 y;\n"
+            "  for(int i=0;i<3;i++){\n"
+            "    if(x[i] <= 0.04045){\n"
+            "      y[i] = x[i] / 12.92;\n"
+            "    } else {\n"
+            "      y[i] = pow((x[i] + a) / (1.0 + a), 2.4);\n"
+            "    }\n"
+            "  }\n"
+            "  return y;\n"
+            "}\n"
+            "vec3 rgb2hsv(vec3 c){\n"
+            "  float r=c.r,g=c.g,b=c.b;\n"
+            "  float mx = max(r, max(g,b));\n"
+            "  float mn = min(r, min(g,b));\n"
+            "  float d  = mx - mn + 1e-8;\n"
+            "  float h = 0.0;\n"
+            "  if(mx==r){ h = mod((g-b)/d, 6.0); }\n"
+            "  else if(mx==g){ h = ((b-r)/d) + 2.0; }\n"
+            "  else{ h = ((r-g)/d) + 4.0; }\n"
+            "  h /= 6.0;\n"
+            "  float s = d/(mx+1e-8);\n"
+            "  float v = mx;\n"
+            "  return vec3(h,s,v);\n"
+            "}\n"
+            "void main(){\n"
+            "  uvec2 gid = gl_WorkGroupID.xy;\n"
+            "  uvec2 lid = gl_LocalInvocationID.xy;\n"
+            "  uvec2 gsz = gl_NumWorkGroups.xy;\n"
+            "  uint groupIndex = gid.y*gsz.x + gid.x;\n"
+            "  if(lid.x==0 && lid.y==0){\n"
+            "    s_sumS = 0.0;\n"
+            "    s_sumLinR = 0.0;\n"
+            "    s_sumLinG = 0.0;\n"
+            "    s_sumLinB = 0.0;\n"
+            "    s_countN = 0u;\n"
+            "    s_countVHi = 0u;\n"
+            "    s_countVLo = 0u;\n"
+            "    s_countSkin = 0u;\n"
+            "    for(int i=0;i<64;i++){ s_hist[i] = 0u; }\n"
+            "  }\n"
+            "  barrier();\n"
+            "  ivec2 size = textureSize(uTex, 0);\n"
+            "  ivec2 base = ivec2(gid * uvec2(16,16));\n"
+            "  ivec2 p = base + ivec2(lid);\n"
+            "  if(p.x < size.x && p.y < size.y){\n"
+            "    vec3 srgb = texelFetch(uTex, p, 0).rgb;\n"
+            "    vec3 hsv = rgb2hsv(srgb);\n"
+            "    float S = hsv.g;\n"
+            "    float V = hsv.b;\n"
+            "    vec3 lin = to_linear(srgb);\n"
+            "    atomicAdd(s_countN, 1u);\n"
+            "    if(V > 0.90){ atomicAdd(s_countVHi, 1u); }\n"
+            "    if(V < 0.05){ atomicAdd(s_countVLo, 1u); }\n"
+            "    float Hdeg = hsv.r * 360.0;\n"
+            "    if(Hdeg>10.0 && Hdeg<50.0 && S>0.1 && S<0.6){ atomicAdd(s_countSkin, 1u); }\n"
+            "    int bin = int(clamp(floor(S*64.0), 0.0, 63.0));\n"
+            "    atomicAdd(s_hist[bin], 1u);\n"
+            "    s_sumS += S;\n"
+            "    s_sumLinR += lin.r;\n"
+            "    s_sumLinG += lin.g;\n"
+            "    s_sumLinB += lin.b;\n"
+            "  }\n"
+            "  barrier();\n"
+            "  if(lid.x==0 && lid.y==0){\n"
+            "    gs[groupIndex].sumS = s_sumS;\n"
+            "    gs[groupIndex].sumLinR = s_sumLinR;\n"
+            "    gs[groupIndex].sumLinG = s_sumLinG;\n"
+            "    gs[groupIndex].sumLinB = s_sumLinB;\n"
+            "    gs[groupIndex].countN = s_countN;\n"
+            "    gs[groupIndex].countVHi = s_countVHi;\n"
+            "    gs[groupIndex].countVLo = s_countVLo;\n"
+            "    gs[groupIndex].countSkin = s_countSkin;\n"
+            "    for(int i=0;i<64;i++){ gs[groupIndex].hist[i] = s_hist[i]; }\n"
+            "  }\n"
             "}\n"
         )
 
@@ -308,16 +619,15 @@ class _OpenGlPreviewBackend(PreviewBackend):
         except Exception:
             return False
 
+        context: QOpenGLContext | None = None
+        surface: QOffscreenSurface | None = None
         try:
-            context = QOpenGLContext()
-            format_hint = QSurfaceFormat()
-            format_hint.setRenderableType(QSurfaceFormat.RenderableType.OpenGL)
-            context.setFormat(format_hint)
-            if not context.create():
-                return False
+            context, format_hint = cls._initialise_context(
+                QOpenGLContext, QSurfaceFormat
+            )
 
             surface = QOffscreenSurface()
-            surface.setFormat(context.format())
+            surface.setFormat(format_hint)
             surface.create()
             if not surface.isValid():
                 return False
@@ -340,10 +650,22 @@ class _OpenGlPreviewBackend(PreviewBackend):
         except Exception:
             return False
         finally:
-            try:
-                context.doneCurrent()
-            except Exception:  # pragma: no cover - defensive
-                pass
+            if context is not None:
+                try:
+                    context.doneCurrent()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+                try:
+                    context.deleteLater()
+                except Exception:  # pragma: no cover - some bindings lack QObject parent
+                    pass
+
+            if surface is not None:
+                try:
+                    surface.destroy()
+                except Exception:  # pragma: no cover - some bindings expose no destroy()
+                    pass
 
         return True
 
@@ -364,7 +686,7 @@ class _OpenGlPreviewBackend(PreviewBackend):
             # without handling a special case.  Rendering an empty session
             # results in a null image which mirrors the CPU backend's
             # behaviour when asked to process an invalid ``QImage``.
-            return _OpenGlPreviewSession(0, 0, 0, None)
+            return _OpenGlPreviewSession(0, 0, 0, None, ColorStats())
 
         if not self._make_current():
             raise RuntimeError("Failed to activate OpenGL context for session creation")
@@ -378,9 +700,11 @@ class _OpenGlPreviewBackend(PreviewBackend):
 
         framebuffer = QOpenGLFramebufferObject(width, height)
 
+        stats = self._compute_session_stats(texture_id, width, height, converted)
+
         self._context.doneCurrent()
 
-        return _OpenGlPreviewSession(width, height, texture_id, framebuffer)
+        return _OpenGlPreviewSession(width, height, texture_id, framebuffer, stats)
 
     def _generate_texture(self) -> int:
         """Create and return a new OpenGL texture identifier."""
@@ -421,6 +745,160 @@ class _OpenGlPreviewBackend(PreviewBackend):
             buffer,
         )
         gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
+
+    def _compute_session_stats(
+        self,
+        texture_id: int,
+        width: int,
+        height: int,
+        fallback_image: QImage,
+    ) -> ColorStats:
+        """Return :class:`ColorStats` using the compute shader when available."""
+
+        fallback_stats: ColorStats | None = None
+
+        def _fallback() -> ColorStats:
+            nonlocal fallback_stats
+            if fallback_stats is None:
+                fallback_stats = compute_color_statistics(fallback_image)
+            return fallback_stats
+
+        if (
+            texture_id == 0
+            or width == 0
+            or height == 0
+            or self._compute_program is None
+            or self._stats_buffer is None
+            or self._gl43 is None
+        ):
+            return _fallback()
+
+        groups_x = (width + 15) // 16
+        groups_y = (height + 15) // 16
+        group_count = max(groups_x * groups_y, 1)
+        stride = 320
+        total_size = stride * group_count
+
+        if not self._stats_buffer.bind():
+            return _fallback()
+        # Allocate or resize the buffer to hold one record per work group.
+        self._stats_buffer.allocate(total_size)
+        self._stats_buffer.release()
+
+        gl = self._gl
+        gl43 = self._gl43
+        program = self._compute_program
+        assert program is not None  # guarded above
+
+        if not program.bind():
+            return _fallback()
+
+        gl.glActiveTexture(gl.GL_TEXTURE0)
+        gl.glBindTexture(gl.GL_TEXTURE_2D, texture_id)
+        program.setUniformValue("uTex", 0)
+
+        buffer_id = self._stats_buffer.bufferId()
+        gl43.glBindBufferBase(gl.GL_SHADER_STORAGE_BUFFER, 1, buffer_id)
+        gl43.glDispatchCompute(groups_x, groups_y, 1)
+        gl43.glMemoryBarrier(gl.GL_SHADER_STORAGE_BARRIER_BIT | gl.GL_BUFFER_UPDATE_BARRIER_BIT)
+
+        program.release()
+        gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
+
+        if not self._stats_buffer.bind():
+            return _fallback()
+
+        mapped = self._stats_buffer.mapRange(
+            0,
+            total_size,
+            QOpenGLBuffer.RangeAccessFlag.ReadAccess,
+        )
+        if mapped is None:
+            self._stats_buffer.release()
+            return _fallback()
+
+        raw = bytes(mapped)
+        self._stats_buffer.unmap()
+        self._stats_buffer.release()
+
+        # Some drivers align SSBO records beyond the declared payload.  Derive the
+        # actual stride from the returned data to ensure we walk the buffer
+        # correctly on all platforms.
+        if len(raw) // group_count > stride:
+            stride = len(raw) // group_count
+
+        sum_saturation = 0.0
+        sum_lin_r = 0.0
+        sum_lin_g = 0.0
+        sum_lin_b = 0.0
+        count = 0
+        highlight_count = 0
+        dark_count = 0
+        skin_count = 0
+        histogram = [0] * 64
+
+        for index in range(group_count):
+            base = index * stride
+            if base + 288 > len(raw):
+                break
+            sum_saturation += struct.unpack_from("<f", raw, base + 0x00)[0]
+            sum_lin_r += struct.unpack_from("<f", raw, base + 0x04)[0]
+            sum_lin_g += struct.unpack_from("<f", raw, base + 0x08)[0]
+            sum_lin_b += struct.unpack_from("<f", raw, base + 0x0C)[0]
+            count += struct.unpack_from("<I", raw, base + 0x10)[0]
+            highlight_count += struct.unpack_from("<I", raw, base + 0x14)[0]
+            dark_count += struct.unpack_from("<I", raw, base + 0x18)[0]
+            skin_count += struct.unpack_from("<I", raw, base + 0x1C)[0]
+            hist_slice = struct.unpack_from("<64I", raw, base + 0x20)
+            for bin_index, bin_value in enumerate(hist_slice):
+                histogram[bin_index] += bin_value
+
+        if count == 0:
+            return ColorStats()
+
+        mean_saturation = sum_saturation / count
+        cumulative = 0
+        median_target = count // 2
+        median_saturation = 0.0
+        for bin_index, bin_value in enumerate(histogram):
+            cumulative += bin_value
+            if cumulative >= median_target:
+                median_saturation = (bin_index + 0.5) / 64.0
+                break
+
+        highlight_ratio = highlight_count / count
+        dark_ratio = dark_count / count
+        skin_ratio = skin_count / count
+
+        avg_lin_r = sum_lin_r / count
+        avg_lin_g = sum_lin_g / count
+        avg_lin_b = sum_lin_b / count
+        avg_lin = (avg_lin_r + avg_lin_g + avg_lin_b) / 3.0
+
+        def _safe_gain(value: float) -> float:
+            if value <= 1e-6:
+                return 1.0
+            return avg_lin / value
+
+        gain_r = max(0.5, min(2.5, _safe_gain(avg_lin_r)))
+        gain_g = max(0.5, min(2.5, _safe_gain(avg_lin_g)))
+        gain_b = max(0.5, min(2.5, _safe_gain(avg_lin_b)))
+
+        cast_magnitude = max(
+            abs(avg_lin_r - avg_lin),
+            abs(avg_lin_g - avg_lin),
+            abs(avg_lin_b - avg_lin),
+        )
+
+        return ColorStats(
+            saturation_mean=min(max(mean_saturation, 0.0), 1.0),
+            saturation_median=min(max(median_saturation, 0.0), 1.0),
+            highlight_ratio=min(max(highlight_ratio, 0.0), 1.0),
+            dark_ratio=min(max(dark_ratio, 0.0), 1.0),
+            skin_ratio=min(max(skin_ratio, 0.0), 1.0),
+            cast_magnitude=min(max(cast_magnitude, 0.0), 1.0),
+            white_balance_gain=(gain_r, gain_g, gain_b),
+        )
 
     def render(self, session: PreviewSession, adjustments: Mapping[str, float]) -> QImage:
         from PySide6.QtGui import QImage as QtImage
@@ -464,6 +942,19 @@ class _OpenGlPreviewBackend(PreviewBackend):
         shadows = float(adjustments.get("Shadows", 0.0))
         contrast_factor = 1.0 + float(adjustments.get("Contrast", 0.0))
         black_point = float(adjustments.get("BlackPoint", 0.0))
+        saturation = float(adjustments.get("Saturation", 0.0))
+        vibrance = float(adjustments.get("Vibrance", 0.0))
+        cast = float(adjustments.get("Cast", 0.0))
+        if (
+            "Color_Gain_R" in adjustments
+            and "Color_Gain_G" in adjustments
+            and "Color_Gain_B" in adjustments
+        ):
+            gain_r = float(adjustments.get("Color_Gain_R", 1.0))
+            gain_g = float(adjustments.get("Color_Gain_G", 1.0))
+            gain_b = float(adjustments.get("Color_Gain_B", 1.0))
+        else:
+            gain_r, gain_g, gain_b = gl_session.color_stats.white_balance_gain
 
         program.setUniformValue(self._uniform_exposure, exposure_term)
         program.setUniformValue(self._uniform_brightness, brightness_term)
@@ -472,6 +963,10 @@ class _OpenGlPreviewBackend(PreviewBackend):
         program.setUniformValue(self._uniform_shadows, shadows)
         program.setUniformValue(self._uniform_contrast, contrast_factor)
         program.setUniformValue(self._uniform_black_point, black_point)
+        program.setUniformValue(self._uniform_saturation, saturation)
+        program.setUniformValue(self._uniform_vibrance, vibrance)
+        program.setUniformValue(self._uniform_cast, cast)
+        program.setUniformValue(self._uniform_gain, gain_r, gain_g, gain_b)
 
         if not self._vertex_buffer.bind():
             program.release()
@@ -535,6 +1030,7 @@ class _OpenGlPreviewSession(PreviewSession):
     height: int
     texture_id: int
     framebuffer: "QOpenGLFramebufferObject | None"
+    color_stats: ColorStats
 
     def dispose(self) -> None:  # pragma: no cover - real cleanup happens in backend
         self.framebuffer = None

--- a/src/iPhoto/gui/ui/controllers/edit_preview_manager.py
+++ b/src/iPhoto/gui/ui/controllers/edit_preview_manager.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import QObject, QRunnable, QThreadPool, QTimer, Qt, Signal
 from PySide6.QtGui import QImage, QPixmap
 
 from ....core.light_resolver import LIGHT_KEYS, resolve_light_vector
+from ....core.color_resolver import COLOR_KEYS, ColorResolver, ColorStats, compute_color_statistics
 from ....core.preview_backends import (
     PreviewBackend,
     PreviewSession,
@@ -87,6 +88,7 @@ class EditPreviewManager(QObject):
         self._base_pixmap: Optional[QPixmap] = None
         self._current_preview_pixmap: Optional[QPixmap] = None
         self._current_adjustments: dict[str, float | bool] = {}
+        self._color_stats: ColorStats | None = None
 
         self._thread_pool = QThreadPool.globalInstance()
         self._preview_job_id = 0
@@ -154,6 +156,8 @@ class EditPreviewManager(QObject):
         self._base_pixmap = base_pixmap if not base_pixmap.isNull() else None
         self._current_preview_pixmap = self._base_pixmap
         self._current_adjustments = dict(adjustments)
+        session_stats = getattr(self._preview_session, "color_stats", None)
+        self._color_stats = session_stats if isinstance(session_stats, ColorStats) else compute_color_statistics(prepared)
 
         if previous_session is not None:
             self._queue_session_for_disposal(previous_session)
@@ -181,6 +185,7 @@ class EditPreviewManager(QObject):
         self._base_pixmap = None
         self._current_preview_pixmap = None
         self._current_adjustments.clear()
+        self._color_stats = None
 
     def cancel_pending_updates(self) -> None:
         """Stop timers and invalidate in-flight previews without tearing down the session."""
@@ -321,14 +326,19 @@ class EditPreviewManager(QObject):
 
         resolved: dict[str, float] = {}
         overrides: dict[str, float] = {}
+        color_overrides: dict[str, float] = {}
         master_value = float(session_values.get("Light_Master", 0.0))
         light_enabled = bool(session_values.get("Light_Enabled", True))
+        color_master = float(session_values.get("Color_Master", 0.0))
+        color_enabled = bool(session_values.get("Color_Enabled", True))
 
         for key, value in session_values.items():
-            if key in ("Light_Master", "Light_Enabled"):
+            if key in ("Light_Master", "Light_Enabled", "Color_Master", "Color_Enabled"):
                 continue
             if key in LIGHT_KEYS:
                 overrides[key] = float(value)
+            elif key in COLOR_KEYS:
+                color_overrides[key] = float(value)
             else:
                 resolved[key] = float(value)
 
@@ -336,6 +346,24 @@ class EditPreviewManager(QObject):
             resolved.update(resolve_light_vector(master_value, overrides, mode="delta"))
         else:
             resolved.update({key: 0.0 for key in LIGHT_KEYS})
+
+        stats = self._color_stats or ColorStats()
+        if color_enabled:
+            resolved.update(
+                ColorResolver.resolve_color_vector(
+                    color_master,
+                    color_overrides,
+                    stats=stats,
+                    mode="delta",
+                )
+            )
+        else:
+            resolved.update({key: 0.0 for key in COLOR_KEYS})
+
+        gain_r, gain_g, gain_b = stats.white_balance_gain
+        resolved["Color_Gain_R"] = gain_r
+        resolved["Color_Gain_G"] = gain_g
+        resolved["Color_Gain_B"] = gain_b
 
         return resolved
 

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
-from typing import Optional, Set
+from typing import Mapping, Optional, Set
 
 from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
 from PySide6.QtGui import QImage, QPixmap
@@ -11,17 +12,26 @@ from PySide6.QtWidgets import QStackedWidget, QWidget
 
 from ...utils import image_loader
 from ....core.image_filters import apply_adjustments
+from ....core.color_resolver import ColorStats, compute_color_statistics
+from ....core.preview_backends import (
+    PreviewBackend,
+    fallback_preview_backend,
+    select_preview_backend,
+)
 from ....io import sidecar
 from ..widgets.image_viewer import ImageViewer
 from ..widgets.live_badge import LiveBadge
 from ..widgets.video_area import VideoArea
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 class _AdjustedImageSignals(QObject):
     """Relay worker completion events back to the GUI thread."""
 
-    completed = Signal(Path, QImage)
-    """Emitted when the adjusted image finished loading successfully."""
+    completed = Signal(Path, QImage, object)
+    """Emitted when the image and optional raw adjustments are ready."""
 
     failed = Signal(Path, str)
     """Emitted when loading or processing the image fails."""
@@ -34,24 +44,20 @@ class _AdjustedImageWorker(QRunnable):
         self,
         source: Path,
         signals: _AdjustedImageSignals,
+        *,
+        apply_on_worker: bool,
     ) -> None:
         super().__init__()
         self.setAutoDelete(False)
         self._source = source
         self._signals = signals
+        self._apply_on_worker = apply_on_worker
         # The worker always decodes the original frame at full fidelity.  The
         # GUI thread performs any downscaling so zooming and full-screen views
         # can leverage every available pixel.
 
     def run(self) -> None:  # pragma: no cover - executed on a worker thread
         """Perform the expensive image work outside the GUI thread."""
-
-        try:
-            raw_adjustments = sidecar.load_adjustments(self._source)
-            adjustments = sidecar.resolve_render_adjustments(raw_adjustments)
-        except Exception as exc:  # pragma: no cover - filesystem errors are rare
-            self._signals.failed.emit(self._source, str(exc))
-            return
 
         try:
             # Requesting ``None`` as the target size forces ``QImageReader`` to
@@ -67,14 +73,29 @@ class _AdjustedImageWorker(QRunnable):
             self._signals.failed.emit(self._source, "Image decoder returned an empty frame")
             return
 
-        if adjustments:
-            try:
-                image = apply_adjustments(image, adjustments)
-            except Exception as exc:  # pragma: no cover - defensive safeguard
-                self._signals.failed.emit(self._source, str(exc))
-                return
+        try:
+            raw_adjustments = dict(sidecar.load_adjustments(self._source) or {})
+        except Exception as exc:  # pragma: no cover - filesystem errors are rare
+            self._signals.failed.emit(self._source, str(exc))
+            return
 
-        self._signals.completed.emit(self._source, image)
+        if self._apply_on_worker and raw_adjustments:
+            stats = compute_color_statistics(image)
+            adjustments = sidecar.resolve_render_adjustments(
+                raw_adjustments,
+                color_stats=stats,
+            )
+            if adjustments:
+                try:
+                    image = apply_adjustments(image, adjustments, color_stats=stats)
+                except Exception as exc:  # pragma: no cover - defensive safeguard
+                    self._signals.failed.emit(self._source, str(exc))
+                    return
+            raw_payload: Optional[Mapping[str, float | bool]] = None
+        else:
+            raw_payload = raw_adjustments
+
+        self._signals.completed.emit(self._source, image, raw_payload)
 
 
 class PlayerViewController(QObject):
@@ -107,6 +128,9 @@ class PlayerViewController(QObject):
         self._pool = QThreadPool.globalInstance()
         self._active_workers: Set[_AdjustedImageWorker] = set()
         self._loading_source: Optional[Path] = None
+        self._render_backend: PreviewBackend | None = None
+        self._backend_renders_on_ui = False
+        self._initialise_render_backend()
 
     # ------------------------------------------------------------------
     # High-level surface selection helpers
@@ -175,13 +199,17 @@ class PlayerViewController(QObject):
 
         signals = _AdjustedImageSignals()
 
-        worker = _AdjustedImageWorker(source, signals)
+        worker = _AdjustedImageWorker(
+            source,
+            signals,
+            apply_on_worker=not self._backend_renders_on_ui,
+        )
         self._active_workers.add(worker)
 
         signals.completed.connect(self._on_adjusted_image_ready)
         signals.failed.connect(self._on_adjusted_image_failed)
 
-        def _finalize_on_completion(img_source: Path, img: QImage) -> None:
+        def _finalize_on_completion(img_source: Path, img: QImage, _raw: object) -> None:
             """Release worker resources once the frame arrives."""
 
             self._release_worker(worker)
@@ -270,7 +298,12 @@ class PlayerViewController(QObject):
     # ------------------------------------------------------------------
     # Worker callbacks
     # ------------------------------------------------------------------
-    def _on_adjusted_image_ready(self, source: Path, image: QImage) -> None:
+    def _on_adjusted_image_ready(
+        self,
+        source: Path,
+        image: QImage,
+        raw_adjustments: object,
+    ) -> None:
         """Render *image* when the matching worker completes successfully."""
 
         if self._loading_source != source:
@@ -286,7 +319,13 @@ class PlayerViewController(QObject):
             )
             return
 
-        pixmap = QPixmap.fromImage(image)
+        processed_image = image
+        adjustments_mapping: Optional[Mapping[str, float | bool]]
+        adjustments_mapping = raw_adjustments if isinstance(raw_adjustments, Mapping) else None
+        if adjustments_mapping:
+            processed_image = self._render_with_backend(source, image, adjustments_mapping)
+
+        pixmap = QPixmap.fromImage(processed_image)
         if pixmap.isNull():
             if self._loading_source == source:
                 self._loading_source = None
@@ -319,3 +358,104 @@ class PlayerViewController(QObject):
         if worker in self._active_workers:
             self._active_workers.remove(worker)
         worker.setAutoDelete(True)
+
+    # ------------------------------------------------------------------
+    # Rendering helpers
+    # ------------------------------------------------------------------
+    def _initialise_render_backend(self) -> None:
+        """Instantiate the most capable render backend for still images."""
+
+        try:
+            backend = select_preview_backend()
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            _LOGGER.warning("Failed to initialise preview backend for player view: %s", exc)
+            self._render_backend = None
+            self._backend_renders_on_ui = False
+            return
+
+        self._render_backend = backend
+        self._backend_renders_on_ui = backend.supports_realtime
+        if backend.supports_realtime:
+            _LOGGER.info("Player view using %s preview backend for GPU rendering", backend.tier_name)
+        else:
+            _LOGGER.info("Player view using %s preview backend", backend.tier_name)
+
+    def _fallback_render_backend(self) -> None:
+        """Downgrade to a safer backend after GPU failures."""
+
+        if self._render_backend is None:
+            return
+        try:
+            fallback = fallback_preview_backend(self._render_backend)
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            _LOGGER.warning("Failed to fall back from %s backend: %s", self._render_backend.tier_name, exc)
+            self._render_backend = None
+            self._backend_renders_on_ui = False
+            return
+
+        if fallback is self._render_backend:
+            # Already at the safest tier.
+            self._backend_renders_on_ui = fallback.supports_realtime
+            return
+
+        self._render_backend = fallback
+        self._backend_renders_on_ui = fallback.supports_realtime
+        _LOGGER.info("Player view fell back to %s preview backend", fallback.tier_name)
+
+    def _render_with_backend(
+        self,
+        source: Path,
+        base_image: QImage,
+        adjustments: Mapping[str, float | bool],
+    ) -> QImage:
+        """Apply *adjustments* using the most appropriate rendering pipeline."""
+
+        backend = self._render_backend if self._backend_renders_on_ui else None
+        if backend is None:
+            return self._apply_cpu_adjustments(source, base_image, adjustments, None)
+
+        session = None
+        stats: ColorStats | None = None
+        try:
+            session = backend.create_session(base_image)
+            stats = getattr(session, "color_stats", None)
+            resolved = sidecar.resolve_render_adjustments(adjustments, color_stats=stats)
+            if not resolved:
+                return base_image
+            rendered = backend.render(session, resolved)
+            if rendered.isNull():
+                raise RuntimeError("GPU pipeline returned a null image")
+            return rendered
+        except Exception as exc:
+            _LOGGER.warning("GPU rendering failed for %s: %s", source, exc)
+            self._fallback_render_backend()
+            stats = stats or (getattr(session, "color_stats", None) if session is not None else None)
+            return self._apply_cpu_adjustments(source, base_image, adjustments, stats)
+        finally:
+            if session is not None:
+                try:
+                    backend.dispose_session(session)
+                except Exception as dispose_exc:  # pragma: no cover - defensive safeguard
+                    _LOGGER.debug("Failed to dispose preview session: %s", dispose_exc)
+
+    def _apply_cpu_adjustments(
+        self,
+        source: Path | None,
+        image: QImage,
+        adjustments: Mapping[str, float | bool],
+        stats: ColorStats | None,
+    ) -> QImage:
+        """Apply *adjustments* on the CPU as a reliable fallback."""
+
+        try:
+            stats_obj = stats if isinstance(stats, ColorStats) else None
+            if stats_obj is None and adjustments:
+                stats_obj = compute_color_statistics(image)
+            resolved = sidecar.resolve_render_adjustments(adjustments, color_stats=stats_obj)
+            if not resolved:
+                return image
+            return apply_adjustments(image, resolved, color_stats=stats_obj)
+        except Exception as exc:  # pragma: no cover - defensive safeguard
+            label = source if source is not None else "<unknown>"
+            _LOGGER.error("CPU rendering failed for %s: %s", label, exc)
+            return image

--- a/src/iPhoto/gui/ui/widgets/edit_color_section.py
+++ b/src/iPhoto/gui/ui/widgets/edit_color_section.py
@@ -1,0 +1,312 @@
+"""Color adjustment section used inside the edit sidebar."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from PySide6.QtCore import Signal, Slot, Qt
+from PySide6.QtGui import QImage, QMouseEvent
+from PySide6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QVBoxLayout,
+    QWidget,
+    QGraphicsOpacityEffect,
+)
+
+from ....core.color_resolver import COLOR_KEYS, COLOR_RANGES, ColorResolver, ColorStats
+from ....core.color_resolver import compute_color_statistics
+from ....core.image_filters import apply_adjustments
+from ..models.edit_session import EditSession
+from .collapsible_section import CollapsibleSection
+from .edit_strip import BWSlider
+from .thumbnail_strip_slider import ThumbnailStripSlider
+
+
+class EditColorSection(QWidget):
+    """Container widget hosting the "Color" adjustment sliders."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._session: Optional[EditSession] = None
+        self._rows: Dict[str, _SliderRow] = {}
+        self._color_stats: ColorStats = ColorStats()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.master_slider = ThumbnailStripSlider(
+            "Color",
+            self,
+            minimum=-1.0,
+            maximum=1.0,
+            initial=0.0,
+        )
+        self.master_slider.set_preview_generator(self._generate_master_preview)
+        self.master_slider.valueChanged.connect(self._handle_master_slider_changed)
+        self.master_slider.clickedWhenDisabled.connect(self._handle_disabled_slider_click)
+        layout.addWidget(self.master_slider)
+
+        options_container = QFrame(self)
+        options_container.setFrameShape(QFrame.Shape.NoFrame)
+        options_container.setFrameShadow(QFrame.Shadow.Plain)
+        options_layout = QVBoxLayout(options_container)
+        options_layout.setContentsMargins(12, 12, 12, 12)
+        options_layout.setSpacing(1)
+
+        labels = [
+            ("Saturation", "Saturation"),
+            ("Vibrance", "Vibrance"),
+            ("Cast", "Cast"),
+        ]
+        for label_text, key in labels:
+            minimum, maximum = COLOR_RANGES[key]
+            row = _SliderRow(key, label_text, minimum, maximum, parent=options_container)
+            row.uiValueChanged.connect(self._handle_sub_slider_changed)
+            row.clickedWhenDisabled.connect(self._handle_disabled_slider_click)
+            options_layout.addWidget(row)
+            self._rows[key] = row
+
+        self.options_section = CollapsibleSection(
+            "Options",
+            "slider.horizontal.3.svg",
+            options_container,
+            self,
+        )
+        self.options_section.set_expanded(False)
+        layout.addWidget(self.options_section)
+        layout.addStretch(1)
+
+    # ------------------------------------------------------------------
+    def bind_session(self, session: Optional[EditSession]) -> None:
+        """Associate the section with *session* and refresh slider state."""
+
+        if self._session is session:
+            return
+        if self._session is not None:
+            self._session.valueChanged.disconnect(self._on_session_value_changed)
+            self._session.resetPerformed.disconnect(self._on_session_reset)
+        self._session = session
+
+        for row in self._rows.values():
+            row.setSession(session)
+
+        if session is not None:
+            session.valueChanged.connect(self._on_session_value_changed)
+            session.resetPerformed.connect(self._on_session_reset)
+            stats = session.color_stats()
+            if stats is not None:
+                self._color_stats = stats
+            self.refresh_from_session()
+        else:
+            self._disable_rows()
+            self.master_slider.setEnabled(False)
+            self.master_slider.update_from_value(0.0)
+
+    def refresh_from_session(self) -> None:
+        """Synchronise slider positions with the attached session."""
+
+        if self._session is None:
+            self._disable_rows()
+            self.master_slider.setEnabled(False)
+            self.master_slider.update_from_value(0.0)
+            return
+        master_value = float(self._session.value("Color_Master"))
+        self.master_slider.update_from_value(master_value)
+        enabled = bool(self._session.value("Color_Enabled"))
+        self.master_slider.setEnabled(enabled)
+        self._apply_enabled_state(enabled)
+        self._update_all_sub_sliders_ui()
+        for row in self._rows.values():
+            row.setEnabled(enabled)
+
+    def _disable_rows(self) -> None:
+        for row in self._rows.values():
+            row.setEnabled(False)
+            row.update_from_value(0.0)
+
+    # ------------------------------------------------------------------
+    def _on_session_value_changed(self, key: str, value: float | bool) -> None:
+        if key == "Color_Enabled":
+            self._apply_enabled_state(bool(value))
+            return
+
+        if key == "Color_Master":
+            self.master_slider.update_from_value(float(value))
+            self._update_all_sub_sliders_ui()
+            return
+
+        if key in COLOR_KEYS:
+            self._update_all_sub_sliders_ui()
+
+    def _on_session_reset(self) -> None:
+        self.refresh_from_session()
+
+    def _handle_master_slider_changed(self, new_value: float) -> None:
+        if self._session is None:
+            return
+        self._session.set_value("Color_Master", float(new_value))
+
+    @Slot(str, float)
+    def _handle_sub_slider_changed(self, key: str, new_ui_value: float) -> None:
+        """Persist the delta for *key* after the user moves a fine-tuning slider."""
+
+        if self._session is None:
+            return
+
+        master_value = float(self._session.value("Color_Master"))
+        base_values = ColorResolver.distribute_master(master_value, self._color_stats)
+        base_value = float(base_values.get(key, 0.0))
+
+        delta_value = _clamp(new_ui_value - base_value, -1.0, 1.0)
+        self._session.set_value(key, delta_value)
+
+    def _update_all_sub_sliders_ui(self) -> None:
+        """Recompute and display the final Color values for every fine-tuning slider."""
+
+        if self._session is None:
+            return
+
+        master_value = float(self._session.value("Color_Master"))
+        base_values = ColorResolver.distribute_master(master_value, self._color_stats)
+
+        for key in COLOR_KEYS:
+            row = self._rows.get(key)
+            if row is None:
+                continue
+
+            base_value = float(base_values.get(key, 0.0))
+            delta_value = float(self._session.value(key))
+            minimum, maximum = COLOR_RANGES[key]
+            final_value = _clamp(base_value + delta_value, minimum, maximum)
+
+            row.update_from_value(final_value)
+
+    def _apply_enabled_state(self, enabled: bool) -> None:
+        self.master_slider.setEnabled(enabled)
+        for row in self._rows.values():
+            row.setEnabled(enabled)
+
+    def set_preview_image(self, image) -> None:
+        """Forward *image* to the master slider and refresh cached statistics."""
+
+        if image is not None:
+            stats = compute_color_statistics(image)
+            self._color_stats = stats
+            if self._session is not None:
+                self._session.set_color_stats(stats)
+        self.master_slider.setImage(image)
+
+    @Slot()
+    def _handle_disabled_slider_click(self) -> None:
+        """Re-enables the Color adjustments if a disabled slider is clicked."""
+
+        if self._session is not None and not self._session.value("Color_Enabled"):
+            self._session.set_value("Color_Enabled", True)
+
+    def _generate_master_preview(self, image: QImage, value: float) -> QImage:
+        """Return a preview frame illustrating the Color master slider effect."""
+
+        stats = compute_color_statistics(image)
+        resolved = ColorResolver.resolve_color_vector(value, None, stats=stats)
+        gain_r, gain_g, gain_b = stats.white_balance_gain
+        adjustments = {
+            "Light_Enabled": False,
+            "Color_Enabled": True,
+            "Saturation": resolved.get("Saturation", 0.0),
+            "Vibrance": resolved.get("Vibrance", 0.0),
+            "Cast": resolved.get("Cast", 0.0),
+            "Color_Gain_R": gain_r,
+            "Color_Gain_G": gain_g,
+            "Color_Gain_B": gain_b,
+        }
+        return apply_adjustments(image, adjustments, color_stats=stats)
+
+
+class _SliderRow(QFrame):
+    """Helper widget bundling a label, slider and numeric read-out."""
+
+    uiValueChanged = Signal(str, float)
+    """Emitted whenever the slider's visual value changes due to user interaction."""
+
+    clickedWhenDisabled = Signal()
+
+    def __init__(
+        self,
+        key: str,
+        label: str,
+        minimum: float,
+        maximum: float,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._key = key
+        self._session: Optional[EditSession] = None
+
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.slider = BWSlider(label, self, minimum=minimum, maximum=maximum, initial=0.0)
+        layout.addWidget(self.slider)
+        self.slider.valueChanged.connect(self._handle_slider_changed)
+
+        self._opacity_effect = QGraphicsOpacityEffect(self)
+        self.setGraphicsEffect(self._opacity_effect)
+
+    def setSession(self, session: Optional[EditSession]) -> None:
+        self._session = session
+
+    def setEnabled(self, enabled: bool) -> None:  # type: ignore[override]
+        """Keep the row enabled to capture clicks, but disable the visual slider."""
+
+        super().setEnabled(True)
+        self.slider.setEnabled(enabled)
+        self._opacity_effect.setOpacity(1.0 if enabled else 0.5)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:  # type: ignore[override]
+        """Handle clicks when the slider is disabled to re-enable it."""
+
+        if event.button() == Qt.MouseButton.LeftButton:
+            if (
+                not self.slider.isEnabled()
+                and self.slider.geometry().contains(event.position().toPoint())
+            ):
+                self.clickedWhenDisabled.emit()
+
+                slider_event = QMouseEvent(
+                    event.type(),
+                    self.slider.mapFrom(self, event.position().toPoint()),
+                    event.globalPosition(),
+                    event.button(),
+                    event.buttons(),
+                    event.modifiers(),
+                )
+                QApplication.sendEvent(self.slider, slider_event)
+                event.accept()
+                return
+        super().mousePressEvent(event)
+
+    def update_from_value(self, value: float) -> None:
+        block = self.slider.blockSignals(True)
+        try:
+            self.slider.setValue(value, emit=False)
+        finally:
+            self.slider.blockSignals(block)
+
+    # ------------------------------------------------------------------
+    def _handle_slider_changed(self, new_value: float) -> None:
+        """Relay the updated slider value while tagging it with the adjustment *key*."""
+
+        self.uiValueChanged.emit(self._key, float(new_value))
+
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    if value < minimum:
+        return minimum
+    if value > maximum:
+        return maximum
+    return value
+

--- a/src/iPhoto/utils/deps.py
+++ b/src/iPhoto/utils/deps.py
@@ -15,6 +15,7 @@ class PillowSupport:
     Image: Any
     ImageOps: Any
     ImageQt: Any
+    ImageFilter: Any
     UnidentifiedImageError: Any
 
 
@@ -36,7 +37,7 @@ def load_pillow() -> Optional[PillowSupport]:
         return None
 
     try:
-        from PIL import Image, ImageOps, UnidentifiedImageError
+        from PIL import Image, ImageFilter, ImageOps, UnidentifiedImageError
     except Exception:  # pragma: no cover - optional dependency missing or broken
         return None
 
@@ -60,6 +61,7 @@ def load_pillow() -> Optional[PillowSupport]:
         Image=Image,
         ImageOps=ImageOps,
         ImageQt=ImageQt,
+        ImageFilter=ImageFilter,
         UnidentifiedImageError=UnidentifiedImageError,
     )
 


### PR DESCRIPTION
## Summary
- reuse the map widget's OpenGL share/default formats when creating the preview backend so both surfaces negotiate the same version
- fall back to explicit core-profile formats only when needed, keeping GPU tone mapping available instead of silently reverting to CPU

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6908b5a5493c832fb6a0d3edd7b1c26a