### PR TITLE
feat: refactor gallery view model to support singleton cluster galler…

### DIFF
--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -69,14 +69,20 @@ class LocationSelectionSession:
     def full_assets(self) -> list:
         return list(self._full_assets)
 
-    def resolve_relative(self, rel: str) -> Path | None:
+    def resolve_asset(self, rel: str):
         target = Path(rel).as_posix()
         for asset in self._full_assets:
             library_relative = getattr(asset, "library_relative", None)
             if isinstance(library_relative, str) and Path(library_relative).as_posix() == target:
-                absolute_path = getattr(asset, "absolute_path", None)
-                if isinstance(absolute_path, Path):
-                    return absolute_path
+                return asset
+        return None
+
+    def resolve_relative(self, rel: str) -> Path | None:
+        asset = self.resolve_asset(rel)
+        if asset is not None:
+            absolute_path = getattr(asset, "absolute_path", None)
+            if isinstance(absolute_path, Path):
+                return absolute_path
         return None
 
     def is_cluster_gallery(self) -> bool:

--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -69,7 +69,7 @@ class LocationSelectionSession:
     def full_assets(self) -> list:
         return list(self._full_assets)
 
-    def resolve_asset(self, rel: str):
+    def resolve_asset(self, rel: str) -> object | None:
         target = Path(rel).as_posix()
         for asset in self._full_assets:
             library_relative = getattr(asset, "library_relative", None)

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -201,18 +201,7 @@ class GalleryViewModel(BaseViewModel):
         asset = self._location_session.resolve_asset(rel)
         if asset is None:
             return
-        self._cluster_gallery_origin = "location"
-        selected_assets = [asset]
-        self.current_section.value = "cluster_gallery"
-        self.static_selection.value = "Location"
-        self.active_root.value = root
-        self.current_query.value = None
-        self.current_direct_assets.value = list(selected_assets)
-        self.can_return_to_map.value = True
-        self._location_session.set_mode("cluster_gallery")
-        self._store.load_selection(root, direct_assets=selected_assets, library_root=root)
-        self.cluster_gallery_mode_changed.emit(True)
-        self.route_requested.emit("gallery")
+        self.open_cluster_gallery([asset])
 
     def open_cluster_gallery(self, assets: list[Any]) -> None:
         root = self._context.library.root()

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -198,24 +198,21 @@ class GalleryViewModel(BaseViewModel):
             or self._location_session.invalidated
         ):
             return
-        resolved_path = self._location_session.resolve_relative(rel)
-        if resolved_path is None:
+        asset = self._location_session.resolve_asset(rel)
+        if asset is None:
             return
-        assets = self._location_session.full_assets()
-        self.current_section.value = "location_gallery"
+        self._cluster_gallery_origin = "location"
+        selected_assets = [asset]
+        self.current_section.value = "cluster_gallery"
         self.static_selection.value = "Location"
         self.active_root.value = root
         self.current_query.value = None
-        self.current_direct_assets.value = list(assets)
-        self.can_return_to_map.value = False
-        self._clear_cluster_gallery_context()
-        self._location_session.set_mode("gallery")
-        self.cluster_gallery_mode_changed.emit(False)
-        self._store.load_selection(root, direct_assets=assets, library_root=root)
+        self.current_direct_assets.value = list(selected_assets)
+        self.can_return_to_map.value = True
+        self._location_session.set_mode("cluster_gallery")
+        self._store.load_selection(root, direct_assets=selected_assets, library_root=root)
+        self.cluster_gallery_mode_changed.emit(True)
         self.route_requested.emit("gallery")
-        row = self._store.row_for_path(resolved_path)
-        if row is not None:
-            self.open_row(row)
 
     def open_cluster_gallery(self, assets: list[Any]) -> None:
         root = self._context.library.root()

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -88,32 +88,46 @@ def test_open_filtered_collection_sets_media_types(tmp_path: Path) -> None:
     assert query.media_types == [MediaType.VIDEO]
 
 
-def test_open_location_asset_uses_full_snapshot_and_emits_detail(tmp_path: Path) -> None:
-    vm, store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+def test_open_location_asset_opens_singleton_cluster_gallery(tmp_path: Path) -> None:
+    vm, store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
     assets = [
         SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg"),
         SimpleNamespace(library_relative="nested/b.jpg", absolute_path=tmp_path / "nested" / "b.jpg"),
     ]
     serial = vm.location_session.begin_load(tmp_path)
     assert vm.location_session.accept_loaded(serial, tmp_path, assets)
-    store.row_for_path.return_value = 1
 
     requested = []
+    cluster_mode = []
+    routes = []
     vm.detail_requested.connect(requested.append)
+    vm.cluster_gallery_mode_changed.connect(cluster_mode.append)
+    vm.route_requested.connect(routes.append)
     vm.open_location_asset("nested/b.jpg")
 
-    store.load_selection.assert_called_once_with(tmp_path, direct_assets=assets, library_root=tmp_path)
-    store.row_for_path.assert_called_once_with(tmp_path / "nested" / "b.jpg")
-    assert requested == [1]
-    assert vm.location_session.mode == "gallery"
+    selected_asset = assets[1]
+    store.load_selection.assert_called_once_with(
+        tmp_path,
+        direct_assets=[selected_asset],
+        library_root=tmp_path,
+    )
+    store.row_for_path.assert_not_called()
+    assert requested == []
+    assert routes == ["gallery"]
+    assert cluster_mode == [True]
+    assert vm.current_section.value == "cluster_gallery"
+    assert vm.current_direct_assets.value == [selected_asset]
+    assert vm.can_return_to_map.value is True
+    assert vm.is_in_cluster_gallery() is True
+    assert vm.location_session.mode == "cluster_gallery"
 
 
-def test_return_to_map_from_cluster_gallery_reuses_snapshot(tmp_path: Path) -> None:
+def test_return_to_map_from_singleton_location_cluster_reuses_snapshot(tmp_path: Path) -> None:
     vm, _store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
     assets = [SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")]
     serial = vm.location_session.begin_load(tmp_path)
     assert vm.location_session.accept_loaded(serial, tmp_path, assets)
-    vm.location_session.set_mode("cluster_gallery")
+    vm.open_location_asset("a.jpg")
 
     routes = []
     map_payloads = []


### PR DESCRIPTION
This pull request refactors how location-based asset selection works in the gallery view, shifting from opening a single asset in detail view to opening it as a singleton cluster gallery. It also updates the supporting session logic and corresponding tests to reflect this new behavior.

**Major changes to location asset selection:**

* The `open_location_asset` method in `gallery_viewmodel.py` now opens the asset as a singleton cluster gallery instead of a detail view, updates the UI state accordingly, and emits the correct signals to reflect this change. (`[src/iPhoto/gui/viewmodels/gallery_viewmodel.pyL201-L218](diffhunk://#diff-7c9bafce976fc2f04d1329994d947f985354b350806378246b022044a1e1978dL201-L218)`)
* The `resolve_relative` method in `location_selection_session.py` now delegates to a new `resolve_asset` helper, which returns the asset object rather than just its path, supporting the new selection logic. (`[src/iPhoto/gui/coordinators/location_selection_session.pyL72-R82](diffhunk://#diff-717ca3b12c440172c01bae4751f92a47a799dee531e372e29d2dbab1c62449ddL72-R82)`)

**Test updates:**

* The test `test_open_location_asset_uses_full_snapshot_and_emits_detail` has been rewritten as `test_open_location_asset_opens_singleton_cluster_gallery` to verify the new cluster gallery behavior, including signal emissions and state changes. (`[tests/gui/viewmodels/test_gallery_viewmodel.pyL91-R130](diffhunk://#diff-37b3d43a196bc95dcdbea02cac235ef25d83df58f07eb8d0b3f74063154501f2L91-R130)`)
* The test for returning to the map from a location cluster has been updated to start from the new singleton cluster gallery state. (`[tests/gui/viewmodels/test_gallery_viewmodel.pyL91-R130](diffhunk://#diff-37b3d43a196bc95dcdbea02cac235ef25d83df58f07eb8d0b3f74063154501f2L91-R130)`)…y mode and update asset resolution logic