### PR TITLE
feat: implement location scan handling in gallery view model and update asset management logic

### DIFF
--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -69,6 +69,58 @@ class LocationSelectionSession:
     def full_assets(self) -> list:
         return list(self._full_assets)
 
+    def replace_assets(self, assets: list) -> None:
+        self._full_assets = sorted(
+            list(assets),
+            key=lambda asset: str(getattr(asset, "library_relative", "")),
+        )
+        self._has_snapshot = True
+        self._invalidated = False
+
+    def upsert_asset(self, asset: object) -> bool:
+        library_relative = getattr(asset, "library_relative", None)
+        if not isinstance(library_relative, str) or not library_relative:
+            return False
+
+        changed = False
+        updated_assets: list[object] = []
+        replaced = False
+        for existing in self._full_assets:
+            existing_rel = getattr(existing, "library_relative", None)
+            if existing_rel == library_relative:
+                updated_assets.append(asset)
+                replaced = True
+                if existing != asset:
+                    changed = True
+            else:
+                updated_assets.append(existing)
+        if not replaced:
+            updated_assets.append(asset)
+            changed = True
+
+        if changed:
+            self._full_assets = sorted(
+                updated_assets,
+                key=lambda current: str(getattr(current, "library_relative", "")),
+            )
+        self._has_snapshot = True
+        self._invalidated = False
+        return changed
+
+    def remove_asset(self, rel: str) -> bool:
+        target = Path(rel).as_posix()
+        filtered_assets = [
+            asset
+            for asset in self._full_assets
+            if Path(str(getattr(asset, "library_relative", ""))).as_posix() != target
+        ]
+        changed = len(filtered_assets) != len(self._full_assets)
+        if changed:
+            self._full_assets = filtered_assets
+        self._has_snapshot = True
+        self._invalidated = False
+        return changed
+
     def resolve_asset(self, rel: str) -> object | None:
         target = Path(rel).as_posix()
         for asset in self._full_assets:

--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -65,8 +65,7 @@ class LocationSelectionSession:
             for a in assets
             if isinstance((rel := getattr(a, "library_relative", None)), str) and rel
         }
-        self._full_assets = list(assets)
-        self._list_dirty = False
+        self._list_dirty = True
         self._has_snapshot = True
         self._invalidated = False
         return True

--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -18,7 +18,9 @@ class LocationSelectionSession:
         self._mode: LocationSelectionMode = "inactive"
         self._invalidated = False
         self._has_snapshot = False
-        # Dict index for O(1) upsert/remove; sorted list is rebuilt lazily.
+        # Keys are POSIX-normalized library_relative strings (Path(rel).as_posix());
+        # values are the corresponding asset objects. Provides O(1) upsert/remove.
+        # The sorted list (_full_assets) is rebuilt lazily via full_assets().
         self._asset_index: dict[str, object] = {}
         self._full_assets: list = []
         self._list_dirty: bool = False
@@ -60,11 +62,11 @@ class LocationSelectionSession:
         if serial != self._request_serial or self._root != normalized_root:
             return False
         self._root = normalized_root
-        self._asset_index = {
-            Path(rel).as_posix(): a
-            for a in assets
-            if isinstance((rel := getattr(a, "library_relative", None)), str) and rel
-        }
+        self._asset_index = {}
+        for a in assets:
+            rel = getattr(a, "library_relative", None)
+            if isinstance(rel, str) and rel:
+                self._asset_index[Path(rel).as_posix()] = a
         self._list_dirty = True
         self._has_snapshot = True
         self._invalidated = False

--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -18,7 +18,10 @@ class LocationSelectionSession:
         self._mode: LocationSelectionMode = "inactive"
         self._invalidated = False
         self._has_snapshot = False
+        # Dict index for O(1) upsert/remove; sorted list is rebuilt lazily.
+        self._asset_index: dict[str, object] = {}
         self._full_assets: list = []
+        self._list_dirty: bool = False
 
     @property
     def root(self) -> Path | None:
@@ -43,7 +46,9 @@ class LocationSelectionSession:
     def begin_load(self, root: Path) -> int:
         normalized_root = Path(root)
         if self._root != normalized_root:
+            self._asset_index = {}
             self._full_assets = []
+            self._list_dirty = False
             self._has_snapshot = False
         self._root = normalized_root
         self._invalidated = True
@@ -55,7 +60,13 @@ class LocationSelectionSession:
         if serial != self._request_serial or self._root != normalized_root:
             return False
         self._root = normalized_root
+        self._asset_index = {
+            Path(rel).as_posix(): a
+            for a in assets
+            if isinstance((rel := getattr(a, "library_relative", None)), str) and rel
+        }
         self._full_assets = list(assets)
+        self._list_dirty = False
         self._has_snapshot = True
         self._invalidated = False
         return True
@@ -67,13 +78,21 @@ class LocationSelectionSession:
         self._invalidated = True
 
     def full_assets(self) -> list:
+        if self._list_dirty:
+            self._full_assets = sorted(
+                list(self._asset_index.values()),
+                key=lambda asset: str(getattr(asset, "library_relative", "")),
+            )
+            self._list_dirty = False
         return list(self._full_assets)
 
     def replace_assets(self, assets: list) -> None:
-        self._full_assets = sorted(
-            list(assets),
-            key=lambda asset: str(getattr(asset, "library_relative", "")),
-        )
+        self._asset_index = {}
+        for a in assets:
+            rel = getattr(a, "library_relative", None)
+            if isinstance(rel, str) and rel:
+                self._asset_index[Path(rel).as_posix()] = a
+        self._list_dirty = True
         self._has_snapshot = True
         self._invalidated = False
 
@@ -82,52 +101,34 @@ class LocationSelectionSession:
         if not isinstance(library_relative, str) or not library_relative:
             return False
 
-        changed = False
-        updated_assets: list[object] = []
-        replaced = False
-        for existing in self._full_assets:
-            existing_rel = getattr(existing, "library_relative", None)
-            if existing_rel == library_relative:
-                updated_assets.append(asset)
-                replaced = True
-                if existing != asset:
-                    changed = True
-            else:
-                updated_assets.append(existing)
-        if not replaced:
-            updated_assets.append(asset)
-            changed = True
+        key = Path(library_relative).as_posix()
+        existing = self._asset_index.get(key)
+        if existing == asset:
+            self._has_snapshot = True
+            self._invalidated = False
+            return False
 
-        if changed:
-            self._full_assets = sorted(
-                updated_assets,
-                key=lambda current: str(getattr(current, "library_relative", "")),
-            )
+        self._asset_index[key] = asset
+        self._list_dirty = True
         self._has_snapshot = True
         self._invalidated = False
-        return changed
+        return True
 
     def remove_asset(self, rel: str) -> bool:
         target = Path(rel).as_posix()
-        filtered_assets = [
-            asset
-            for asset in self._full_assets
-            if Path(str(getattr(asset, "library_relative", ""))).as_posix() != target
-        ]
-        changed = len(filtered_assets) != len(self._full_assets)
-        if changed:
-            self._full_assets = filtered_assets
+        if target not in self._asset_index:
+            self._has_snapshot = True
+            self._invalidated = False
+            return False
+
+        del self._asset_index[target]
+        self._list_dirty = True
         self._has_snapshot = True
         self._invalidated = False
-        return changed
+        return True
 
     def resolve_asset(self, rel: str) -> object | None:
-        target = Path(rel).as_posix()
-        for asset in self._full_assets:
-            library_relative = getattr(asset, "library_relative", None)
-            if isinstance(library_relative, str) and Path(library_relative).as_posix() == target:
-                return asset
-        return None
+        return self._asset_index.get(Path(rel).as_posix())
 
     def resolve_relative(self, rel: str) -> Path | None:
         asset = self.resolve_asset(rel)

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -384,6 +384,8 @@ class MainCoordinator(QObject):
         self._context.library.treeUpdated.connect(self._on_library_tree_updated)
         self._facade.scanChunkReady.connect(self._gallery_store.handle_scan_chunk)
         self._facade.scanFinished.connect(self._gallery_store.handle_scan_finished)
+        self._context.library.scanChunkReady.connect(self._gallery_vm.handle_location_scan_chunk)
+        self._context.library.scanFinished.connect(self._gallery_vm.handle_location_scan_finished)
         self._gallery_vm.message_requested.connect(self._status_bar.show_message)
 
         # Grid interactions

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -12,7 +12,7 @@ from iPhoto.domain.models.core import MediaType
 from iPhoto.domain.models.query import AssetQuery
 from iPhoto.gui.coordinators.location_selection_session import LocationSelectionSession
 from iPhoto.gui.facade import AppFacade
-from iPhoto.library.geo_aggregator import _geotagged_asset_from_row
+from iPhoto.library.geo_aggregator import geotagged_asset_from_row
 
 from .base import BaseViewModel
 from .gallery_collection_store import GalleryCollectionStore
@@ -324,7 +324,7 @@ class GalleryViewModel(BaseViewModel):
 
         changed = False
         for row in chunk:
-            asset = _geotagged_asset_from_row(root, row)
+            asset = geotagged_asset_from_row(root, row)
             if asset is not None:
                 changed = self._location_session.upsert_asset(asset) or changed
                 continue
@@ -465,6 +465,5 @@ class GalleryViewModel(BaseViewModel):
             return False
         return (
             scan_root_resolved == root_resolved
-            or scan_root_resolved in root_resolved.parents
             or root_resolved in scan_root_resolved.parents
         )

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -12,6 +12,7 @@ from iPhoto.domain.models.core import MediaType
 from iPhoto.domain.models.query import AssetQuery
 from iPhoto.gui.coordinators.location_selection_session import LocationSelectionSession
 from iPhoto.gui.facade import AppFacade
+from iPhoto.library.geo_aggregator import _geotagged_asset_from_row
 
 from .base import BaseViewModel
 from .gallery_collection_store import GalleryCollectionStore
@@ -314,6 +315,37 @@ class GalleryViewModel(BaseViewModel):
     def return_to_map_from_cluster_gallery(self) -> None:
         self.return_from_cluster_gallery()
 
+    def handle_location_scan_chunk(self, scan_root: Path, chunk: list[dict]) -> None:
+        if self._location_session.mode == "inactive":
+            return
+        root = self._context.library.root()
+        if root is None or not self._scan_root_matches_location_context(scan_root, root):
+            return
+
+        changed = False
+        for row in chunk:
+            asset = _geotagged_asset_from_row(root, row)
+            if asset is not None:
+                changed = self._location_session.upsert_asset(asset) or changed
+                continue
+            rel = row.get("rel") if isinstance(row, dict) else None
+            if isinstance(rel, str) and rel:
+                changed = self._location_session.remove_asset(rel) or changed
+
+        if changed and self._location_session.mode == "map":
+            self.map_assets_changed.emit(self._location_session.full_assets(), root)
+
+    def handle_location_scan_finished(self, scan_root: Path, success: bool) -> None:
+        if not success or self._location_session.mode == "inactive":
+            return
+        root = self._context.library.root()
+        if root is None or not self._scan_root_matches_location_context(scan_root, root):
+            return
+
+        self._location_session.replace_assets(list(self._context.library.get_geotagged_assets()))
+        if self._location_session.mode == "map":
+            self.map_assets_changed.emit(self._location_session.full_assets(), root)
+
     def on_library_tree_updated(self) -> bool:
         self._location_session.invalidate()
         if self.is_location_context_active():
@@ -424,3 +456,15 @@ class GalleryViewModel(BaseViewModel):
         if rel_str in ("", "."):
             return None
         return rel_str
+
+    def _scan_root_matches_location_context(self, scan_root: Path, root: Path) -> bool:
+        try:
+            scan_root_resolved = scan_root.resolve()
+            root_resolved = root.resolve()
+        except OSError:
+            return False
+        return (
+            scan_root_resolved == root_resolved
+            or scan_root_resolved in root_resolved.parents
+            or root_resolved in scan_root_resolved.parents
+        )

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -316,10 +316,12 @@ class GalleryViewModel(BaseViewModel):
         self.return_from_cluster_gallery()
 
     def handle_location_scan_chunk(self, scan_root: Path, chunk: list[dict]) -> None:
-        if self._location_session.mode == "inactive":
-            return
         root = self._context.library.root()
         if root is None or not self._scan_root_matches_location_context(scan_root, root):
+            return
+        if self._location_session.mode == "inactive":
+            if self._location_session.root == root and self._location_session.has_snapshot:
+                self._location_session.invalidate()
             return
 
         changed = False
@@ -336,10 +338,14 @@ class GalleryViewModel(BaseViewModel):
             self.map_assets_changed.emit(self._location_session.full_assets(), root)
 
     def handle_location_scan_finished(self, scan_root: Path, success: bool) -> None:
-        if not success or self._location_session.mode == "inactive":
+        if not success:
             return
         root = self._context.library.root()
         if root is None or not self._scan_root_matches_location_context(scan_root, root):
+            return
+        if self._location_session.mode == "inactive":
+            if self._location_session.root == root and self._location_session.has_snapshot:
+                self._location_session.invalidate()
             return
 
         self._location_session.replace_assets(list(self._context.library.get_geotagged_assets()))

--- a/src/iPhoto/library/geo_aggregator.py
+++ b/src/iPhoto/library/geo_aggregator.py
@@ -52,6 +52,96 @@ class GeotaggedAsset:
     """Library-relative path of the paired motion file when known."""
 
 
+def _geotagged_asset_from_row(root: Path, row: object) -> Optional[GeotaggedAsset]:
+    """Return a ``GeotaggedAsset`` converted from one index-store row."""
+
+    if not isinstance(row, dict):
+        return None
+    gps = row.get("gps")
+    if not isinstance(gps, dict):
+        return None
+    lat = gps.get("lat")
+    lon = gps.get("lon")
+    if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+        return None
+
+    rel = row.get("rel")
+    if not isinstance(rel, str) or not rel:
+        return None
+
+    live_role_raw = row.get("live_role")
+    live_role = int(live_role_raw) if isinstance(live_role_raw, (int, float)) else 0
+    # Keep only visible rows to mirror regular gallery queries.
+    # Hidden motion components (live_role != 0) must not be shown as
+    # standalone assets in the location cluster gallery.
+    if live_role != 0:
+        return None
+
+    abs_path = (root / rel).resolve()
+    location_name = resolve_location_name(gps)
+
+    parent_album_path = row.get("parent_album_path")
+    if parent_album_path:
+        album_path = root / parent_album_path
+        prefix = parent_album_path + "/"
+        if rel.startswith(prefix):
+            album_relative_str = rel[len(prefix):]
+        elif rel == parent_album_path:
+            album_relative_str = ""
+        else:
+            album_relative_str = Path(rel).name
+    else:
+        album_path = root
+        album_relative_str = rel
+
+    asset_id = str(row.get("id") or rel)
+    classified_image, classified_video = classify_media(row)
+    is_image = classified_image or bool(row.get("is_image"))
+    is_video = classified_video or bool(row.get("is_video"))
+
+    still_image_time = row.get("still_image_time")
+    if isinstance(still_image_time, (int, float)):
+        still_image_value: Optional[float] = float(still_image_time)
+    else:
+        still_image_value = None
+
+    duration = row.get("dur")
+    if isinstance(duration, (int, float)):
+        duration_value: Optional[float] = float(duration)
+    else:
+        duration_value = None
+
+    live_group_raw = row.get("live_photo_group_id")
+    live_group_id = (
+        str(live_group_raw).strip()
+        if isinstance(live_group_raw, str) and live_group_raw.strip()
+        else None
+    )
+    partner_raw = row.get("live_partner_rel")
+    live_partner_rel = (
+        str(partner_raw).strip()
+        if isinstance(partner_raw, str) and partner_raw.strip()
+        else None
+    )
+
+    return GeotaggedAsset(
+        library_relative=rel,
+        album_relative=album_relative_str,
+        absolute_path=abs_path,
+        album_path=album_path,
+        asset_id=asset_id,
+        latitude=float(lat),
+        longitude=float(lon),
+        is_image=is_image,
+        is_video=is_video,
+        still_image_time=still_image_value,
+        duration=duration_value,
+        location_name=location_name,
+        live_photo_group_id=live_group_id,
+        live_partner_rel=live_partner_rel,
+    )
+
+
 class GeoAggregatorMixin:
     """Mixin providing geotagged asset collection for LibraryManager."""
 
@@ -82,99 +172,13 @@ class GeoAggregatorMixin:
             return assets
 
         for row in rows:
-            if not isinstance(row, dict):
+            asset = _geotagged_asset_from_row(root, row)
+            if asset is None:
                 continue
-            gps = row.get("gps")
-            if not isinstance(gps, dict):
+            if asset.absolute_path in seen:
                 continue
-            lat = gps.get("lat")
-            lon = gps.get("lon")
-            if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
-                continue
-            # ``resolve_location_name`` maps the GPS coordinate to a human-readable
-            # label (typically the city) so that low zoom levels can show a
-            # meaningful aggregate marker instead of individual thumbnails.
-            location_name = resolve_location_name(gps)
-            rel = row.get("rel")
-            if not isinstance(rel, str) or not rel:
-                continue
-            abs_path = (root / rel).resolve()
-            if abs_path in seen:
-                continue
-            seen.add(abs_path)
-            library_relative_str = rel
-            # Compute album_path from the parent directory of the asset
-            parent_album_path = row.get("parent_album_path")
-            if parent_album_path:
-                album_path = root / parent_album_path
-                # Compute album-relative path by stripping the parent prefix
-                # Use string operations for robustness with paths at album root
-                prefix = parent_album_path + "/"
-                if rel.startswith(prefix):
-                    album_relative_str = rel[len(prefix):]
-                elif rel == parent_album_path:
-                    # File at the album root with same name as album (edge case)
-                    album_relative_str = ""
-                else:
-                    album_relative_str = Path(rel).name
-            else:
-                album_path = root
-                album_relative_str = rel
-            asset_id = str(row.get("id") or rel)
-            classified_image, classified_video = classify_media(row)
-            # Combine classifier results with any persisted flags to remain
-            # compatible with older index rows that stored boolean values.
-            is_image = classified_image or bool(row.get("is_image"))
-            is_video = classified_video or bool(row.get("is_video"))
-            still_image_time = row.get("still_image_time")
-            if isinstance(still_image_time, (int, float)):
-                still_image_value: Optional[float] = float(still_image_time)
-            else:
-                still_image_value = None
-            duration = row.get("dur")
-            if isinstance(duration, (int, float)):
-                duration_value: Optional[float] = float(duration)
-            else:
-                duration_value = None
-            live_role_raw = row.get("live_role")
-            live_role = int(live_role_raw) if isinstance(live_role_raw, (int, float)) else 0
-            # Keep only visible rows to mirror regular gallery queries.
-            # Hidden motion components (live_role != 0) must not be shown as
-            # standalone assets in the location cluster gallery.
-            if live_role != 0:
-                continue
-
-            live_group_raw = row.get("live_photo_group_id")
-            live_group_id = (
-                str(live_group_raw).strip()
-                if isinstance(live_group_raw, str) and live_group_raw.strip()
-                else None
-            )
-            partner_raw = row.get("live_partner_rel")
-            live_partner_rel = (
-                str(partner_raw).strip()
-                if isinstance(partner_raw, str) and partner_raw.strip()
-                else None
-            )
-
-            assets.append(
-                GeotaggedAsset(
-                    library_relative=library_relative_str,
-                    album_relative=album_relative_str,
-                    absolute_path=abs_path,
-                    album_path=album_path,
-                    asset_id=asset_id,
-                    latitude=float(lat),
-                    longitude=float(lon),
-                    is_image=is_image,
-                    is_video=is_video,
-                    still_image_time=still_image_value,
-                    duration=duration_value,
-                    location_name=location_name,
-                    live_photo_group_id=live_group_id,
-                    live_partner_rel=live_partner_rel,
-                )
-            )
+            seen.add(asset.absolute_path)
+            assets.append(asset)
 
         assets.sort(key=lambda item: item.library_relative)
         setattr(self, "_geotagged_assets_cache_root", root)

--- a/src/iPhoto/library/geo_aggregator.py
+++ b/src/iPhoto/library/geo_aggregator.py
@@ -52,7 +52,7 @@ class GeotaggedAsset:
     """Library-relative path of the paired motion file when known."""
 
 
-def _geotagged_asset_from_row(root: Path, row: object) -> Optional[GeotaggedAsset]:
+def geotagged_asset_from_row(root: Path, row: object) -> Optional[GeotaggedAsset]:
     """Return a ``GeotaggedAsset`` converted from one index-store row."""
 
     if not isinstance(row, dict):
@@ -172,7 +172,7 @@ class GeoAggregatorMixin:
             return assets
 
         for row in rows:
-            asset = _geotagged_asset_from_row(root, row)
+            asset = geotagged_asset_from_row(root, row)
             if asset is None:
                 continue
             if asset.absolute_path in seen:

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -21,15 +21,15 @@ LOGGER = get_logger()
 class _PairingWorker(QRunnable):
     """Run live-photo pairing off the main thread after a scan completes."""
 
-    def __init__(self, root: Path, library_root: Optional[Path]) -> None:
+    def __init__(self, scan_root: Path, library_root: Optional[Path]) -> None:
         super().__init__()
-        self._root = root
+        self._scan_root = scan_root
         self._library_root = library_root
 
     def run(self) -> None:
         try:
             from .. import app as backend  # noqa: PLC0415
-            backend.pair(self._root, library_root=self._library_root)
+            backend.pair(self._scan_root, library_root=self._library_root)
         except Exception as exc:  # noqa: BLE001
             LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)
 

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -266,12 +266,16 @@ class ScanCoordinatorMixin:
         if not chunk:
             return
 
+        self._geotagged_assets_cache = None
+        self._geotagged_assets_cache_root = None
         if self._current_face_scanner is not None:
             self._current_face_scanner.enqueue_rows(chunk)
         self.scanChunkReady.emit(root, chunk)
 
     def _on_scan_finished(self, root: Path, rows: List[dict]) -> None:
         # Emit scanFinished for downstream handling (e.g., updating links or finalizing scan).
+        self._geotagged_assets_cache = None
+        self._geotagged_assets_cache_root = None
         self.scanFinished.emit(root, True)
         # Clear worker reference after emitting signal to prevent race conditions
         locker = QMutexLocker(self._scan_buffer_lock)

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
-from PySide6.QtCore import QMutexLocker
+from PySide6.QtCore import QMutexLocker, QRunnable
 
 from ..cache.index_store import get_global_repository
 from ..utils.logging import get_logger
@@ -16,6 +16,22 @@ if TYPE_CHECKING:
     pass
 
 LOGGER = get_logger()
+
+
+class _PairingWorker(QRunnable):
+    """Run live-photo pairing off the main thread after a scan completes."""
+
+    def __init__(self, root: Path, library_root: Optional[Path]) -> None:
+        super().__init__()
+        self._root = root
+        self._library_root = library_root
+
+    def run(self) -> None:
+        try:
+            from .. import app as backend  # noqa: PLC0415
+            backend.pair(self._root, library_root=self._library_root)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)
 
 
 class ScanCoordinatorMixin:
@@ -282,19 +298,15 @@ class ScanCoordinatorMixin:
         if face_scanner is not None:
             face_scanner.finish_input()
 
-        # Persist Live Photo pairings once a scan completes so the database and
-        # links.json reflect the latest scan results.
-        try:
-            from .. import app as backend
-            backend.pair(root, library_root=self._root)
-        except Exception as exc:
-            LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)
-
         self._geotagged_assets_cache = None
         self._geotagged_assets_cache_root = None
-        # Emit scanFinished only after pairing writes so location refreshes use
-        # the authoritative persisted state.
+        # Emit immediately so the UI (status bar, map refresh) can react without
+        # waiting for the potentially slow live-photo pairing step.
         self.scanFinished.emit(root, True)
+
+        # Persist live-photo pairings in the background to avoid blocking the
+        # main thread while downstream listeners start refreshing.
+        self._scan_thread_pool.start(_PairingWorker(root, self._root))
 
     def _on_scan_error(self, root: Path, message: str) -> None:
         locker = QMutexLocker(self._scan_buffer_lock)

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -273,11 +273,8 @@ class ScanCoordinatorMixin:
         self.scanChunkReady.emit(root, chunk)
 
     def _on_scan_finished(self, root: Path, rows: List[dict]) -> None:
-        # Emit scanFinished for downstream handling (e.g., updating links or finalizing scan).
-        self._geotagged_assets_cache = None
-        self._geotagged_assets_cache_root = None
-        self.scanFinished.emit(root, True)
-        # Clear worker reference after emitting signal to prevent race conditions
+        # Clear worker reference before downstream listeners react so a completed
+        # scan does not still appear in-flight while final post-processing runs.
         locker = QMutexLocker(self._scan_buffer_lock)
         self._current_scanner_worker = None
         face_scanner = self._current_face_scanner
@@ -292,6 +289,12 @@ class ScanCoordinatorMixin:
             backend.pair(root, library_root=self._root)
         except Exception as exc:
             LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)
+
+        self._geotagged_assets_cache = None
+        self._geotagged_assets_cache_root = None
+        # Emit scanFinished only after pairing writes so location refreshes use
+        # the authoritative persisted state.
+        self.scanFinished.emit(root, True)
 
     def _on_scan_error(self, root: Path, message: str) -> None:
         locker = QMutexLocker(self._scan_buffer_lock)

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -31,7 +31,12 @@ class _PairingWorker(QRunnable):
             from .. import app as backend  # noqa: PLC0415
             backend.pair(self._scan_root, library_root=self._library_root)
         except Exception as exc:  # noqa: BLE001
-            LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)
+            LOGGER.warning(
+                "Failed to persist live photo pairings after scan of %s "
+                "(re-scanning the library will retry pairing): %s",
+                self._scan_root,
+                exc,
+            )
 
 
 class ScanCoordinatorMixin:

--- a/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
+++ b/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
@@ -79,3 +79,42 @@ def test_on_map_asset_activated_delegates_to_navigation() -> None:
     coordinator._on_map_asset_activated("nested/photo.jpg")
 
     coordinator._navigation.open_location_asset.assert_called_once_with("nested/photo.jpg")
+
+
+def test_connect_signals_wires_location_scan_updates_from_library() -> None:
+    coordinator = MainCoordinator.__new__(MainCoordinator)
+    coordinator._window = MagicMock()
+    coordinator._window.ui = MagicMock()
+    coordinator._context = MagicMock()
+    coordinator._facade = MagicMock()
+    coordinator._gallery_store = MagicMock()
+    coordinator._gallery_vm = MagicMock()
+    coordinator._status_bar = MagicMock()
+    coordinator._asset_list_vm = MagicMock()
+    coordinator._playback = MagicMock()
+    coordinator._detail_vm = MagicMock()
+    coordinator._navigation = MagicMock()
+    coordinator._dialog = MagicMock()
+    coordinator._edit = MagicMock()
+    coordinator._restore_preferences = MagicMock()
+    coordinator._on_library_tree_updated = MagicMock()
+    coordinator._on_asset_clicked = MagicMock()
+    coordinator._on_favorite_clicked = MagicMock()
+    coordinator._sync_selection = MagicMock()
+    coordinator._on_map_asset_activated = MagicMock()
+    coordinator._on_cluster_activated = MagicMock()
+    coordinator._handle_open_album_dialog = MagicMock()
+    coordinator._handle_face_name_toggle_changed = MagicMock()
+    coordinator.open_album_from_path = MagicMock()
+    coordinator._on_people_cluster_activated = MagicMock()
+    coordinator._on_people_group_activated = MagicMock()
+    coordinator._handle_wheel_action_changed = MagicMock()
+
+    coordinator._connect_signals()
+
+    coordinator._context.library.scanChunkReady.connect.assert_any_call(
+        coordinator._gallery_vm.handle_location_scan_chunk
+    )
+    coordinator._context.library.scanFinished.connect.assert_any_call(
+        coordinator._gallery_vm.handle_location_scan_finished
+    )

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -263,6 +263,49 @@ def test_location_scan_updates_ignore_unrelated_scan_roots(tmp_path: Path) -> No
     assert vm.location_session.full_assets() == []
 
 
+def test_location_scan_chunk_invalidates_cached_snapshot_while_location_is_inactive(tmp_path: Path) -> None:
+    vm, _store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    existing = SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [existing])
+    vm.location_session.set_mode("inactive")
+
+    vm.handle_location_scan_chunk(
+        tmp_path / "Album",
+        [
+            {
+                "rel": "Album/new.jpg",
+                "id": "asset-2",
+                "gps": {"lat": 52.5, "lon": 13.4},
+                "mime": "image/jpeg",
+                "parent_album_path": "Album",
+            }
+        ],
+    )
+
+    assert vm.location_session.invalidated is True
+
+
+def test_open_location_map_reloads_after_inactive_snapshot_was_invalidated_by_scan(tmp_path: Path) -> None:
+    vm, _store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    stale = SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")
+    refreshed = SimpleNamespace(library_relative="Album/new.jpg", absolute_path=tmp_path / "Album" / "new.jpg")
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [stale])
+    vm.location_session.set_mode("inactive")
+    context.library.get_geotagged_assets.return_value = [refreshed]
+
+    payloads = []
+    vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
+
+    vm.handle_location_scan_finished(tmp_path / "Album", True)
+    vm.open_location_map()
+
+    assert vm.location_session.invalidated is False
+    assert vm.location_session.full_assets() == [refreshed]
+    assert payloads[-1] == ([refreshed], tmp_path)
+
+
 def test_open_people_dashboard_routes_to_people_view(tmp_path: Path) -> None:
     vm, store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
     routes = []

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from iPhoto.config import RECENTLY_DELETED_DIR_NAME
 from iPhoto.cache.index_store import get_global_repository, reset_global_repository
@@ -33,6 +34,14 @@ def _make_vm(*, library_root: Path | None = None):
 def _face_repository(library_root: Path) -> FaceRepository:
     faces_root = library_root / ".iPhoto" / "faces"
     return FaceRepository(faces_root / "face_index.db", faces_root / "face_state.db")
+
+
+@pytest.fixture(autouse=True)
+def _stub_location_names(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "iPhoto.library.geo_aggregator.resolve_location_name",
+        lambda gps: f"{gps.get('lat')},{gps.get('lon')}",
+    )
 
 
 def test_open_album_loads_recursive_album_query(tmp_path: Path) -> None:
@@ -138,6 +147,120 @@ def test_return_to_map_from_singleton_location_cluster_reuses_snapshot(tmp_path:
 
     assert routes == ["map"]
     assert map_payloads == [(assets, tmp_path)]
+
+
+def test_location_scan_chunk_updates_map_snapshot_incrementally(tmp_path: Path) -> None:
+    vm, _store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    existing = SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [existing])
+    vm.location_session.set_mode("map")
+
+    payloads = []
+    vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
+
+    vm.handle_location_scan_chunk(
+        tmp_path / "Album",
+        [
+            {
+                "rel": "Album/new.jpg",
+                "id": "asset-2",
+                "gps": {"lat": 52.5, "lon": 13.4},
+                "mime": "image/jpeg",
+                "parent_album_path": "Album",
+            }
+        ],
+    )
+
+    snapshot = vm.location_session.full_assets()
+    assert [asset.library_relative for asset in snapshot] == ["Album/new.jpg", "a.jpg"]
+    assert payloads[-1] == (snapshot, tmp_path)
+
+
+def test_location_scan_chunk_removes_assets_that_no_longer_qualify(tmp_path: Path) -> None:
+    vm, _store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    existing = SimpleNamespace(library_relative="Album/new.jpg", absolute_path=tmp_path / "Album" / "new.jpg")
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [existing])
+    vm.location_session.set_mode("map")
+
+    payloads = []
+    vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
+
+    vm.handle_location_scan_chunk(
+        tmp_path / "Album",
+        [{"rel": "Album/new.jpg", "id": "asset-2", "live_role": 1}],
+    )
+
+    snapshot = vm.location_session.full_assets()
+    assert snapshot == []
+    assert payloads[-1] == (snapshot, tmp_path)
+
+
+def test_location_scan_chunk_updates_snapshot_without_refreshing_cluster_gallery(tmp_path: Path) -> None:
+    vm, _store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [])
+    vm.location_session.set_mode("cluster_gallery")
+
+    payloads = []
+    vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
+
+    vm.handle_location_scan_chunk(
+        tmp_path,
+        [
+            {
+                "rel": "Album/new.jpg",
+                "id": "asset-2",
+                "gps": {"lat": 52.5, "lon": 13.4},
+                "mime": "image/jpeg",
+                "parent_album_path": "Album",
+            }
+        ],
+    )
+
+    assert payloads == []
+    assert vm.location_session.resolve_asset("Album/new.jpg") is not None
+
+
+def test_location_scan_finished_rebuilds_snapshot_and_refreshes_map(tmp_path: Path) -> None:
+    vm, _store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    existing = SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")
+    refreshed = SimpleNamespace(library_relative="Album/final.jpg", absolute_path=tmp_path / "Album" / "final.jpg")
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [existing])
+    vm.location_session.set_mode("map")
+    context.library.get_geotagged_assets.return_value = [refreshed]
+
+    payloads = []
+    vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
+
+    vm.handle_location_scan_finished(tmp_path / "Album", True)
+
+    snapshot = vm.location_session.full_assets()
+    assert snapshot == [refreshed]
+    assert payloads[-1] == (snapshot, tmp_path)
+
+
+def test_location_scan_updates_ignore_unrelated_scan_roots(tmp_path: Path) -> None:
+    vm, _store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    serial = vm.location_session.begin_load(tmp_path)
+    assert vm.location_session.accept_loaded(serial, tmp_path, [])
+    vm.location_session.set_mode("map")
+    context.library.get_geotagged_assets.return_value = [SimpleNamespace(library_relative="x.jpg")]
+
+    payloads = []
+    vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
+
+    other_root = tmp_path.parent / "OtherLibrary"
+    vm.handle_location_scan_chunk(
+        other_root,
+        [{"rel": "Album/new.jpg", "gps": {"lat": 52.5, "lon": 13.4}, "mime": "image/jpeg"}],
+    )
+    vm.handle_location_scan_finished(other_root, True)
+
+    assert payloads == []
+    assert vm.location_session.full_assets() == []
 
 
 def test_open_people_dashboard_routes_to_people_view(tmp_path: Path) -> None:

--- a/tests/test_library_geotagged_assets.py
+++ b/tests/test_library_geotagged_assets.py
@@ -118,3 +118,78 @@ def test_geotagged_assets_reuse_cached_rows_until_library_changes(
 
     assert repo.calls == 1
     assert first == second
+
+
+def test_scan_chunk_invalidates_geotagged_cache(tmp_path: Path) -> None:
+    root = tmp_path / "Library"
+    album = root / "Album"
+    album.mkdir(parents=True, exist_ok=True)
+    _write_album_manifest(album)
+
+    row = {
+        "rel": "Album/photo.jpg",
+        "gps": {"lat": 10.0, "lon": 20.0},
+        "mime": "image/jpeg",
+        "id": "asset-1",
+        "parent_album_path": "Album",
+    }
+
+    class _Repo:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def read_geotagged(self):
+            self.calls += 1
+            return [row]
+
+    repo = _Repo()
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    with (
+        patch("iPhoto.library.geo_aggregator.get_global_repository", return_value=repo),
+        patch("iPhoto.library.geo_aggregator.resolve_location_name", return_value=None),
+    ):
+        manager.get_geotagged_assets()
+        manager._on_scan_chunk(root, [{"rel": "Album/new.jpg", "id": "asset-2"}])
+        manager.get_geotagged_assets()
+
+    assert repo.calls == 2
+
+
+def test_scan_finished_invalidates_geotagged_cache(tmp_path: Path) -> None:
+    root = tmp_path / "Library"
+    album = root / "Album"
+    album.mkdir(parents=True, exist_ok=True)
+    _write_album_manifest(album)
+
+    row = {
+        "rel": "Album/photo.jpg",
+        "gps": {"lat": 10.0, "lon": 20.0},
+        "mime": "image/jpeg",
+        "id": "asset-1",
+        "parent_album_path": "Album",
+    }
+
+    class _Repo:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def read_geotagged(self):
+            self.calls += 1
+            return [row]
+
+    repo = _Repo()
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    with (
+        patch("iPhoto.library.geo_aggregator.get_global_repository", return_value=repo),
+        patch("iPhoto.library.geo_aggregator.resolve_location_name", return_value=None),
+        patch("iPhoto.library.scan_coordinator.LOGGER.warning"),
+    ):
+        manager.get_geotagged_assets()
+        manager._on_scan_finished(root, [row])
+        manager.get_geotagged_assets()
+
+    assert repo.calls == 2


### PR DESCRIPTION
This pull request implements incremental updates to the location map view during library scans and refactors geotagged asset extraction for improved testability and maintainability. It introduces new methods for efficiently updating the set of map assets in response to scan events, ensures the UI remains in sync with the underlying data, and adds comprehensive tests to verify this behavior.

**Incremental location map updates and event handling:**

* The `GalleryViewModel` now handles `scanChunkReady` and `scanFinished` signals from the library to incrementally update and refresh the set of geotagged assets shown on the map, without requiring a full reload after every scan chunk. This is achieved via the new `handle_location_scan_chunk` and `handle_location_scan_finished` methods, which update the session snapshot and emit `map_assets_changed` only when appropriate. [[1]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR387-R388) [[2]](diffhunk://#diff-7c9bafce976fc2f04d1329994d947f985354b350806378246b022044a1e1978dR318-R348) [[3]](diffhunk://#diff-7c9bafce976fc2f04d1329994d947f985354b350806378246b022044a1e1978dR459-R470)
* The `LocationSelectionSession` class adds `replace_assets`, `upsert_asset`, and `remove_asset` methods to efficiently manage the set of assets as scan results stream in. These methods ensure the session state remains consistent and only emit changes when necessary.

**Geo-aggregator refactor and cache management:**

* Refactors geotagged asset extraction logic into a new `_geotagged_asset_from_row` function, making it easier to test and maintain. The `GeoAggregatorMixin.get_geotagged_assets` method now uses this function and properly deduplicates assets by absolute path. [[1]](diffhunk://#diff-a2237301b5ec91838b145040f586f4d6f8370fa2de8c185325576186400edf30L55-L145) [[2]](diffhunk://#diff-a2237301b5ec91838b145040f586f4d6f8370fa2de8c185325576186400edf30L160-R128) [[3]](diffhunk://#diff-a2237301b5ec91838b145040f586f4d6f8370fa2de8c185325576186400edf30L177-R181)
* Ensures the geotagged assets cache is invalidated on every scan chunk and scan finish event, so that future queries reflect the latest data.

**Testing improvements:**

* Adds comprehensive tests to verify incremental map updates, removal of assets that no longer qualify, correct refresh behavior, and that scan events are only handled for the relevant library root.
* Adds a test to confirm that the main coordinator wires up the new scan update signals correctly.
* Introduces a pytest fixture to stub out location name resolution for deterministic test results.

**Dependency and import updates:**

* Updates imports to use the new `_geotagged_asset_from_row` function.
* Adds `pytest` as a test dependency in test modules.

These changes collectively improve the responsiveness and reliability of the location map feature during library scans, and make the codebase easier to test and extend.