### PR TITLE
Improve edit mode responsiveness and toolbar separation

### DIFF
--- a/src/iPhoto/gui/ui/controllers/edit_theme_manager.py
+++ b/src/iPhoto/gui/ui/controllers/edit_theme_manager.py
@@ -183,8 +183,16 @@ class EditThemeManager:
                     )
 
         self._ui.edit_sidebar.set_control_icon_tint(dark_icon_color)
-        self._ui.zoom_out_button.setIcon(load_icon("minus.svg", color=dark_icon_hex))
-        self._ui.zoom_in_button.setIcon(load_icon("plus.svg", color=dark_icon_hex))
+        tinted_minus = load_icon("minus.svg", color=dark_icon_hex)
+        tinted_plus = load_icon("plus.svg", color=dark_icon_hex)
+        tinted_info = load_icon("info.circle.svg", color=dark_icon_hex)
+        tinted_favorite = load_icon("suit.heart.svg", color=dark_icon_hex)
+        self._ui.zoom_out_button.setIcon(tinted_minus)
+        self._ui.zoom_in_button.setIcon(tinted_plus)
+        self._ui.edit_zoom_out_button.setIcon(tinted_minus)
+        self._ui.edit_zoom_in_button.setIcon(tinted_plus)
+        self._ui.edit_info_button.setIcon(tinted_info)
+        self._ui.edit_favorite_button.setIcon(tinted_favorite)
 
         if self._detail_ui_controller is not None:
             self._detail_ui_controller.set_toolbar_icon_tint(dark_icon_color)
@@ -430,6 +438,10 @@ class EditThemeManager:
 
         self._ui.zoom_out_button.setIcon(load_icon("minus.svg"))
         self._ui.zoom_in_button.setIcon(load_icon("plus.svg"))
+        self._ui.edit_zoom_out_button.setIcon(load_icon("minus.svg"))
+        self._ui.edit_zoom_in_button.setIcon(load_icon("plus.svg"))
+        self._ui.edit_info_button.setIcon(load_icon("info.circle.svg"))
+        self._ui.edit_favorite_button.setIcon(load_icon("suit.heart.svg"))
         if self._detail_ui_controller is not None:
             self._detail_ui_controller.set_toolbar_icon_tint(None)
         else:

--- a/src/iPhoto/gui/ui/tasks/adjustment_workers.py
+++ b/src/iPhoto/gui/ui/tasks/adjustment_workers.py
@@ -1,0 +1,82 @@
+"""Background workers for loading and saving edit adjustment sidecars."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from PySide6.QtCore import QObject, QRunnable, Signal
+
+from ....io import sidecar
+
+
+class AdjustmentLoadWorkerSignals(QObject):
+    """Signals emitted by :class:`AdjustmentLoadWorker`."""
+
+    loaded = Signal(Path, dict)
+    """Emitted when the sidecar load succeeded."""
+
+    failed = Signal(Path, str)
+    """Emitted when the sidecar could not be read."""
+
+
+class AdjustmentLoadWorker(QRunnable):
+    """Load adjustment sidecars off the GUI thread."""
+
+    def __init__(self, source: Path) -> None:
+        super().__init__()
+        self._source = source
+        self.signals = AdjustmentLoadWorkerSignals()
+
+    def run(self) -> None:  # type: ignore[override]
+        """Perform the blocking disk I/O on a worker thread."""
+
+        try:
+            adjustments = sidecar.load_adjustments(self._source)
+        except Exception as exc:  # pragma: no cover - filesystem failures are rare
+            # Propagate the failure back to the controller so the edit workflow
+            # can fall back to default adjustments without stalling the UI.
+            self.signals.failed.emit(self._source, str(exc))
+            return
+
+        self.signals.loaded.emit(self._source, dict(adjustments))
+
+
+class AdjustmentSaveWorkerSignals(QObject):
+    """Signals emitted by :class:`AdjustmentSaveWorker`."""
+
+    succeeded = Signal(Path)
+    """Emitted once the adjustments were persisted to disk."""
+
+    failed = Signal(Path, str)
+    """Emitted when writing the sidecar file failed."""
+
+
+class AdjustmentSaveWorker(QRunnable):
+    """Persist adjustment mappings without blocking the GUI thread."""
+
+    def __init__(self, source: Path, adjustments: Mapping[str, float | bool]) -> None:
+        super().__init__()
+        self._source = source
+        self._adjustments = dict(adjustments)
+        self.signals = AdjustmentSaveWorkerSignals()
+
+    def run(self) -> None:  # type: ignore[override]
+        """Write the sidecar file in a background thread."""
+
+        try:
+            sidecar.save_adjustments(self._source, self._adjustments)
+        except Exception as exc:  # pragma: no cover - error propagation only
+            self.signals.failed.emit(self._source, str(exc))
+            return
+
+        self.signals.succeeded.emit(self._source)
+
+
+__all__ = [
+    "AdjustmentLoadWorker",
+    "AdjustmentLoadWorkerSignals",
+    "AdjustmentSaveWorker",
+    "AdjustmentSaveWorkerSignals",
+]
+

--- a/src/iPhoto/gui/ui/tasks/color_stats_worker.py
+++ b/src/iPhoto/gui/ui/tasks/color_stats_worker.py
@@ -1,0 +1,45 @@
+"""Worker that computes colour statistics for preview rendering asynchronously."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, QRunnable, Signal
+from PySide6.QtGui import QImage
+
+from ....core.color_resolver import ColorStats, compute_color_statistics
+
+
+class ColorStatsWorkerSignals(QObject):
+    """Signals relaying :class:`ColorStatsWorker` completion events."""
+
+    completed = Signal(ColorStats)
+    """Emitted when statistics were calculated successfully."""
+
+    failed = Signal(str)
+    """Emitted when statistics could not be computed."""
+
+
+class ColorStatsWorker(QRunnable):
+    """Compute colour statistics for a :class:`~PySide6.QtGui.QImage`."""
+
+    def __init__(self, image: QImage) -> None:
+        super().__init__()
+        # ``QImage`` uses implicit sharing, so ``copy`` ensures the worker
+        # operates on a detached buffer even if the caller mutates the original
+        # image later on the GUI thread.
+        self._image = QImage(image)
+        self.signals = ColorStatsWorkerSignals()
+
+    def run(self) -> None:  # type: ignore[override]
+        """Perform the CPU heavy statistics computation."""
+
+        try:
+            stats = compute_color_statistics(self._image)
+        except Exception as exc:  # pragma: no cover - resiliency path only
+            self.signals.failed.emit(str(exc))
+            return
+
+        self.signals.completed.emit(stats)
+
+
+__all__ = ["ColorStatsWorker", "ColorStatsWorkerSignals"]
+

--- a/src/iPhoto/gui/ui/ui_main_window.py
+++ b/src/iPhoto/gui/ui/ui_main_window.py
@@ -156,8 +156,12 @@ class Ui_MainWindow(object):
         self.edit_sidebar = self.detail_page.edit_sidebar
         self.edit_mode_control = self.detail_page.edit_mode_control
         self.edit_header_container = self.detail_page.edit_header_container
-        self.edit_zoom_host = self.detail_page.edit_zoom_host
-        self.edit_zoom_host_layout = self.detail_page.edit_zoom_host_layout
+        self.edit_zoom_widget = self.detail_page.edit_zoom_widget
+        self.edit_zoom_slider = self.detail_page.edit_zoom_slider
+        self.edit_zoom_in_button = self.detail_page.edit_zoom_in_button
+        self.edit_zoom_out_button = self.detail_page.edit_zoom_out_button
+        self.edit_info_button = self.detail_page.edit_info_button
+        self.edit_favorite_button = self.detail_page.edit_favorite_button
         self.edit_right_controls_layout = self.detail_page.edit_right_controls_layout
 
         right_panel = QWidget()

--- a/src/iPhoto/gui/ui/widgets/detail_page.py
+++ b/src/iPhoto/gui/ui/widgets/detail_page.py
@@ -68,10 +68,12 @@ class DetailPageWidget(QWidget):
         self.edit_compare_button = QToolButton(self)
         self.edit_reset_button = QPushButton(self)
         self.edit_done_button = QPushButton(self)
-        self.edit_zoom_host = QWidget(self)
-        self.edit_zoom_host_layout = QHBoxLayout(self.edit_zoom_host)
-        self.edit_zoom_host_layout.setContentsMargins(0, 0, 0, 0)
-        self.edit_zoom_host_layout.setSpacing(4)
+        self.edit_zoom_widget = QWidget(self)
+        self.edit_zoom_slider = QSlider(Qt.Orientation.Horizontal, self.edit_zoom_widget)
+        self.edit_zoom_in_button = QToolButton(self.edit_zoom_widget)
+        self.edit_zoom_out_button = QToolButton(self.edit_zoom_widget)
+        self.edit_info_button = QToolButton(self)
+        self.edit_favorite_button = QToolButton(self)
         self.edit_sidebar = EditSidebar()
         self.edit_sidebar.setObjectName("editSidebar")
 
@@ -351,9 +353,27 @@ class DetailPageWidget(QWidget):
         self.edit_reset_button.setFixedHeight(EDIT_HEADER_BUTTON_HEIGHT)
         left_controls_layout.addWidget(self.edit_reset_button)
 
-        self.edit_zoom_host_layout.setContentsMargins(0, 0, 0, 0)
-        self.edit_zoom_host_layout.setSpacing(4)
-        left_controls_layout.addWidget(self.edit_zoom_host)
+        small_button_size = QSize(
+            int(HEADER_BUTTON_SIZE.width() / 2),
+            int(HEADER_BUTTON_SIZE.height() / 2),
+        )
+        edit_zoom_layout = QHBoxLayout(self.edit_zoom_widget)
+        edit_zoom_layout.setContentsMargins(0, 0, 0, 0)
+        edit_zoom_layout.setSpacing(4)
+        self._configure_header_button(self.edit_zoom_out_button, "minus.svg", "Zoom Out")
+        self.edit_zoom_out_button.setFixedSize(small_button_size)
+        edit_zoom_layout.addWidget(self.edit_zoom_out_button)
+        self.edit_zoom_slider.setRange(10, 400)
+        self.edit_zoom_slider.setSingleStep(5)
+        self.edit_zoom_slider.setPageStep(25)
+        self.edit_zoom_slider.setValue(100)
+        self.edit_zoom_slider.setFixedWidth(90)
+        self.edit_zoom_slider.setToolTip("Zoom")
+        edit_zoom_layout.addWidget(self.edit_zoom_slider)
+        self._configure_header_button(self.edit_zoom_in_button, "plus.svg", "Zoom In")
+        self.edit_zoom_in_button.setFixedSize(small_button_size)
+        edit_zoom_layout.addWidget(self.edit_zoom_in_button)
+        left_controls_layout.addWidget(self.edit_zoom_widget)
 
         container_layout.addWidget(left_controls_container)
 
@@ -374,6 +394,13 @@ class DetailPageWidget(QWidget):
             QSizePolicy.Policy.Maximum,
             QSizePolicy.Policy.Preferred,
         )
+
+        self._configure_header_button(self.edit_info_button, "info.circle.svg", "Info")
+        right_controls_layout.addWidget(self.edit_info_button)
+
+        self._configure_header_button(self.edit_favorite_button, "suit.heart.svg", "Add to Favorites")
+        self.edit_favorite_button.setEnabled(False)
+        right_controls_layout.addWidget(self.edit_favorite_button)
 
         self.edit_done_button.setObjectName("editDoneButton")
         self.edit_done_button.setAutoDefault(False)
@@ -405,6 +432,10 @@ class DetailPageWidget(QWidget):
 
         container_layout.addWidget(right_controls_container)
         self.edit_right_controls_layout = right_controls_layout
+
+        self.edit_zoom_widget.hide()
+        self.edit_info_button.hide()
+        self.edit_favorite_button.hide()
 
         return container
 


### PR DESCRIPTION
## Summary
- load and save edit sidecar adjustments on a thread pool and reuse in-memory shader uniforms when leaving edit mode
- duplicate edit header controls instead of reparenting shared widgets and propagate state/theme styling to the new controls
- defer heavy preview colour statistics and theme flips off the GUI thread to keep transitions smooth

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690d14ffe274832f8ad167d560b52989