### PR TITLE
Implement face scan row merging with preserved library state

### DIFF
--- a/src/iPhoto/app.py
+++ b/src/iPhoto/app.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 import sqlite3
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 from .cache.index_store import get_global_repository
 from .config import (
     DEFAULT_EXCLUDE,
     DEFAULT_INCLUDE,
-    RECENTLY_DELETED_DIR_NAME,
 )
 from .errors import IndexCorruptedError, ManifestInvalidError
 from .index_sync_service import (
@@ -168,32 +167,6 @@ def rescan(
     # Compute album path for library-relative paths
     album_path = _compute_album_path(root, library_root)
 
-    # ``original_rel_path`` is only populated for assets in the shared trash
-    # album.  Rescanning that directory must therefore preserve the existing
-    # mapping so the restore feature still knows where each item originated.
-    is_recently_deleted = root.name == RECENTLY_DELETED_DIR_NAME
-    preserved_fields = (
-        "original_rel_path",
-        "original_album_id",
-        "original_album_subpath",
-    )
-    preserved_restore_rows: Dict[str, dict] = {}
-    if is_recently_deleted:
-        try:
-            for row in store.read_all():
-                rel_value = row.get("rel")
-                if not isinstance(rel_value, str):
-                    continue
-                if not any(field in row for field in preserved_fields):
-                    continue
-                rel_key = Path(rel_value).as_posix()
-                preserved_restore_rows[rel_key] = row
-        except IndexCorruptedError:
-            # A corrupted index means we cannot recover historical restore
-            # targets.  Emit a warning and continue with a clean rescan so new
-            # trash entries still receive restore metadata.
-            LOGGER.warning("Unable to read previous trash index for %s", root)
-
     album = Album.open(root)
     include = album.manifest.get("filters", {}).get("include", DEFAULT_INCLUDE)
     exclude = album.manifest.get("filters", {}).get("exclude", DEFAULT_EXCLUDE)
@@ -216,19 +189,6 @@ def rescan(
             if "rel" in row:
                 row["rel"] = f"{album_path}/{row['rel']}"
     
-    if is_recently_deleted and preserved_restore_rows:
-        for new_row in rows:
-            rel_value = new_row.get("rel")
-            if not isinstance(rel_value, str):
-                continue
-            rel_key = Path(rel_value).as_posix()
-            cached = preserved_restore_rows.get(rel_key)
-            if not cached:
-                continue
-            for field in preserved_fields:
-                if field in cached and field not in new_row:
-                    new_row[field] = cached[field]
-
     _update_index_snapshot(root, rows, library_root=library_root)
     
     # For _ensure_links, we need album-relative rows
@@ -306,9 +266,9 @@ def scan_specific_files(
 
     db_root = library_root if library_root else root
     store = get_global_repository(db_root)
-    # We use append_rows which handles merging/updating based on 'rel' key
-    # It also handles locking safely.
-    store.append_rows(rows)
+    # Merge scanned facts while preserving library-managed state such as
+    # face_status and favorites for unchanged assets.
+    store.merge_scan_rows(rows)
 
 
 def pair(root: Path, library_root: Optional[Path] = None) -> List[LiveGroup]:

--- a/src/iPhoto/cache/index_store/engine.py
+++ b/src/iPhoto/cache/index_store/engine.py
@@ -62,7 +62,7 @@ class DatabaseManager:
         return conn
 
     @contextmanager
-    def transaction(self) -> Iterator[sqlite3.Connection]:
+    def transaction(self, *, begin_mode: str | None = None) -> Iterator[sqlite3.Connection]:
         """Context manager for transactional operations.
         
         This context manager batches multiple updates into a single transaction
@@ -91,14 +91,28 @@ class DatabaseManager:
         """
         if self._conn:
             # WARNING: Nested transaction - no savepoint, just yields existing connection
-            # The nested block shares the outer transaction's fate
+            # The nested block shares the outer transaction's fate.
+            if begin_mode and not self._conn.in_transaction:
+                self._conn.execute(f"BEGIN {begin_mode}")
             yield self._conn
             return
 
         self._conn = self._create_connection()
         try:
-            with self._conn:
-                yield self._conn
+            if begin_mode is None:
+                with self._conn:
+                    yield self._conn
+            else:
+                self._conn.execute(f"BEGIN {begin_mode}")
+                try:
+                    yield self._conn
+                except Exception:
+                    if self._conn.in_transaction:
+                        self._conn.rollback()
+                    raise
+                else:
+                    if self._conn.in_transaction:
+                        self._conn.commit()
         finally:
             self._conn.close()
             self._conn = None

--- a/src/iPhoto/cache/index_store/engine.py
+++ b/src/iPhoto/cache/index_store/engine.py
@@ -89,6 +89,14 @@ class DatabaseManager:
             ...     conn.execute("INSERT INTO assets ...")
             ...     conn.execute("UPDATE assets ...")
         """
+        _VALID_BEGIN_MODES = {"DEFERRED", "IMMEDIATE", "EXCLUSIVE"}
+        if begin_mode is not None and (
+            not isinstance(begin_mode, str) or begin_mode.upper() not in _VALID_BEGIN_MODES
+        ):
+            raise ValueError(
+                f"Invalid begin_mode {begin_mode!r}. "
+                f"Must be one of: {', '.join(sorted(_VALID_BEGIN_MODES))}."
+            )
         if self._conn:
             # WARNING: Nested transaction - no savepoint, just yields existing connection
             # The nested block shares the outer transaction's fate.

--- a/src/iPhoto/cache/index_store/repository.py
+++ b/src/iPhoto/cache/index_store/repository.py
@@ -140,7 +140,7 @@ class AssetRepository:
             )
             recovery.recover()
 
-    def transaction(self):
+    def transaction(self, *, begin_mode: str | None = None):
         """Context manager for batching multiple operations.
         
         Example:
@@ -148,7 +148,7 @@ class AssetRepository:
             ...     repo.upsert_row("a.jpg", {...})
             ...     repo.upsert_row("b.jpg", {...})
         """
-        return self._db_manager.transaction()
+        return self._db_manager.transaction(begin_mode=begin_mode)
 
     def close(self) -> None:
         """Close any active database connections.
@@ -201,7 +201,7 @@ class AssetRepository:
             dict.fromkeys(str(row["rel"]) for row in materialized_rows if row.get("rel"))
         )
 
-        with self.transaction() as conn:
+        with self.transaction(begin_mode="IMMEDIATE") as conn:
             existing_rows_by_rel: Dict[str, Dict[str, Any]] = {}
             if unique_rels:
                 conn.row_factory = sqlite3.Row

--- a/src/iPhoto/cache/index_store/repository.py
+++ b/src/iPhoto/cache/index_store/repository.py
@@ -30,6 +30,7 @@ from .migrations import SchemaMigrator
 from .queries import QueryBuilder
 from .recovery import RecoveryService
 from .row_mapper import db_row_to_dict, insert_rows, row_to_db_params
+from .scan_merge import merge_scan_rows as merge_scan_rows_payload
 
 logger = get_logger()
 
@@ -169,6 +170,23 @@ class AssetRepository:
         """Merge *rows* into the index, replacing duplicates by ``rel`` key."""
         with self.transaction() as conn:
             self._insert_rows(conn, rows)
+
+    def merge_scan_rows(self, rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Merge scanned rows while preserving persisted library-managed state."""
+
+        materialized_rows = [dict(row) for row in rows]
+        if not materialized_rows:
+            return []
+
+        existing_rows = self.get_rows_by_rels(
+            str(row["rel"])
+            for row in materialized_rows
+            if isinstance(row.get("rel"), str) and row.get("rel")
+        )
+        merged_rows = merge_scan_rows_payload(materialized_rows, existing_rows)
+        with self.transaction() as conn:
+            self._insert_rows(conn, merged_rows)
+        return merged_rows
 
     def upsert_row(self, rel: str, row: Dict[str, Any]) -> None:
         """Insert or update a single row identified by *rel*."""

--- a/src/iPhoto/cache/index_store/repository.py
+++ b/src/iPhoto/cache/index_store/repository.py
@@ -172,20 +172,43 @@ class AssetRepository:
             self._insert_rows(conn, rows)
 
     def merge_scan_rows(self, rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Merge scanned rows while preserving persisted library-managed state."""
+        """Merge scanned rows while preserving persisted library-managed state.
+
+        The SELECT for existing rows and the subsequent INSERT are performed
+        within the same transaction so the read/write is atomic and cannot
+        lose concurrent updates to ``face_status`` or other library-managed
+        fields.
+        """
 
         materialized_rows = [dict(row) for row in rows]
         if not materialized_rows:
             return []
 
-        existing_rows = self.get_rows_by_rels(
+        rels_to_fetch = [
             str(row["rel"])
             for row in materialized_rows
-            if isinstance(row.get("rel"), str) and row.get("rel")
-        )
-        merged_rows = merge_scan_rows_payload(materialized_rows, existing_rows)
+            if row.get("rel")
+        ]
+
         with self.transaction() as conn:
+            existing_rows_by_rel: Dict[str, Dict[str, Any]] = {}
+            if rels_to_fetch:
+                conn.row_factory = sqlite3.Row
+                placeholders = ", ".join(["?"] * len(rels_to_fetch))
+                cursor = conn.execute(
+                    f"SELECT * FROM assets WHERE rel IN ({placeholders})",
+                    rels_to_fetch,
+                )
+                for db_row in cursor:
+                    d = self._db_row_to_dict(db_row)
+                    rel_value = d.get("rel")
+                    if rel_value is not None:
+                        existing_rows_by_rel[str(rel_value)] = d
+                conn.row_factory = None
+
+            merged_rows = merge_scan_rows_payload(materialized_rows, existing_rows_by_rel)
             self._insert_rows(conn, merged_rows)
+
         return merged_rows
 
     def upsert_row(self, rel: str, row: Dict[str, Any]) -> None:

--- a/src/iPhoto/cache/index_store/repository.py
+++ b/src/iPhoto/cache/index_store/repository.py
@@ -37,6 +37,12 @@ logger = get_logger()
 # Database filename for the global index
 GLOBAL_INDEX_DB_NAME = "global_index.db"
 
+# SQLite supports at most SQLITE_MAX_VARIABLE_NUMBER bound parameters per query
+# (compile-time default 999, raised to 32766 in SQLite ≥3.32).  Use a
+# conservative chunk size so large scans never hit the limit regardless of
+# the SQLite version in use.
+_SQLITE_PARAM_CHUNK_SIZE = 900
+
 # Global singleton instance and lock for thread-safe access
 _global_instance: Optional["AssetRepository"] = None
 _global_lock = threading.Lock()
@@ -178,32 +184,39 @@ class AssetRepository:
         within the same transaction so the read/write is atomic and cannot
         lose concurrent updates to ``face_status`` or other library-managed
         fields.
+
+        Existing rows are fetched in chunks of at most
+        ``_SQLITE_PARAM_CHUNK_SIZE`` to avoid hitting SQLite's bound-parameter
+        limit when a large snapshot is passed (e.g. from
+        ``index_sync_service.update_index_snapshot``).
         """
 
         materialized_rows = [dict(row) for row in rows]
         if not materialized_rows:
             return []
 
-        rels_to_fetch = [
-            str(row["rel"])
-            for row in materialized_rows
-            if row.get("rel")
-        ]
+        # De-duplicate while preserving insertion order so each rel is queried
+        # at most once.
+        unique_rels: List[str] = list(
+            dict.fromkeys(str(row["rel"]) for row in materialized_rows if row.get("rel"))
+        )
 
         with self.transaction() as conn:
             existing_rows_by_rel: Dict[str, Dict[str, Any]] = {}
-            if rels_to_fetch:
+            if unique_rels:
                 conn.row_factory = sqlite3.Row
-                placeholders = ", ".join(["?"] * len(rels_to_fetch))
-                cursor = conn.execute(
-                    f"SELECT * FROM assets WHERE rel IN ({placeholders})",
-                    rels_to_fetch,
-                )
-                for db_row in cursor:
-                    d = self._db_row_to_dict(db_row)
-                    rel_value = d.get("rel")
-                    if rel_value is not None:
-                        existing_rows_by_rel[str(rel_value)] = d
+                for offset in range(0, len(unique_rels), _SQLITE_PARAM_CHUNK_SIZE):
+                    chunk = unique_rels[offset : offset + _SQLITE_PARAM_CHUNK_SIZE]
+                    placeholders = ", ".join(["?"] * len(chunk))
+                    cursor = conn.execute(
+                        f"SELECT * FROM assets WHERE rel IN ({placeholders})",
+                        chunk,
+                    )
+                    for db_row in cursor:
+                        d = self._db_row_to_dict(db_row)
+                        rel_value = d.get("rel")
+                        if rel_value is not None:
+                            existing_rows_by_rel[str(rel_value)] = d
                 conn.row_factory = None
 
             merged_rows = merge_scan_rows_payload(materialized_rows, existing_rows_by_rel)

--- a/src/iPhoto/cache/index_store/scan_merge.py
+++ b/src/iPhoto/cache/index_store/scan_merge.py
@@ -1,0 +1,64 @@
+"""Helpers for merging scan rows with persisted library state."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping
+
+from ...people import initial_face_status, normalize_face_status
+
+_PRESERVED_SCAN_STATE_FIELDS = (
+    "is_favorite",
+    "original_rel_path",
+    "original_album_id",
+    "original_album_subpath",
+    "live_role",
+    "live_partner_rel",
+)
+
+
+def merge_scan_rows(
+    scanned_rows: Iterable[Dict[str, Any]],
+    existing_rows_by_rel: Mapping[str, Dict[str, Any]],
+) -> list[Dict[str, Any]]:
+    """Merge freshly scanned rows with persisted library-managed state."""
+
+    return [
+        merge_scan_row(row, existing_rows_by_rel.get(str(row.get("rel") or "")))
+        for row in scanned_rows
+    ]
+
+
+def merge_scan_row(
+    scanned_row: Dict[str, Any],
+    existing_row: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    """Merge one scanned row with an existing persisted row."""
+
+    merged = dict(scanned_row)
+
+    if existing_row is not None:
+        for field in _PRESERVED_SCAN_STATE_FIELDS:
+            if field in existing_row and (field not in merged or merged.get(field) in (None, "")):
+                merged[field] = existing_row.get(field)
+
+    existing_face_status = None
+    if existing_row is not None:
+        existing_face_status = normalize_face_status(existing_row.get("face_status"))
+
+    if existing_face_status is not None and _asset_identity_unchanged(existing_row, merged):
+        merged["face_status"] = existing_face_status
+    else:
+        merged["face_status"] = initial_face_status(merged)
+
+    return merged
+
+
+def _asset_identity_unchanged(
+    existing_row: Dict[str, Any],
+    scanned_row: Dict[str, Any],
+) -> bool:
+    existing_id = existing_row.get("id")
+    scanned_id = scanned_row.get("id")
+    if existing_id is None or scanned_id is None:
+        return False
+    return str(existing_id) == str(scanned_id)

--- a/src/iPhoto/cache/index_store/scan_merge.py
+++ b/src/iPhoto/cache/index_store/scan_merge.py
@@ -41,14 +41,20 @@ def merge_scan_row(
             if field in existing_row and (field not in merged or merged.get(field) in (None, "")):
                 merged[field] = existing_row.get(field)
 
+    identity_unchanged = existing_row is not None and _asset_identity_unchanged(existing_row, merged)
     existing_face_status = None
     if existing_row is not None:
         existing_face_status = normalize_face_status(existing_row.get("face_status"))
 
-    if existing_face_status is not None and _asset_identity_unchanged(existing_row, merged):
+    if existing_face_status is not None and identity_unchanged:
         merged["face_status"] = existing_face_status
     else:
-        merged["face_status"] = initial_face_status(merged)
+        merged["face_status"] = initial_face_status(
+            _row_for_face_status(
+                merged,
+                preserve_live_state=identity_unchanged,
+            )
+        )
 
     return merged
 
@@ -62,3 +68,17 @@ def _asset_identity_unchanged(
     if existing_id is None or scanned_id is None:
         return False
     return str(existing_id) == str(scanned_id)
+
+
+def _row_for_face_status(
+    merged_row: Dict[str, Any],
+    *,
+    preserve_live_state: bool,
+) -> Dict[str, Any]:
+    if preserve_live_state:
+        return merged_row
+
+    row = dict(merged_row)
+    row.pop("live_role", None)
+    row.pop("live_partner_rel", None)
+    return row

--- a/src/iPhoto/index_sync_service.py
+++ b/src/iPhoto/index_sync_service.py
@@ -100,10 +100,10 @@ def update_index_snapshot(
     if not fresh_rows:
         return
 
-    # Additive-only: only append new/updated rows, never delete
-    # append_rows uses INSERT OR REPLACE which is idempotent
+    # Additive-only: only append new/updated rows, never delete.
+    # Scan merges preserve persisted state fields such as face_status.
     try:
-        store.append_rows(materialised_snapshot)
+        store.merge_scan_rows(materialised_snapshot)
     except IndexCorruptedError:
         store.write_rows(materialised_snapshot)
 

--- a/src/iPhoto/library/workers/face_scan_worker.py
+++ b/src/iPhoto/library/workers/face_scan_worker.py
@@ -9,12 +9,9 @@ from typing import Iterable
 from PySide6.QtCore import QThread, Signal
 
 from ...cache.index_store import get_global_repository
-from ...people.pipeline import (
-    FaceClusterPipeline,
-    canonicalize_cluster_identities,
-    cluster_face_records,
-)
-from ...people.repository import FaceRecord, FaceRepository
+from ...people.pipeline import FaceClusterPipeline
+from ...people.repository import FaceRepository
+from ...people.scan_session import FaceScanSession
 from ...people.service import face_library_paths
 from ...people.status import (
     FACE_STATUS_DONE,
@@ -74,6 +71,7 @@ class FaceScanWorker(QThread):
         paths = face_library_paths(self._library_root)
         repository = FaceRepository(paths.index_db_path, paths.state_db_path)
         pipeline = FaceClusterPipeline(model_root=paths.model_dir)
+        session = FaceScanSession()
 
         while not self._cancelled:
             self._top_up_pending_rows()
@@ -82,11 +80,22 @@ class FaceScanWorker(QThread):
                 if self._input_closed:
                     self._top_up_pending_rows()
                     if self._queue.empty():
+                        if session.commit(
+                            repository,
+                            distance_threshold=pipeline.distance_threshold,
+                            min_samples=pipeline.min_samples,
+                        ):
+                            self.peopleIndexUpdated.emit()
                         return
                 continue
 
             try:
-                self._process_batch(batch, pipeline, repository, paths.thumbnail_dir)
+                self._process_batch(
+                    batch,
+                    pipeline,
+                    session,
+                    paths.thumbnail_dir,
+                )
             except RuntimeError as exc:
                 self._mark_remaining_failed(batch)
                 self.statusChanged.emit(str(exc))
@@ -135,56 +144,24 @@ class FaceScanWorker(QThread):
         self,
         batch: list[dict],
         pipeline: FaceClusterPipeline,
-        repository,
+        session: FaceScanSession,
         thumbnail_dir: Path,
     ) -> None:
-        repository.remove_faces_for_assets(
-            [str(row.get("id") or "") for row in batch],
-            [str(row.get("rel") or "") for row in batch],
-        )
-
         detected = pipeline.detect_faces_for_rows(
             batch,
             library_root=self._library_root,
             thumbnail_dir=thumbnail_dir,
         )
 
-        new_faces: list[FaceRecord] = []
-        done_ids: list[str] = []
-        retry_ids: list[str] = []
         for item in detected:
-            self._queued_ids.discard(item.asset_id)
-            if item.error:
-                retry_ids.append(item.asset_id)
-                continue
-            done_ids.append(item.asset_id)
-            new_faces.extend(item.faces)
+            if item.asset_id:
+                self._queued_ids.discard(item.asset_id)
 
-        all_faces = repository.get_all_faces() + new_faces
-        if all_faces:
-            clustered_faces, persons = cluster_face_records(
-                all_faces,
-                distance_threshold=pipeline.distance_threshold,
-                min_samples=pipeline.min_samples,
-            )
-            state_repository = repository.state_repository
-            if state_repository is not None:
-                clustered_faces, persons = canonicalize_cluster_identities(
-                    clustered_faces,
-                    persons,
-                    state_repository,
-                    distance_threshold=pipeline.distance_threshold,
-                )
-            repository.replace_all(clustered_faces, persons)
-            if state_repository is not None:
-                state_repository.sync_scan_results(persons, clustered_faces)
-        else:
-            repository.replace_all([], [])
+        done_ids, retry_ids = session.stage_detection_results(detected)
 
         store = get_global_repository(self._library_root)
         store.update_face_statuses(done_ids, FACE_STATUS_DONE)
         store.update_face_statuses(retry_ids, FACE_STATUS_RETRY)
-        self.peopleIndexUpdated.emit()
         if retry_ids:
             self.statusChanged.emit("Some assets need a face-scan retry.")
 

--- a/src/iPhoto/library/workers/face_scan_worker.py
+++ b/src/iPhoto/library/workers/face_scan_worker.py
@@ -97,6 +97,8 @@ class FaceScanWorker(QThread):
                             get_global_repository(self._library_root).update_face_statuses(
                                 pending_done_ids, FACE_STATUS_RETRY
                             )
+                            for asset_id in pending_done_ids:
+                                self._queued_ids.discard(asset_id)
                             pending_done_ids.clear()
                             self.statusChanged.emit(
                                 "Face scanning paused due to a commit error."
@@ -104,6 +106,9 @@ class FaceScanWorker(QThread):
                             return
                         store = get_global_repository(self._library_root)
                         store.update_face_statuses(pending_done_ids, FACE_STATUS_DONE)
+                        # Retire in-flight IDs now that the DB reflects DONE.
+                        for asset_id in pending_done_ids:
+                            self._queued_ids.discard(asset_id)
                         pending_done_ids.clear()
                         if committed:
                             self.peopleIndexUpdated.emit()
@@ -175,27 +180,45 @@ class FaceScanWorker(QThread):
     ) -> list[str]:
         """Detect faces for *batch*, stage results, and return the done asset IDs.
 
-        ``retry_ids`` are written to the store immediately since they will never
-        reach ``session.commit()``.  ``done_ids`` are returned to the caller so
-        they can be written only after a successful commit, preventing a state
-        where assets are marked ``done`` without a corresponding People snapshot.
+        Ordering is deliberate:
+        1. Retry IDs are written to the store *before* done items are staged so
+           that a DB failure cannot leave the session with staged faces for assets
+           that are still ``pending/retry`` in the index.
+        2. Done IDs are **not** removed from ``_queued_ids`` here; they stay in
+           the set until ``run()`` writes ``FACE_STATUS_DONE`` after a successful
+           ``session.commit()``.  This prevents ``_top_up_pending_rows()`` from
+           re-fetching and re-enqueuing those assets while they are still
+           ``pending`` in the DB but already processed in-memory.
         """
-        detected = pipeline.detect_faces_for_rows(
-            batch,
-            library_root=self._library_root,
-            thumbnail_dir=thumbnail_dir,
+        detected = list(
+            pipeline.detect_faces_for_rows(
+                batch,
+                library_root=self._library_root,
+                thumbnail_dir=thumbnail_dir,
+            )
         )
 
-        for item in detected:
-            if item.asset_id:
-                self._queued_ids.discard(item.asset_id)
+        # Split into done / retry items up-front so we can write retry
+        # statuses to the DB before any staging occurs.
+        done_items = [item for item in detected if item.asset_id and not item.error]
+        retry_items = [item for item in detected if item.asset_id and item.error]
+        retry_ids = [str(item.asset_id) for item in retry_items]
 
-        done_ids, retry_ids = session.stage_detection_results(detected)
-
+        # Write retry statuses first; if this raises, the session is still clean.
         store = get_global_repository(self._library_root)
         store.update_face_statuses(retry_ids, FACE_STATUS_RETRY)
+
+        # Retire retry IDs from the in-flight set immediately.
+        for asset_id in retry_ids:
+            self._queued_ids.discard(asset_id)
+
         if retry_ids:
             self.statusChanged.emit("Some assets need a face-scan retry.")
+
+        # Stage done items only after retry DB writes succeed.
+        # The second return value contains retry IDs discovered by the session;
+        # since we pre-filtered to done_items only, it will always be empty.
+        done_ids, _ignored_retry_ids = session.stage_detection_results(done_items)
 
         return done_ids
 

--- a/src/iPhoto/library/workers/face_scan_worker.py
+++ b/src/iPhoto/library/workers/face_scan_worker.py
@@ -72,6 +72,10 @@ class FaceScanWorker(QThread):
         repository = FaceRepository(paths.index_db_path, paths.state_db_path)
         pipeline = FaceClusterPipeline(model_root=paths.model_dir)
         session = FaceScanSession()
+        # Accumulate done IDs across batches; only written to the store after a
+        # successful session.commit() so that a commit failure cannot leave
+        # assets marked "done" without a corresponding People snapshot.
+        pending_done_ids: list[str] = []
 
         while not self._cancelled:
             self._top_up_pending_rows()
@@ -80,28 +84,50 @@ class FaceScanWorker(QThread):
                 if self._input_closed:
                     self._top_up_pending_rows()
                     if self._queue.empty():
-                        if session.commit(
-                            repository,
-                            distance_threshold=pipeline.distance_threshold,
-                            min_samples=pipeline.min_samples,
-                        ):
+                        try:
+                            committed = session.commit(
+                                repository,
+                                distance_threshold=pipeline.distance_threshold,
+                                min_samples=pipeline.min_samples,
+                            )
+                        except Exception as exc:
+                            LOGGER.warning(
+                                "Face scan commit failed: %s", exc, exc_info=True
+                            )
+                            get_global_repository(self._library_root).update_face_statuses(
+                                pending_done_ids, FACE_STATUS_RETRY
+                            )
+                            pending_done_ids.clear()
+                            self.statusChanged.emit(
+                                "Face scanning paused due to a commit error."
+                            )
+                            return
+                        store = get_global_repository(self._library_root)
+                        store.update_face_statuses(pending_done_ids, FACE_STATUS_DONE)
+                        pending_done_ids.clear()
+                        if committed:
                             self.peopleIndexUpdated.emit()
                         return
                 continue
 
             try:
-                self._process_batch(
+                batch_done_ids = self._process_batch(
                     batch,
                     pipeline,
                     session,
                     paths.thumbnail_dir,
                 )
+                pending_done_ids.extend(batch_done_ids)
             except RuntimeError as exc:
                 self._mark_remaining_failed(batch)
                 self.statusChanged.emit(str(exc))
                 return
             except Exception as exc:  # pragma: no cover - defensive runtime guard
                 LOGGER.warning("Face scan batch failed: %s", exc, exc_info=True)
+                # The batch is retried so the assets remain pending/retry in the
+                # store and will be re-detected on the next scan.  We do NOT
+                # extend pending_done_ids here because we cannot guarantee
+                # session.commit() will succeed for partially staged results.
                 self._mark_rows_retry(batch)
                 self.statusChanged.emit("Face scanning paused due to an unexpected error.")
                 if self._input_closed:
@@ -146,7 +172,14 @@ class FaceScanWorker(QThread):
         pipeline: FaceClusterPipeline,
         session: FaceScanSession,
         thumbnail_dir: Path,
-    ) -> None:
+    ) -> list[str]:
+        """Detect faces for *batch*, stage results, and return the done asset IDs.
+
+        ``retry_ids`` are written to the store immediately since they will never
+        reach ``session.commit()``.  ``done_ids`` are returned to the caller so
+        they can be written only after a successful commit, preventing a state
+        where assets are marked ``done`` without a corresponding People snapshot.
+        """
         detected = pipeline.detect_faces_for_rows(
             batch,
             library_root=self._library_root,
@@ -160,10 +193,11 @@ class FaceScanWorker(QThread):
         done_ids, retry_ids = session.stage_detection_results(detected)
 
         store = get_global_repository(self._library_root)
-        store.update_face_statuses(done_ids, FACE_STATUS_DONE)
         store.update_face_statuses(retry_ids, FACE_STATUS_RETRY)
         if retry_ids:
             self.statusChanged.emit("Some assets need a face-scan retry.")
+
+        return done_ids
 
     def _mark_rows_retry(self, rows: Iterable[dict]) -> None:
         ids = [str(row.get("id") or "") for row in rows if row.get("id")]

--- a/src/iPhoto/library/workers/scanner_worker.py
+++ b/src/iPhoto/library/workers/scanner_worker.py
@@ -201,15 +201,16 @@ class ScannerWorker(QRunnable):
         is always emitted with the chunk. This ensures that downstream consumers are
         notified of all processed chunks, even if some were not successfully stored.
         """
+        emitted_chunk = chunk
         try:
-            store.append_rows(chunk)
+            emitted_chunk = store.merge_scan_rows(chunk)
         except Exception as e:
             LOGGER.error(f"Failed to persist chunk of {len(chunk)} items: {e}")
             self._failed_count += len(chunk)
             self._signals.batchFailed.emit(self._root, len(chunk))
             # We continue even if DB write fails, though these items won't be persisted
 
-        self._signals.chunkReady.emit(self._root, chunk)
+        self._signals.chunkReady.emit(self._root, emitted_chunk)
 
     def cancel(self) -> None:
         """Request cancellation of the in-progress scan."""

--- a/src/iPhoto/library/workers/scanner_worker.py
+++ b/src/iPhoto/library/workers/scanner_worker.py
@@ -197,18 +197,18 @@ class ScannerWorker(QRunnable):
         persistence fails, it logs the error, increments the failed count, and emits
         the `batchFailed` signal with the number of items in the failed chunk.
 
-        Regardless of whether persistence succeeds or fails, the `chunkReady` signal
-        is always emitted with the chunk. This ensures that downstream consumers are
-        notified of all processed chunks, even if some were not successfully stored.
+        `chunkReady` is emitted only for rows that were durably merged into the
+        repository. Downstream consumers such as `FaceScanWorker` treat the emitted
+        rows as authoritative persisted state, so failed batches must not leak
+        through this signal.
         """
-        emitted_chunk = chunk
         try:
             emitted_chunk = store.merge_scan_rows(chunk)
         except Exception as e:
             LOGGER.error(f"Failed to persist chunk of {len(chunk)} items: {e}")
             self._failed_count += len(chunk)
             self._signals.batchFailed.emit(self._root, len(chunk))
-            # We continue even if DB write fails, though these items won't be persisted
+            return
 
         self._signals.chunkReady.emit(self._root, emitted_chunk)
 

--- a/src/iPhoto/people/face_repository.py
+++ b/src/iPhoto/people/face_repository.py
@@ -48,7 +48,13 @@ class FaceRepository:
         if self._state_repo is not None:
             self._state_repo.initialize()
 
-    def replace_all(self, faces: list[FaceRecord], persons: list[PersonRecord]) -> None:
+    def replace_all(
+        self,
+        faces: list[FaceRecord],
+        persons: list[PersonRecord],
+        *,
+        sync_runtime_state: bool = True,
+    ) -> None:
         self.initialize()
         with closing(self._connect()) as conn:
             conn.execute("DELETE FROM persons")
@@ -103,9 +109,14 @@ class FaceRepository:
                 ],
             )
             conn.commit()
-        if self._state_repo is not None:
-            self._sync_person_cover_defaults()
-            self.refresh_all_group_assets()
+        if sync_runtime_state:
+            self.sync_runtime_state()
+
+    def sync_runtime_state(self) -> None:
+        if self._state_repo is None:
+            return
+        self._sync_person_cover_defaults()
+        self.refresh_all_group_assets()
 
     def get_all_faces(self) -> list[FaceRecord]:
         self.initialize()
@@ -119,6 +130,20 @@ class FaceRepository:
                 ORDER BY detected_at ASC, face_id ASC
                 """).fetchall()
         return [self._face_from_row(row) for row in rows]
+
+    def get_all_person_records(self) -> list[PersonRecord]:
+        self.initialize()
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    person_id, name, key_face_id, face_count, center_embedding,
+                    created_at, updated_at
+                FROM persons
+                ORDER BY created_at ASC, person_id ASC
+                """
+            ).fetchall()
+        return [self._person_from_row(row) for row in rows]
 
     def remove_faces_for_assets(
         self,
@@ -623,4 +648,18 @@ class FaceRepository:
             detected_at=row["detected_at"],
             image_width=int(row["image_width"]),
             image_height=int(row["image_height"]),
+        )
+
+    @staticmethod
+    def _person_from_row(row: sqlite3.Row) -> PersonRecord:
+        center_blob = row["center_embedding"]
+        embedding_dim = int(len(center_blob) / 4) if center_blob else 0
+        return PersonRecord(
+            person_id=str(row["person_id"]),
+            name=row["name"],
+            key_face_id=str(row["key_face_id"]),
+            face_count=int(row["face_count"]),
+            center_embedding=_deserialize_embedding(center_blob, embedding_dim),
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
         )

--- a/src/iPhoto/people/scan_session.py
+++ b/src/iPhoto/people/scan_session.py
@@ -52,20 +52,33 @@ class FaceScanSession:
         *,
         distance_threshold: float,
         min_samples: int,
+        existing_faces: list[FaceRecord] | None = None,
     ) -> tuple[list[FaceRecord], list[PersonRecord]]:
-        """Build the final runtime snapshot for this scan session."""
+        """Build the final runtime snapshot for this scan session.
+
+        Args:
+            repository: The face repository to use for clustering and state lookup.
+            distance_threshold: Clustering distance threshold.
+            min_samples: Minimum cluster samples parameter.
+            existing_faces: Pre-fetched list of all persisted faces.  When
+                provided, no extra DB read is performed; callers that already
+                hold this data (e.g. ``commit()``) should pass it in to avoid
+                a redundant round-trip.
+        """
 
         staged_asset_ids = set(self._faces_by_asset_id)
         staged_asset_rels = {
             asset_rel for asset_rel in self._asset_rel_by_asset_id.values() if asset_rel
         }
 
-        existing_faces = [
+        if existing_faces is None:
+            existing_faces = repository.get_all_faces()
+
+        all_faces = [
             face
-            for face in repository.get_all_faces()
+            for face in existing_faces
             if face.asset_id not in staged_asset_ids and face.asset_rel not in staged_asset_rels
         ]
-        all_faces = list(existing_faces)
         for faces in self._faces_by_asset_id.values():
             all_faces.extend(faces)
 
@@ -99,13 +112,18 @@ class FaceScanSession:
         if not self.has_staged_changes():
             return False
 
+        # Fetch the current state once so it can be passed to
+        # build_runtime_snapshot() (avoiding a second get_all_faces() call
+        # inside that method) and kept for rollback if the commit fails.
+        previous_faces = repository.get_all_faces()
+        previous_persons = repository.get_all_person_records()
+
         clustered_faces, persons = self.build_runtime_snapshot(
             repository,
             distance_threshold=distance_threshold,
             min_samples=min_samples,
+            existing_faces=previous_faces,
         )
-        previous_faces = repository.get_all_faces()
-        previous_persons = repository.get_all_person_records()
         repository.replace_all(clustered_faces, persons, sync_runtime_state=False)
         state_repository = repository.state_repository
         try:

--- a/src/iPhoto/people/scan_session.py
+++ b/src/iPhoto/people/scan_session.py
@@ -104,9 +104,17 @@ class FaceScanSession:
             distance_threshold=distance_threshold,
             min_samples=min_samples,
         )
-        repository.replace_all(clustered_faces, persons)
+        previous_faces = repository.get_all_faces()
+        previous_persons = repository.get_all_person_records()
+        repository.replace_all(clustered_faces, persons, sync_runtime_state=False)
         state_repository = repository.state_repository
-        if state_repository is not None and clustered_faces:
-            state_repository.sync_scan_results(persons, clustered_faces)
+        try:
+            repository.sync_runtime_state()
+            if state_repository is not None and clustered_faces:
+                state_repository.sync_scan_results(persons, clustered_faces)
+        except Exception:
+            repository.replace_all(previous_faces, previous_persons, sync_runtime_state=False)
+            repository.sync_runtime_state()
+            raise
         self.clear()
         return True

--- a/src/iPhoto/people/scan_session.py
+++ b/src/iPhoto/people/scan_session.py
@@ -1,0 +1,112 @@
+"""Session-scoped staging for incremental face scanning."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .pipeline import (
+    DetectedAssetFaces,
+    canonicalize_cluster_identities,
+    cluster_face_records,
+)
+from .repository import FaceRecord, FaceRepository, PersonRecord
+
+
+class FaceScanSession:
+    """Accumulate per-asset face updates and commit one runtime snapshot."""
+
+    def __init__(self) -> None:
+        self._faces_by_asset_id: dict[str, list[FaceRecord]] = {}
+        self._asset_rel_by_asset_id: dict[str, str] = {}
+
+    def has_staged_changes(self) -> bool:
+        return bool(self._faces_by_asset_id)
+
+    def clear(self) -> None:
+        self._faces_by_asset_id.clear()
+        self._asset_rel_by_asset_id.clear()
+
+    def stage_detection_results(
+        self,
+        detected_results: Iterable[DetectedAssetFaces],
+    ) -> tuple[list[str], list[str]]:
+        """Stage successful detections and split done vs retry asset ids."""
+
+        done_ids: list[str] = []
+        retry_ids: list[str] = []
+        for item in detected_results:
+            asset_id = str(item.asset_id or "")
+            if not asset_id:
+                continue
+            if item.error:
+                retry_ids.append(asset_id)
+                continue
+            self._faces_by_asset_id[asset_id] = list(item.faces)
+            self._asset_rel_by_asset_id[asset_id] = str(item.asset_rel or "")
+            done_ids.append(asset_id)
+        return done_ids, retry_ids
+
+    def build_runtime_snapshot(
+        self,
+        repository: FaceRepository,
+        *,
+        distance_threshold: float,
+        min_samples: int,
+    ) -> tuple[list[FaceRecord], list[PersonRecord]]:
+        """Build the final runtime snapshot for this scan session."""
+
+        staged_asset_ids = set(self._faces_by_asset_id)
+        staged_asset_rels = {
+            asset_rel for asset_rel in self._asset_rel_by_asset_id.values() if asset_rel
+        }
+
+        existing_faces = [
+            face
+            for face in repository.get_all_faces()
+            if face.asset_id not in staged_asset_ids and face.asset_rel not in staged_asset_rels
+        ]
+        all_faces = list(existing_faces)
+        for faces in self._faces_by_asset_id.values():
+            all_faces.extend(faces)
+
+        if not all_faces:
+            return [], []
+
+        clustered_faces, persons = cluster_face_records(
+            all_faces,
+            distance_threshold=distance_threshold,
+            min_samples=min_samples,
+        )
+        state_repository = repository.state_repository
+        if state_repository is not None:
+            clustered_faces, persons = canonicalize_cluster_identities(
+                clustered_faces,
+                persons,
+                state_repository,
+                distance_threshold=distance_threshold,
+            )
+        return clustered_faces, persons
+
+    def commit(
+        self,
+        repository: FaceRepository,
+        *,
+        distance_threshold: float,
+        min_samples: int,
+    ) -> bool:
+        """Commit one unified People snapshot for this scan session."""
+
+        if not self.has_staged_changes():
+            return False
+
+        clustered_faces, persons = self.build_runtime_snapshot(
+            repository,
+            distance_threshold=distance_threshold,
+            min_samples=min_samples,
+        )
+        repository.replace_all(clustered_faces, persons)
+        state_repository = repository.state_repository
+        if state_repository is not None and clustered_faces:
+            state_repository.sync_scan_results(persons, clustered_faces)
+        self.clear()
+        return True

--- a/tests/cache/test_global_repository.py
+++ b/tests/cache/test_global_repository.py
@@ -126,6 +126,78 @@ class TestGlobalRepositorySingleton:
         assert rows["asset-video"]["face_status"] == "done"
         assert repo.count_by_face_status() == {"retry": 1, "done": 1}
 
+    def test_merge_scan_rows_preserves_face_status_and_library_state_for_same_asset(
+        self, tmp_path: Path
+    ) -> None:
+        repo = get_global_repository(tmp_path)
+        repo.write_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-photo",
+                    "media_type": 0,
+                    "face_status": "done",
+                    "is_favorite": 1,
+                    "original_rel_path": "imports/photo.jpg",
+                    "original_album_id": "trash-album",
+                    "original_album_subpath": "trash/subpath",
+                    "live_role": 1,
+                    "live_partner_rel": "album/photo.mov",
+                }
+            ]
+        )
+
+        merged_rows = repo.merge_scan_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-photo",
+                    "media_type": 0,
+                    "bytes": 123,
+                }
+            ]
+        )
+
+        assert merged_rows[0]["face_status"] == "done"
+        row = repo.get_rows_by_ids(["asset-photo"])["asset-photo"]
+        assert row["face_status"] == "done"
+        assert row["is_favorite"] == 1
+        assert row["original_rel_path"] == "imports/photo.jpg"
+        assert row["original_album_id"] == "trash-album"
+        assert row["original_album_subpath"] == "trash/subpath"
+        assert row["live_role"] == 1
+        assert row["live_partner_rel"] == "album/photo.mov"
+
+    def test_merge_scan_rows_resets_face_status_when_asset_id_changes(self, tmp_path: Path) -> None:
+        repo = get_global_repository(tmp_path)
+        repo.write_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-old",
+                    "media_type": 0,
+                    "face_status": "done",
+                    "is_favorite": 1,
+                }
+            ]
+        )
+
+        merged_rows = repo.merge_scan_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-new",
+                    "media_type": 0,
+                    "bytes": 456,
+                }
+            ]
+        )
+
+        assert merged_rows[0]["face_status"] == "pending"
+        row = repo.get_rows_by_ids(["asset-new"])["asset-new"]
+        assert row["face_status"] == "pending"
+        assert row["is_favorite"] == 1
+
 
 class TestIdempotentWrites:
     """Tests verifying idempotent write behavior (Constraint #3)."""

--- a/tests/cache/test_global_repository.py
+++ b/tests/cache/test_global_repository.py
@@ -198,7 +198,7 @@ class TestGlobalRepositorySingleton:
         assert row["face_status"] == "pending"
         assert row["is_favorite"] == 1
 
-    def test_merge_scan_rows_does_not_reuse_hidden_live_role_for_changed_asset(
+    def test_merge_scan_rows_preserves_live_role_and_partner_rel_for_changed_asset_id(
         self, tmp_path: Path
     ) -> None:
         repo = get_global_repository(tmp_path)

--- a/tests/cache/test_global_repository.py
+++ b/tests/cache/test_global_repository.py
@@ -198,6 +198,37 @@ class TestGlobalRepositorySingleton:
         assert row["face_status"] == "pending"
         assert row["is_favorite"] == 1
 
+    def test_merge_scan_rows_does_not_reuse_hidden_live_role_for_changed_asset(
+        self, tmp_path: Path
+    ) -> None:
+        repo = get_global_repository(tmp_path)
+        repo.write_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-old",
+                    "media_type": 0,
+                    "face_status": "skipped",
+                    "live_role": 1,
+                    "live_partner_rel": "album/photo.mov",
+                }
+            ]
+        )
+
+        merged_rows = repo.merge_scan_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-new",
+                    "media_type": 0,
+                }
+            ]
+        )
+
+        assert merged_rows[0]["live_role"] == 1
+        assert merged_rows[0]["live_partner_rel"] == "album/photo.mov"
+        assert merged_rows[0]["face_status"] == "pending"
+
 
 class TestIdempotentWrites:
     """Tests verifying idempotent write behavior (Constraint #3)."""

--- a/tests/cache/test_global_repository.py
+++ b/tests/cache/test_global_repository.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+import time
 from pathlib import Path
 import pytest
 from iPhoto.cache.index_store import (
@@ -228,6 +230,143 @@ class TestGlobalRepositorySingleton:
         assert merged_rows[0]["live_role"] == 1
         assert merged_rows[0]["live_partner_rel"] == "album/photo.mov"
         assert merged_rows[0]["face_status"] == "pending"
+
+    def test_merge_scan_rows_blocks_competing_writer_until_commit(self, tmp_path: Path) -> None:
+        repo = get_global_repository(tmp_path)
+        repo.write_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-photo",
+                    "media_type": 0,
+                    "face_status": "done",
+                    "is_favorite": 1,
+                }
+            ]
+        )
+
+        original_insert_rows = repo._insert_rows
+        insert_started = threading.Event()
+        allow_insert = threading.Event()
+        merge_finished = threading.Event()
+        update_finished = threading.Event()
+        merge_error: list[BaseException] = []
+        update_error: list[BaseException] = []
+
+        def blocking_insert(conn, rows):
+            insert_started.set()
+            if not allow_insert.wait(timeout=5):
+                raise TimeoutError("Timed out waiting to release merge_scan_rows insert")
+            return original_insert_rows(conn, rows)
+
+        repo._insert_rows = blocking_insert
+
+        def run_merge() -> None:
+            try:
+                repo.merge_scan_rows(
+                    [
+                        {
+                            "rel": "album/photo.jpg",
+                            "id": "asset-photo",
+                            "media_type": 0,
+                            "bytes": 123,
+                        }
+                    ]
+                )
+            except BaseException as exc:  # pragma: no cover - surfaced in assertions
+                merge_error.append(exc)
+            finally:
+                merge_finished.set()
+
+        def run_update() -> None:
+            try:
+                repo.update_face_status("asset-photo", "retry")
+            except BaseException as exc:  # pragma: no cover - surfaced in assertions
+                update_error.append(exc)
+            finally:
+                update_finished.set()
+
+        merge_thread = threading.Thread(target=run_merge, name="merge-scan-rows")
+        update_thread = threading.Thread(target=run_update, name="update-face-status")
+        merge_thread.start()
+        assert insert_started.wait(timeout=5), "merge_scan_rows never reached the write window"
+
+        update_thread.start()
+        time.sleep(0.2)
+        assert update_finished.is_set() is False
+
+        allow_insert.set()
+        merge_thread.join(timeout=5)
+        update_thread.join(timeout=5)
+
+        repo._insert_rows = original_insert_rows
+
+        assert merge_finished.is_set() is True
+        assert update_finished.is_set() is True
+        assert merge_error == []
+        assert update_error == []
+        row = repo.get_rows_by_ids(["asset-photo"])["asset-photo"]
+        assert row["face_status"] == "retry"
+        assert row["is_favorite"] == 1
+
+    def test_merge_scan_rows_rolls_back_when_interrupted_mid_write(
+        self, tmp_path: Path
+    ) -> None:
+        repo = get_global_repository(tmp_path)
+        repo.write_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-photo",
+                    "media_type": 0,
+                    "face_status": "done",
+                    "bytes": 100,
+                },
+                {
+                    "rel": "album/keep.jpg",
+                    "id": "asset-keep",
+                    "media_type": 0,
+                    "face_status": "retry",
+                    "bytes": 200,
+                },
+            ]
+        )
+
+        original_insert_rows = repo._insert_rows
+
+        def interrupted_insert(conn, rows):
+            rows_list = list(rows)
+            original_insert_rows(conn, rows_list[:1])
+            raise InterruptedError("Simulated interruption during merge_scan_rows")
+
+        repo._insert_rows = interrupted_insert
+
+        with pytest.raises(InterruptedError, match="Simulated interruption"):
+            repo.merge_scan_rows(
+                [
+                    {
+                        "rel": "album/photo.jpg",
+                        "id": "asset-photo",
+                        "media_type": 0,
+                        "bytes": 999,
+                    },
+                    {
+                        "rel": "album/new.jpg",
+                        "id": "asset-new",
+                        "media_type": 0,
+                        "bytes": 300,
+                    },
+                ]
+            )
+
+        repo._insert_rows = original_insert_rows
+
+        rows = repo.get_rows_by_ids(["asset-photo", "asset-keep", "asset-new"])
+        assert rows["asset-photo"]["face_status"] == "done"
+        assert rows["asset-photo"]["bytes"] == 100
+        assert rows["asset-keep"]["face_status"] == "retry"
+        assert rows["asset-keep"]["bytes"] == 200
+        assert "asset-new" not in rows
 
 
 class TestIdempotentWrites:

--- a/tests/cache/test_move_delete_optimizations.py
+++ b/tests/cache/test_move_delete_optimizations.py
@@ -66,6 +66,11 @@ class TestWALMode:
             mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
             assert mode == "wal"
 
+    def test_begin_mode_starts_transaction_before_first_write(self, tmp_path: Path) -> None:
+        db = DatabaseManager(tmp_path / "test.db")
+        with db.transaction(begin_mode="IMMEDIATE") as conn:
+            assert conn.in_transaction is True
+
 
 # ------------------------------------------------------------------
 # Plan 2 §6.2.1: get_rows_by_rels()

--- a/tests/test_face_cluster_demo.py
+++ b/tests/test_face_cluster_demo.py
@@ -276,11 +276,18 @@ def test_sync_scan_results_does_not_call_nested_person_order_query(
     def _forbidden_nested_query(_person_ids):
         raise AssertionError("sync_scan_results should not call get_person_order_map")
 
-    monkeypatch.setattr(state_repository, "get_person_order_map", _forbidden_nested_query)
+    monkeypatch.setattr(
+        state_repository,
+        "get_person_order_map",
+        _forbidden_nested_query,
+        raising=False,
+    )
     state_repository.sync_scan_results([person], [face])
 
     verify_repository = db.FaceClusterStateRepository(workspace.state_db_path)
-    assert verify_repository.get_person_order_map(["profile-a"]) == {"profile-a": 0}
+    assert {profile.person_id for profile in verify_repository.get_profiles()} == {"profile-a"}
+    if hasattr(verify_repository, "get_person_order_map"):
+        assert verify_repository.get_person_order_map(["profile-a"]) == {"profile-a": 0}
 
 
 def test_editable_name_label_emits_trimmed_text(qapp: QApplication) -> None:

--- a/tests/test_people_repository.py
+++ b/tests/test_people_repository.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from iPhoto.people.pipeline import DetectedAssetFaces
 from iPhoto.people.repository import FaceRecord, FaceRepository, PersonRecord
@@ -528,3 +529,195 @@ def test_face_scan_session_preserves_group_id_and_custom_cover_after_commit(tmp_
     assert len(groups) == 1
     assert groups[0].group_id == group.group_id
     assert repository.get_group_cover_asset_id(group.group_id) == "asset-shared"
+
+
+def test_face_scan_session_rolls_back_runtime_snapshot_when_runtime_state_sync_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    embedding_a = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    embedding_b = np.asarray([0.0, 1.0, 0.0], dtype=np.float32)
+    initial_faces = [
+        _face_record(
+            face_id="face-a-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            embedding=embedding_a,
+            face_key="face-key-a-shared",
+        ),
+        _face_record(
+            face_id="face-b-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            embedding=embedding_b,
+            face_key="face-key-b-shared",
+        ),
+    ]
+    initial_persons = [
+        _person_record(
+            person_id="person-a",
+            key_face_id="face-a-shared",
+            face_count=1,
+            name="Alice",
+            embedding=embedding_a,
+        ),
+        _person_record(
+            person_id="person-b",
+            key_face_id="face-b-shared",
+            face_count=1,
+            name="Bob",
+            embedding=embedding_b,
+        ),
+    ]
+    repository.replace_all(initial_faces, initial_persons)
+    assert repository.state_repository is not None
+    repository.state_repository.sync_scan_results(initial_persons, initial_faces)
+    group = repository.create_group(["person-a", "person-b"])
+    assert group is not None
+
+    session = FaceScanSession()
+    session.stage_detection_results(
+        [
+            DetectedAssetFaces(
+                asset_id="asset-new-shared",
+                asset_rel="album/new-shared.jpg",
+                faces=[
+                    _face_record(
+                        face_id="face-a-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.97, 0.03, 0.0], dtype=np.float32),
+                        face_key="face-key-a-new-shared",
+                    ),
+                    _face_record(
+                        face_id="face-b-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.03, 0.97, 0.0], dtype=np.float32),
+                        face_key="face-key-b-new-shared",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    original_sync_runtime_state = repository.sync_runtime_state
+    call_count = {"value": 0}
+
+    def fail_once() -> None:
+        call_count["value"] += 1
+        if call_count["value"] == 1:
+            raise RuntimeError("cache refresh failed")
+        original_sync_runtime_state()
+
+    monkeypatch.setattr(repository, "sync_runtime_state", fail_once)
+
+    with pytest.raises(RuntimeError, match="cache refresh failed"):
+        session.commit(repository, distance_threshold=0.6, min_samples=2)
+
+    assert [summary.person_id for summary in repository.get_person_summaries()] == [
+        "person-a",
+        "person-b",
+    ]
+    assert repository.get_common_asset_ids_for_group(group.group_id) == ["asset-shared"]
+
+
+def test_face_scan_session_rolls_back_runtime_snapshot_when_profile_sync_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    embedding_a = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    embedding_b = np.asarray([0.0, 1.0, 0.0], dtype=np.float32)
+    initial_faces = [
+        _face_record(
+            face_id="face-a-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            embedding=embedding_a,
+            face_key="face-key-a-shared",
+        ),
+        _face_record(
+            face_id="face-b-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            embedding=embedding_b,
+            face_key="face-key-b-shared",
+        ),
+    ]
+    initial_persons = [
+        _person_record(
+            person_id="person-a",
+            key_face_id="face-a-shared",
+            face_count=1,
+            name="Alice",
+            embedding=embedding_a,
+        ),
+        _person_record(
+            person_id="person-b",
+            key_face_id="face-b-shared",
+            face_count=1,
+            name="Bob",
+            embedding=embedding_b,
+        ),
+    ]
+    repository.replace_all(initial_faces, initial_persons)
+    assert repository.state_repository is not None
+    repository.state_repository.sync_scan_results(initial_persons, initial_faces)
+    group = repository.create_group(["person-a", "person-b"])
+    assert group is not None
+
+    session = FaceScanSession()
+    session.stage_detection_results(
+        [
+            DetectedAssetFaces(
+                asset_id="asset-new-shared",
+                asset_rel="album/new-shared.jpg",
+                faces=[
+                    _face_record(
+                        face_id="face-a-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.96, 0.04, 0.0], dtype=np.float32),
+                        face_key="face-key-a-new-shared",
+                    ),
+                    _face_record(
+                        face_id="face-b-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.04, 0.96, 0.0], dtype=np.float32),
+                        face_key="face-key-b-new-shared",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    original_sync_scan_results = repository.state_repository.sync_scan_results
+    call_count = {"value": 0}
+
+    def fail_once(persons: list[PersonRecord], faces: list[FaceRecord]) -> None:
+        call_count["value"] += 1
+        if call_count["value"] == 1:
+            raise RuntimeError("profile sync failed")
+        original_sync_scan_results(persons, faces)
+
+    monkeypatch.setattr(repository.state_repository, "sync_scan_results", fail_once)
+
+    with pytest.raises(RuntimeError, match="profile sync failed"):
+        session.commit(repository, distance_threshold=0.6, min_samples=2)
+
+    assert [summary.person_id for summary in repository.get_person_summaries()] == [
+        "person-a",
+        "person-b",
+    ]
+    assert repository.get_common_asset_ids_for_group(group.group_id) == ["asset-shared"]

--- a/tests/test_people_repository.py
+++ b/tests/test_people_repository.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import numpy as np
 
+from iPhoto.people.pipeline import DetectedAssetFaces
 from iPhoto.people.repository import FaceRecord, FaceRepository, PersonRecord
+from iPhoto.people.scan_session import FaceScanSession
 
 
 def _now_iso() -> str:
@@ -17,13 +19,16 @@ def _face_record(
     face_id: str,
     asset_id: str,
     asset_rel: str,
-    person_id: str,
+    person_id: str | None,
     thumbnail_path: str | None = None,
+    embedding: np.ndarray | None = None,
+    face_key: str | None = None,
 ) -> FaceRecord:
-    embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    if embedding is None:
+        embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
     return FaceRecord(
         face_id=face_id,
-        face_key=f"key-{face_id}",
+        face_key=face_key or f"key-{face_id}",
         asset_id=asset_id,
         asset_rel=asset_rel,
         box_x=10,
@@ -47,8 +52,10 @@ def _person_record(
     key_face_id: str,
     face_count: int,
     name: str | None = "Alice",
+    embedding: np.ndarray | None = None,
 ) -> PersonRecord:
-    embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    if embedding is None:
+        embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
     timestamp = _now_iso()
     return PersonRecord(
         person_id=person_id,
@@ -352,3 +359,172 @@ def test_list_asset_face_annotations_returns_only_matching_asset(tmp_path: Path)
     assert annotations[0].display_name is None
     assert annotations[0].box_w == 80
     assert annotations[0].image_width == 400
+
+
+def test_face_scan_session_leaves_runtime_snapshot_unchanged_until_commit(tmp_path: Path) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    embedding_a = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    embedding_b = np.asarray([0.0, 1.0, 0.0], dtype=np.float32)
+    initial_faces = [
+        _face_record(
+            face_id="face-a-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            embedding=embedding_a,
+            face_key="face-key-a-shared",
+        ),
+        _face_record(
+            face_id="face-b-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            embedding=embedding_b,
+            face_key="face-key-b-shared",
+        ),
+    ]
+    initial_persons = [
+        _person_record(
+            person_id="person-a",
+            key_face_id="face-a-shared",
+            face_count=1,
+            name="Alice",
+            embedding=embedding_a,
+        ),
+        _person_record(
+            person_id="person-b",
+            key_face_id="face-b-shared",
+            face_count=1,
+            name="Bob",
+            embedding=embedding_b,
+        ),
+    ]
+    repository.replace_all(initial_faces, initial_persons)
+    assert repository.state_repository is not None
+    repository.state_repository.sync_scan_results(initial_persons, initial_faces)
+
+    group = repository.create_group(["person-a", "person-b"])
+    assert group is not None
+
+    session = FaceScanSession()
+    done_ids, retry_ids = session.stage_detection_results(
+        [
+            DetectedAssetFaces(
+                asset_id="asset-new-shared",
+                asset_rel="album/new-shared.jpg",
+                faces=[
+                    _face_record(
+                        face_id="face-a-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.98, 0.02, 0.0], dtype=np.float32),
+                        face_key="face-key-a-new-shared",
+                    ),
+                    _face_record(
+                        face_id="face-b-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.02, 0.98, 0.0], dtype=np.float32),
+                        face_key="face-key-b-new-shared",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    assert done_ids == ["asset-new-shared"]
+    assert retry_ids == []
+    assert repository.get_common_asset_ids_for_group(group.group_id) == ["asset-shared"]
+
+    session.commit(repository, distance_threshold=0.6, min_samples=2)
+
+    summaries = repository.get_person_summaries()
+    assert {summary.person_id for summary in summaries} == {"person-a", "person-b"}
+    assert repository.get_common_asset_ids_for_group(group.group_id) == [
+        "asset-new-shared",
+        "asset-shared",
+    ]
+
+
+def test_face_scan_session_preserves_group_id_and_custom_cover_after_commit(tmp_path: Path) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    embedding_a = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    embedding_b = np.asarray([0.0, 1.0, 0.0], dtype=np.float32)
+    initial_faces = [
+        _face_record(
+            face_id="face-a-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            embedding=embedding_a,
+            face_key="face-key-a-shared",
+        ),
+        _face_record(
+            face_id="face-b-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            embedding=embedding_b,
+            face_key="face-key-b-shared",
+        ),
+    ]
+    initial_persons = [
+        _person_record(
+            person_id="person-a",
+            key_face_id="face-a-shared",
+            face_count=1,
+            name="Alice",
+            embedding=embedding_a,
+        ),
+        _person_record(
+            person_id="person-b",
+            key_face_id="face-b-shared",
+            face_count=1,
+            name="Bob",
+            embedding=embedding_b,
+        ),
+    ]
+    repository.replace_all(initial_faces, initial_persons)
+    assert repository.state_repository is not None
+    repository.state_repository.sync_scan_results(initial_persons, initial_faces)
+
+    group = repository.create_group(["person-a", "person-b"])
+    assert group is not None
+    assert repository.set_group_cover_asset(group.group_id, "asset-shared") is True
+
+    session = FaceScanSession()
+    session.stage_detection_results(
+        [
+            DetectedAssetFaces(
+                asset_id="asset-new-shared",
+                asset_rel="album/new-shared.jpg",
+                faces=[
+                    _face_record(
+                        face_id="face-a-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.96, 0.04, 0.0], dtype=np.float32),
+                        face_key="face-key-a-new-shared",
+                    ),
+                    _face_record(
+                        face_id="face-b-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.04, 0.96, 0.0], dtype=np.float32),
+                        face_key="face-key-b-new-shared",
+                    ),
+                ],
+            )
+        ]
+    )
+
+    session.commit(repository, distance_threshold=0.6, min_samples=2)
+
+    groups = repository.list_groups()
+    assert len(groups) == 1
+    assert groups[0].group_id == group.group_id
+    assert repository.get_group_cover_asset_id(group.group_id) == "asset-shared"

--- a/tests/test_people_service.py
+++ b/tests/test_people_service.py
@@ -8,7 +8,10 @@ import pytest
 
 from iPhoto.cache.index_store import get_global_repository, reset_global_repository
 from iPhoto.config import WORK_DIR_NAME
+from iPhoto.library.workers.face_scan_worker import FaceScanWorker
+from iPhoto.people.pipeline import DetectedAssetFaces
 from iPhoto.people.repository import FaceRecord, PersonRecord
+from iPhoto.people.scan_session import FaceScanSession
 from iPhoto.people.service import PeopleService, face_library_paths, shared_face_model_dir
 
 
@@ -49,6 +52,55 @@ def _person_record(
     *, person_id: str, key_face_id: str, face_count: int, name: str | None = None
 ) -> PersonRecord:
     embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    timestamp = _now_iso()
+    return PersonRecord(
+        person_id=person_id,
+        name=name,
+        key_face_id=key_face_id,
+        face_count=face_count,
+        center_embedding=embedding,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+
+def _face_record_with_embedding(
+    *,
+    face_id: str,
+    face_key: str,
+    asset_id: str,
+    asset_rel: str,
+    person_id: str | None,
+    embedding: np.ndarray,
+) -> FaceRecord:
+    return FaceRecord(
+        face_id=face_id,
+        face_key=face_key,
+        asset_id=asset_id,
+        asset_rel=asset_rel,
+        box_x=10,
+        box_y=12,
+        box_w=80,
+        box_h=80,
+        confidence=0.99,
+        embedding=embedding,
+        embedding_dim=int(embedding.shape[0]),
+        thumbnail_path=None,
+        person_id=person_id,
+        detected_at=_now_iso(),
+        image_width=400,
+        image_height=300,
+    )
+
+
+def _person_record_with_embedding(
+    *,
+    person_id: str,
+    key_face_id: str,
+    face_count: int,
+    name: str | None,
+    embedding: np.ndarray,
+) -> PersonRecord:
     timestamp = _now_iso()
     return PersonRecord(
         person_id=person_id,
@@ -381,3 +433,127 @@ def test_people_service_lists_asset_face_annotations_and_preserves_names(tmp_pat
     service.rename_cluster("person-a", "Alice")
     updated = service.list_asset_face_annotations("asset-a")
     assert updated[0].display_name == "Alice"
+
+
+def test_people_service_dashboard_stays_stable_until_face_scan_session_commits(tmp_path: Path) -> None:
+    library_root = tmp_path / "Library"
+    library_root.mkdir()
+
+    global_repo = get_global_repository(library_root)
+    global_repo.write_rows(
+        [
+            {"rel": "album/shared.jpg", "id": "asset-shared", "media_type": 0, "face_status": "done"},
+            {
+                "rel": "album/new-shared.jpg",
+                "id": "asset-new-shared",
+                "media_type": 0,
+                "face_status": "pending",
+            },
+        ]
+    )
+
+    service = PeopleService(library_root)
+    repository = service.repository()
+    assert repository is not None
+
+    embedding_a = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
+    embedding_b = np.asarray([0.0, 1.0, 0.0], dtype=np.float32)
+    initial_faces = [
+        _face_record_with_embedding(
+            face_id="face-a-shared",
+            face_key="face-key-a-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            embedding=embedding_a,
+        ),
+        _face_record_with_embedding(
+            face_id="face-b-shared",
+            face_key="face-key-b-shared",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            embedding=embedding_b,
+        ),
+    ]
+    initial_persons = [
+        _person_record_with_embedding(
+            person_id="person-a",
+            key_face_id="face-a-shared",
+            face_count=1,
+            name="Alice",
+            embedding=embedding_a,
+        ),
+        _person_record_with_embedding(
+            person_id="person-b",
+            key_face_id="face-b-shared",
+            face_count=1,
+            name="Bob",
+            embedding=embedding_b,
+        ),
+    ]
+    repository.replace_all(initial_faces, initial_persons)
+    assert repository.state_repository is not None
+    repository.state_repository.sync_scan_results(initial_persons, initial_faces)
+    group = service.create_group(["person-a", "person-b"])
+    assert group is not None
+
+    session = FaceScanSession()
+    session.stage_detection_results(
+        [
+            DetectedAssetFaces(
+                asset_id="asset-new-shared",
+                asset_rel="album/new-shared.jpg",
+                faces=[
+                    _face_record_with_embedding(
+                        face_id="face-a-new-shared",
+                        face_key="face-key-a-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.98, 0.02, 0.0], dtype=np.float32),
+                    ),
+                    _face_record_with_embedding(
+                        face_id="face-b-new-shared",
+                        face_key="face-key-b-new-shared",
+                        asset_id="asset-new-shared",
+                        asset_rel="album/new-shared.jpg",
+                        person_id=None,
+                        embedding=np.asarray([0.02, 0.98, 0.0], dtype=np.float32),
+                    ),
+                ],
+            )
+        ]
+    )
+
+    summaries_before, groups_before, pending_before = service.load_dashboard()
+    assert [summary.person_id for summary in summaries_before] == ["person-a", "person-b"]
+    assert groups_before[0].group_id == group.group_id
+    assert groups_before[0].asset_count == 1
+    assert pending_before == 1
+
+    session.commit(repository, distance_threshold=0.6, min_samples=2)
+    global_repo.update_face_status("asset-new-shared", "done")
+
+    summaries_after, groups_after, pending_after = service.load_dashboard()
+    assert [summary.person_id for summary in summaries_after] == ["person-a", "person-b"]
+    assert groups_after[0].group_id == group.group_id
+    assert groups_after[0].asset_count == 2
+    assert pending_after == 0
+
+
+def test_face_scan_worker_enqueue_rows_skips_done_assets(tmp_path: Path) -> None:
+    worker = FaceScanWorker(tmp_path)
+
+    worker.enqueue_rows(
+        [
+            {"id": "asset-done", "media_type": 0, "face_status": "done"},
+            {"id": "asset-pending", "media_type": 0, "face_status": "pending"},
+            {"id": "asset-retry", "media_type": 0, "face_status": "retry"},
+            {"id": "asset-video", "media_type": 1, "face_status": "pending"},
+        ]
+    )
+
+    batch = worker._next_batch()
+
+    assert [row["id"] for row in batch] == ["asset-pending", "asset-retry"]

--- a/tests/test_people_service.py
+++ b/tests/test_people_service.py
@@ -9,6 +9,7 @@ import pytest
 from iPhoto.cache.index_store import get_global_repository, reset_global_repository
 from iPhoto.config import WORK_DIR_NAME
 from iPhoto.library.workers.face_scan_worker import FaceScanWorker
+from iPhoto.library.workers.scanner_worker import ScannerSignals, ScannerWorker
 from iPhoto.people.pipeline import DetectedAssetFaces
 from iPhoto.people.repository import FaceRecord, PersonRecord
 from iPhoto.people.scan_session import FaceScanSession
@@ -557,3 +558,22 @@ def test_face_scan_worker_enqueue_rows_skips_done_assets(tmp_path: Path) -> None
     batch = worker._next_batch()
 
     assert [row["id"] for row in batch] == ["asset-pending", "asset-retry"]
+
+
+def test_scanner_worker_does_not_emit_chunk_ready_for_failed_persist(tmp_path: Path) -> None:
+    class FailingStore:
+        def merge_scan_rows(self, chunk: list[dict]) -> list[dict]:
+            raise RuntimeError("db write failed")
+
+    signals = ScannerSignals()
+    emitted_chunks: list[tuple[Path, list[dict]]] = []
+    failed_batches: list[tuple[Path, int]] = []
+    signals.chunkReady.connect(lambda root, chunk: emitted_chunks.append((root, chunk)))
+    signals.batchFailed.connect(lambda root, count: failed_batches.append((root, count)))
+
+    worker = ScannerWorker(tmp_path, [], [], signals)
+    worker._process_chunk(FailingStore(), [{"id": "asset-1", "rel": "album/a.jpg"}])
+
+    assert emitted_chunks == []
+    assert failed_batches == [(tmp_path, 1)]
+    assert worker.failed_count == 1


### PR DESCRIPTION
This pull request introduces significant improvements to how scanned asset data is merged with the existing library state, ensuring that important fields (like face recognition status and favorites) are preserved during rescans and incremental updates. It also refactors the face scan workflow to use a session-based approach for batching and committing face detection results. The changes improve data integrity, incremental scan support, and test coverage.

**Scan row merging and state preservation:**

* Added a new `merge_scan_rows` method to the repository, which merges freshly scanned asset rows with existing persisted state, preserving fields such as `face_status`, `is_favorite`, and others. This replaces previous ad-hoc logic and ensures consistent handling during rescans and incremental updates. (`src/iPhoto/cache/index_store/repository.py`, `src/iPhoto/cache/index_store/scan_merge.py`, `src/iPhoto/app.py`, `src/iPhoto/index_sync_service.py`, `src/iPhoto/library/workers/scanner_worker.py`, [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL309-R271) [[2]](diffhunk://#diff-d37ee75e9e06396e398b77db3b4c41641152f4ef0dfc4fe7b1bcdd657b1b6e5fR174-R190) [[3]](diffhunk://#diff-aa291d148756d8aa43d467a2022557b3c3e863eee205779a93df3e3cd4a60464R1-R64) [[4]](diffhunk://#diff-4768faf61c1cdf9ac7462cd5e3009f020cfe648503a7fc4813ec5d7a16caa895L103-R106) [[5]](diffhunk://#diff-a71f1eec18372c49a3d0e3367f44fdfe8b3946bfc96f8581f4e717a56661b5dfR204-R213)
* Updated tests to verify that `merge_scan_rows` correctly preserves or resets `face_status` and other library-managed fields as appropriate. (`tests/cache/test_global_repository.py`, [tests/cache/test_global_repository.pyR129-R200](diffhunk://#diff-78abfc5208737c78644d77ce98b98b61157f9a343bdfac8e6e5197902c406ba4R129-R200))

**Face scan session refactor:**

* Introduced a new `FaceScanSession` class to accumulate face detection results per scan session and commit a unified People snapshot at the end. This improves consistency and batching for face recognition updates. (`src/iPhoto/people/scan_session.py`, [src/iPhoto/people/scan_session.pyR1-R112](diffhunk://#diff-56b82d1046f40e8c25d8e990afdfb7f5a68aa1701e755878225798ae84b882c3R1-R112))
* Refactored the face scan worker to use `FaceScanSession`, staging detection results and committing them in batches instead of updating the repository after each asset. (`src/iPhoto/library/workers/face_scan_worker.py`, [[1]](diffhunk://#diff-df433263ef34db6e5fdf8749d658ce056e68a5176ee63ddce4d8c6053db7b801L12-R14) [[2]](diffhunk://#diff-df433263ef34db6e5fdf8749d658ce056e68a5176ee63ddce4d8c6053db7b801R74) [[3]](diffhunk://#diff-df433263ef34db6e5fdf8749d658ce056e68a5176ee63ddce4d8c6053db7b801R83-R98) [[4]](diffhunk://#diff-df433263ef34db6e5fdf8749d658ce056e68a5176ee63ddce4d8c6053db7b801L138-L187)

**Code cleanup and minor fixes:**

* Removed unused imports and simplified code in several modules. (`src/iPhoto/app.py`, [src/iPhoto/app.pyL7-L13](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL7-L13))
* Minor test improvements and monkeypatching robustness. (`tests/test_face_cluster_demo.py`, [[1]](diffhunk://#diff-62b0f229a6be61f7a8d28bb5210719f950cb29ef49ad0565e7206b5b31a1cdb1L279-R289); `tests/test_people_repository.py`, [[2]](diffhunk://#diff-a847c6aba4cdf013562c85f349bd66e2662688ce1e7d428131fc2ad6c1a14df3R8-R10)

These changes collectively make the asset scanning and face recognition workflows more robust, maintainable, and correct.