### PR TITLE
Fix scanner case sensitivity test failure on Windows

### DIFF
--- a/tests/test_heif_and_case_sensitivity.py
+++ b/tests/test_heif_and_case_sensitivity.py
@@ -5,17 +5,21 @@ from src.iPhoto.config import DEFAULT_INCLUDE, DEFAULT_EXCLUDE
 
 @pytest.fixture
 def scan_test_dir(tmp_path):
-    """Creates a temporary directory with various file extensions."""
+    """Creates a temporary directory with various file extensions.
+
+    We use different base names for uppercase and lowercase variants to ensure
+    they exist as distinct files even on case-insensitive filesystems (Windows/macOS).
+    """
     # Create files
     files = [
-        "image.heif",
-        "IMAGE.HEIF",
-        "image.heic",
-        "IMAGE.HEIC",
-        "image.jpg",
-        "IMAGE.JPG",
-        "video.mov",
-        "VIDEO.MOV",
+        "image_lower.heif",
+        "image_upper.HEIF",
+        "image_lower.heic",
+        "image_upper.HEIC",
+        "image_lower.jpg",
+        "image_upper.JPG",
+        "video_lower.mov",
+        "video_upper.MOV",
         "image.heifs",
         "image.heicf"
     ]


### PR DESCRIPTION
The `test_scanner_supports_heif_and_case_sensitivity` test was failing on Windows because it attempted to create `image.heif` and `IMAGE.HEIF` in the same directory. On case-insensitive filesystems, these filenames collide, resulting in a single file on disk, which caused the test to incorrectly assert that files were missing from the index.

This change:
1. Updates the test to use unique filenames (e.g., `image_lower.heif`, `image_upper.HEIF`) to ensure they exist as distinct files on all platforms.
2. Simplifies `DEFAULT_INCLUDE` in `src/iPhoto/config.py` to `["**/*"]`. This delegates extension filtering entirely to `scanner.py`, which uses robust case-insensitive checks against a hardcoded list of supported extensions, avoiding potential cross-platform glob inconsistencies.