### PR TITLE
Copilot/fix UI blocking people section

### DIFF
--- a/src/iPhoto/gui/ui/controllers/window_theme_controller.py
+++ b/src/iPhoto/gui/ui/controllers/window_theme_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QObject
@@ -275,9 +276,41 @@ class WindowThemeController(QObject):
             f"QPushButton:pressed {{ background-color: {edit_btn_pressed}; }}"
             f"QPushButton:disabled {{ color: {disabled_fg}; border-color: {edit_btn_border.name(QColor.NameFormat.HexArgb)}; }}"
         )
+        self._apply_zoom_slider_style(colors)
 
         # 4. Refresh Menus
         self._refresh_menu_styles()
+
+    def _apply_zoom_slider_style(self, colors: ThemeColors) -> None:
+        """Stabilise the header zoom-slider handle on Linux while leaving other platforms native."""
+
+        zoom_slider = getattr(self._ui, "zoom_slider", None)
+        if zoom_slider is None:
+            return
+        if not sys.platform.startswith("linux"):
+            zoom_slider.setStyleSheet("")
+            return
+
+        if colors.is_dark:
+            groove_bg = "rgba(255, 255, 255, 70)"
+            add_page_bg = "rgba(255, 255, 255, 24)"
+            sub_page_bg = "#d7d8da"
+            handle_bg = "#f5f6f8"
+            handle_border = "rgba(0, 0, 0, 90)"
+        else:
+            groove_bg = "rgba(17, 17, 17, 64)"
+            add_page_bg = "rgba(17, 17, 17, 20)"
+            sub_page_bg = "rgba(17, 17, 17, 210)"
+            handle_bg = "#f5f6f8"
+            handle_border = "rgba(17, 17, 17, 88)"
+
+        zoom_slider.setStyleSheet(
+            "QSlider { background: transparent; min-height: 18px; }\n"
+            f"QSlider::groove:horizontal {{ height: 3px; margin: 0; background: {groove_bg}; border-radius: 1px; }}\n"
+            f"QSlider::sub-page:horizontal {{ background: {sub_page_bg}; border-radius: 1px; }}\n"
+            f"QSlider::add-page:horizontal {{ background: {add_page_bg}; border-radius: 1px; }}\n"
+            f"QSlider::handle:horizontal {{ background: {handle_bg}; width: 12px; margin: -5px 0; border-radius: 6px; border: 1px solid {handle_border}; }}"
+        )
 
     def _update_icon_tints(self, colors: ThemeColors) -> None:
         """Update icon colors for buttons that need it."""

--- a/tests/ui/controllers/test_window_theme_controller.py
+++ b/tests/ui/controllers/test_window_theme_controller.py
@@ -5,7 +5,7 @@ import pytest
 
 from PySide6.QtCore import QObject
 from PySide6.QtGui import QPalette
-from PySide6.QtWidgets import QWidget, QToolButton, QLabel, QPushButton
+from PySide6.QtWidgets import QWidget, QToolButton, QLabel, QPushButton, QSlider
 
 from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeController
 from iPhoto.gui.ui.theme_manager import ThemeManager, LIGHT_THEME, DARK_THEME
@@ -67,6 +67,7 @@ class StubUi(QObject):
         self.video_area.set_surface_color = MagicMock()
 
         self.edit_button = make_widget("editButton", QPushButton)
+        self.zoom_slider = make_widget("zoomSlider", QSlider)
 
         # --- Icons / Toolbar ---
         self.edit_sidebar = make_widget("editSidebar")
@@ -256,6 +257,31 @@ def test_ui_component_styling(window_theme_controller, mock_theme_manager):
     # 5. Video Area Surface
     # In Light Mode, video area should match window background
     ui.video_area.set_surface_color.assert_called_with(bg)
+
+
+def test_zoom_slider_keeps_native_style_off_linux(mock_theme_manager, mock_window_shell, monkeypatch):
+    """Windows/macOS should keep the native header zoom-slider styling."""
+    monkeypatch.setattr(wtc_module.sys, "platform", "win32")
+    ui = StubUi()
+    ui.window_shell.parentWidget.return_value = mock_window_shell
+
+    WindowThemeController(ui, None, mock_theme_manager)
+
+    ui.zoom_slider.setStyleSheet.assert_called_with("")
+
+
+def test_zoom_slider_gets_linux_handle_fix(mock_theme_manager, mock_window_shell, monkeypatch):
+    """Linux should receive the explicit slider-handle stylesheet fix."""
+    monkeypatch.setattr(wtc_module.sys, "platform", "linux")
+    ui = StubUi()
+    ui.window_shell.parentWidget.return_value = mock_window_shell
+
+    WindowThemeController(ui, None, mock_theme_manager)
+
+    style = ui.zoom_slider.setStyleSheet.call_args[0][0]
+    assert "QSlider::handle:horizontal" in style
+    assert "width: 12px" in style
+    assert "margin: -5px 0" in style
 
 
 def test_icon_tinting(window_theme_controller, mock_theme_manager):


### PR DESCRIPTION
This pull request adds a platform-specific style fix for the header zoom-slider (`zoom_slider`) in the application's UI, ensuring consistent appearance and behavior across operating systems, especially on Linux. It also introduces comprehensive tests to verify the new styling logic.

**Platform-specific zoom slider styling:**

* Added the `_apply_zoom_slider_style` method in `window_theme_controller.py` to explicitly style the `zoom_slider` on Linux for better visual stability, while preserving native styling on Windows and macOS.
* Imported the `sys` module to detect the operating system for conditional styling logic.

**Testing improvements:**

* Extended the test UI stub to include a `zoom_slider` (`QSlider`) for testing. [[1]](diffhunk://#diff-1faca5a683daf6bff016ebcd914da49e7bb7e020a6a2900f18f28640fb209e13R70) [[2]](diffhunk://#diff-1faca5a683daf6bff016ebcd914da49e7bb7e020a6a2900f18f28640fb209e13L8-R8)
* Added `test_zoom_slider_keeps_native_style_off_linux` to verify that the native style is preserved on Windows/macOS.
* Added `test_zoom_slider_gets_linux_handle_fix` to verify that the explicit style is applied on Linux and the handle styling is correct.