### PR TITLE
Respect filmstrip visibility preference on exiting edit mode

### DIFF
--- a/src/iPhoto/gui/ui/controllers/edit_view_transition.py
+++ b/src/iPhoto/gui/ui/controllers/edit_view_transition.py
@@ -110,8 +110,19 @@ class EditViewTransitionManager(QObject):
             animate=animate,
         )
 
-    def leave_edit_mode(self, animate: bool = True) -> None:
-        """Restore the standard chrome and animate the sidebar out of view."""
+    def leave_edit_mode(self, animate: bool = True, *, show_filmstrip: bool = True) -> None:
+        """Restore the standard chrome and animate the sidebar out of view.
+
+        Parameters
+        ----------
+        animate:
+            When ``True`` the sidebar collapse is animated; ``False`` snaps
+            everything back immediately which is useful for error recovery.
+        show_filmstrip:
+            Controls whether the filmstrip is made visible again once edit mode
+            finishes.  Callers can pass ``False`` when the user's preferences
+            request the filmstrip remain hidden on the detail page.
+        """
 
         if self._transition_direction == "exit":
             return
@@ -122,7 +133,14 @@ class EditViewTransitionManager(QObject):
 
         self._ui.detail_chrome_container.show()
         self._ui.edit_header_container.show()
-        self._ui.filmstrip_view.show()
+        if show_filmstrip:
+            self._ui.filmstrip_view.show()
+        else:
+            # Ensure the filmstrip stays hidden when the user's settings request
+            # it.  Calling ``hide`` keeps the widget state consistent even if it
+            # was temporarily shown by other UI interactions while edit mode
+            # was active.
+            self._ui.filmstrip_view.hide()
         if animate:
             self._detail_header_opacity.setOpacity(0.0)
             self._edit_header_opacity.setOpacity(1.0)

--- a/src/iPhoto/gui/ui/controllers/view_controller_manager.py
+++ b/src/iPhoto/gui/ui/controllers/view_controller_manager.py
@@ -80,6 +80,7 @@ class ViewControllerManager(QObject):
             window,
             navigation=navigation,
             detail_ui_controller=self._detail_ui,
+            settings=context.settings,
         )
         self._map_controller = LocationMapController(
             context.library,


### PR DESCRIPTION
## Summary
- add an opt-in flag to the edit transition manager so the filmstrip is only shown when desired
- read the stored `ui.show_filmstrip` setting inside the edit controller and forward it to the transition logic
- inject the shared settings manager when constructing the edit controller

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690d22287e24832f9e1b8cb989b7cff1