### PR TITLE
Implement index pruning and enhance link synchronization

### DIFF
--- a/src/iPhoto/app.py
+++ b/src/iPhoto/app.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sqlite3
-from typing import Callable, List, Optional
+from collections.abc import Callable
+from pathlib import Path
 
 from .cache.index_store import get_global_repository
 from .config import (
@@ -12,18 +12,14 @@ from .config import (
     DEFAULT_INCLUDE,
 )
 from .errors import IndexCorruptedError, ManifestInvalidError
-from .index_sync_service import (
-    compute_links_payload as _compute_links_payload,
-    ensure_links as _ensure_links,
-    load_incremental_index_cache,
-    sync_live_roles_to_db as _sync_live_roles_to_db,
-    update_index_snapshot as _update_index_snapshot,
-    write_links as _write_links,
-)
+from .index_sync_service import ensure_links as _ensure_links
+from .index_sync_service import load_incremental_index_cache
+from .index_sync_service import prune_index_scope as _prune_index_scope
+from .index_sync_service import sync_live_roles_to_db as _sync_live_roles_to_db_impl
+from .index_sync_service import update_index_snapshot as _update_index_snapshot
 from .models.album import Album
 from .models.types import LiveGroup
 from .path_normalizer import compute_album_path as _compute_album_path
-from .path_normalizer import normalise_rel_key as _normalise_rel_key
 from .utils.logging import get_logger
 
 LOGGER = get_logger()
@@ -35,10 +31,20 @@ def _is_index_recoverable_error(exc: Exception) -> bool:
     return isinstance(exc, (sqlite3.Error, IndexCorruptedError, ManifestInvalidError))
 
 
+def _sync_live_roles_to_db(
+    root: Path,
+    groups: list[LiveGroup],
+    library_root: Path | None = None,
+) -> None:
+    """Backward-compatible wrapper around the index sync helper."""
+
+    _sync_live_roles_to_db_impl(root, groups, library_root=library_root)
+
+
 def open_album(
     root: Path,
     autoscan: bool = True,
-    library_root: Optional[Path] = None,
+    library_root: Path | None = None,
     *,
     hydrate_index: bool = True,
 ) -> Album:
@@ -151,9 +157,9 @@ def open_album(
 
 def rescan(
     root: Path,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
-    library_root: Optional[Path] = None,
-) -> List[dict]:
+    progress_callback: Callable[[int, int], None] | None = None,
+    library_root: Path | None = None,
+) -> list[dict]:
     """Rescan the album and return the fresh index rows.
     
     Args:
@@ -190,6 +196,7 @@ def rescan(
                 row["rel"] = f"{album_path}/{row['rel']}"
     
     _update_index_snapshot(root, rows, library_root=library_root)
+    _prune_index_scope(root, rows, library_root=library_root)
     
     # For _ensure_links, we need album-relative rows
     if album_path:
@@ -215,7 +222,7 @@ def rescan(
 
 
 def scan_specific_files(
-    root: Path, files: List[Path], library_root: Optional[Path] = None
+    root: Path, files: list[Path], library_root: Path | None = None
 ) -> None:
     """Generate index rows for specific files and merge them into the index.
 
@@ -241,17 +248,17 @@ def scan_specific_files(
     # Actually, process_media_paths takes image_paths and video_paths.
 
     # We will just categorize them here.
-    image_paths: List[Path] = []
-    video_paths: List[Path] = []
+    image_paths: list[Path] = []
+    video_paths: list[Path] = []
 
     # Minimal set of extensions matching scanner.py
-    _IMAGE_EXTENSIONS = {".heic", ".heif", ".heifs", ".heicf", ".jpg", ".jpeg", ".png"}
-    _VIDEO_EXTENSIONS = {".mov", ".mp4", ".m4v", ".qt"}
+    image_extensions = {".heic", ".heif", ".heifs", ".heicf", ".jpg", ".jpeg", ".png"}
+    video_extensions = {".mov", ".mp4", ".m4v", ".qt"}
 
     for f in files:
-        if f.suffix.lower() in _IMAGE_EXTENSIONS:
+        if f.suffix.lower() in image_extensions:
             image_paths.append(f)
-        elif f.suffix.lower() in _VIDEO_EXTENSIONS:
+        elif f.suffix.lower() in video_extensions:
             video_paths.append(f)
 
     rows = list(process_media_paths(root, image_paths, video_paths))
@@ -271,7 +278,7 @@ def scan_specific_files(
     store.merge_scan_rows(rows)
 
 
-def pair(root: Path, library_root: Optional[Path] = None) -> List[LiveGroup]:
+def pair(root: Path, library_root: Path | None = None) -> list[LiveGroup]:
     """Rebuild live photo pairings from the current index.
     
     Args:
@@ -308,11 +315,5 @@ def pair(root: Path, library_root: Optional[Path] = None) -> List[LiveGroup]:
         rows = album_rows
     else:
         rows = list(get_global_repository(db_root).read_all())
-    
-    groups, payload = _compute_links_payload(rows)
-    _write_links(root, payload)
 
-    # Also sync to DB
-    _sync_live_roles_to_db(root, groups, library_root=library_root)
-
-    return groups
+    return _ensure_links(root, rows, library_root=library_root)

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -6,48 +6,46 @@ This replaces the legacy MainController as the top-level orchestrator.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import (
-    QObject,
-    QThreadPool,
-    QModelIndex,
-    QItemSelectionModel,
     QCoreApplication,
+    QItemSelectionModel,
+    QModelIndex,
+    QObject,
     Qt,
+    QThreadPool,
 )
 from PySide6.QtGui import QAction
 
+from iPhoto import app as backend
 from iPhoto.application.contracts.runtime_entry_contract import RuntimeEntryContract
-from iPhoto.gui.ui.models.roles import Roles
-from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
-from iPhoto.gui.ui.controllers.dialog_controller import DialogController
-from iPhoto.gui.ui.controllers.header_controller import HeaderController
-from iPhoto.gui.ui.controllers.share_controller import ShareController
-from iPhoto.gui.ui.controllers.status_bar_controller import StatusBarController
-from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeController
-from iPhoto.gui.ui.controllers.preview_controller import PreviewController
-from iPhoto.gui.ui.controllers.context_menu_controller import ContextMenuController
-from iPhoto.gui.ui.controllers.selection_controller import SelectionController
-from iPhoto.gui.ui.controllers.export_controller import ExportController
-from iPhoto.gui.ui.media import MediaAdjustmentCommitter, MediaSelectionSession
-from iPhoto.gui.ui.widgets.asset_delegate import AssetGridDelegate
-
-# New Architecture Imports
 from iPhoto.application.services.asset_service import AssetService
 from iPhoto.di.container import DependencyContainer
 from iPhoto.events.bus import EventBus
+from iPhoto.gui.coordinators.edit_coordinator import EditCoordinator
+from iPhoto.gui.coordinators.navigation_coordinator import NavigationCoordinator
+from iPhoto.gui.coordinators.playback_coordinator import PlaybackCoordinator
+from iPhoto.gui.coordinators.view_router import ViewRouter
+from iPhoto.gui.ui.controllers.context_menu_controller import ContextMenuController
+from iPhoto.gui.ui.controllers.dialog_controller import DialogController
+from iPhoto.gui.ui.controllers.export_controller import ExportController
+from iPhoto.gui.ui.controllers.header_controller import HeaderController
+from iPhoto.gui.ui.controllers.preview_controller import PreviewController
+from iPhoto.gui.ui.controllers.selection_controller import SelectionController
+from iPhoto.gui.ui.controllers.share_controller import ShareController
+from iPhoto.gui.ui.controllers.status_bar_controller import StatusBarController
+from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeController
+from iPhoto.gui.ui.media import MediaAdjustmentCommitter, MediaSelectionSession
+from iPhoto.gui.ui.models.roles import Roles
+from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
+from iPhoto.gui.ui.widgets.asset_delegate import AssetGridDelegate
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailViewModel
 from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAdapter
 from iPhoto.gui.viewmodels.gallery_viewmodel import GalleryViewModel
 from iPhoto.people.service import PeopleService
-
-# New Coordinators
-from iPhoto.gui.coordinators.view_router import ViewRouter
-from iPhoto.gui.coordinators.navigation_coordinator import NavigationCoordinator
-from iPhoto.gui.coordinators.playback_coordinator import PlaybackCoordinator
-from iPhoto.gui.coordinators.edit_coordinator import EditCoordinator
 
 if TYPE_CHECKING:
     from iPhoto.gui.ui.main_window import MainWindow
@@ -72,6 +70,7 @@ class MainCoordinator(QObject):
         # facade reference kept for signal wiring as some systems still emit through it
         self._facade = context.facade
         self._logger = logging.getLogger(__name__)
+        self._media_failure_cleanup_paths: set[str] = set()
 
         # Resolve Services
         if self._container:
@@ -400,6 +399,8 @@ class MainCoordinator(QObject):
 
         # Coordinator Signals
         self._playback.assetChanged.connect(self._sync_selection)
+        self._player_view_controller.imageLoadingFailed.connect(self._handle_media_load_failed)
+        ui.video_area.mediaLoadFailed.connect(self._handle_media_load_failed)
 
         # Viewer Interactions (Wheel Navigation)
         ui.image_viewer.nextItemRequested.connect(self._playback.select_next)
@@ -521,6 +522,45 @@ class MainCoordinator(QObject):
         if playback is not None:
             playback.set_people_library_root(root)
 
+    def _handle_media_load_failed(self, path: Path, message: str) -> None:
+        path_key = str(path)
+        if path_key in self._media_failure_cleanup_paths:
+            return
+
+        self._media_failure_cleanup_paths.add(path_key)
+        try:
+            self._dialog.show_error(f"File not found or unreadable: {path.name}\n\n{message}")
+
+            repository = self._context.asset_runtime.repository
+            asset = repository.get_by_path(path)
+            if asset is None:
+                return
+
+            repository.delete(asset.id)
+
+            library_root = self._context.library.root()
+            pair_root: Path | None = None
+            if library_root is not None:
+                try:
+                    path.resolve().relative_to(library_root.resolve())
+                except (OSError, ValueError):
+                    pair_root = None
+                else:
+                    pair_root = path.parent if path.parent != library_root else library_root
+            if pair_root is not None and library_root is not None:
+                try:
+                    backend.pair(pair_root, library_root=library_root)
+                except Exception:  # noqa: BLE001 - best-effort derived snapshot refresh
+                    self._logger.warning(
+                        "Failed to refresh live pairing after removing %s",
+                        path,
+                        exc_info=True,
+                    )
+
+            self._gallery_store.reload_current_selection()
+        finally:
+            self._media_failure_cleanup_paths.discard(path_key)
+
     def _on_asset_clicked(self, index: QModelIndex):
         if self._selection_controller and self._selection_controller.is_active():
             return
@@ -605,7 +645,7 @@ class MainCoordinator(QObject):
         # 2. Volume / Mute
         stored_volume = settings.get("ui.volume", 75)
         try:
-            initial_volume = int(round(float(stored_volume)))
+            initial_volume = round(float(stored_volume))
         except (TypeError, ValueError):
             initial_volume = 75
         initial_volume = max(0, min(100, initial_volume))
@@ -656,10 +696,7 @@ class MainCoordinator(QObject):
         try:
             return str(path.resolve())
         except OSError:
-            try:
-                return str(Path(path))
-            except Exception:
-                return None
+            return str(path)
 
     # --- Public Accessors for Window ---
     def toggle_playback(self):

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import time
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -351,6 +352,8 @@ class PlaybackCoordinator(QObject):
                 is_video=presentation.is_video,
             )
         previous = self._current_presentation
+        if previous is not None:
+            presentation = self._preserve_live_presentation(previous, presentation)
         self._current_presentation = presentation
         row = presentation.row
         self._asset_model.set_current_row(row)
@@ -373,6 +376,43 @@ class PlaybackCoordinator(QObject):
             self._clear_play_profile(presentation.row)
             return
         self._render_presentation(presentation)
+
+    def _preserve_live_presentation(
+        self,
+        previous: DetailPresentation,
+        current: DetailPresentation,
+    ) -> DetailPresentation:
+        """Keep Live replay metadata stable across same-asset refreshes.
+
+        During rescans the same asset may briefly refresh through a partial row
+        that has not yet been re-paired. When the previous Live motion file
+        still exists on disk, preserve that replay state for the currently
+        displayed asset instead of transiently degrading it to a still image.
+        """
+
+        if previous.row != current.row or previous.path != current.path:
+            return current
+        if current.is_live and current.live_motion_abs is not None:
+            return current
+        if not previous.is_live or previous.live_motion_abs is None:
+            return current
+        try:
+            if not previous.live_motion_abs.exists():
+                return current
+        except OSError:
+            return current
+
+        info = dict(current.info)
+        if previous.live_motion_rel is not None:
+            info.setdefault("live_partner_rel", str(previous.live_motion_rel))
+
+        return replace(
+            current,
+            is_live=True,
+            info=info,
+            live_motion_rel=previous.live_motion_rel,
+            live_motion_abs=previous.live_motion_abs,
+        )
 
     def _render_presentation(self, presentation: DetailPresentation) -> None:
         render_started = time.perf_counter()

--- a/src/iPhoto/gui/services/library_update_service.py
+++ b/src/iPhoto/gui/services/library_update_service.py
@@ -460,6 +460,7 @@ class LibraryUpdateService(QObject):
             # therefore we flush the global index and ``links.json`` here to
             # mirror the historical facade behaviour before notifying listeners.
             backend._update_index_snapshot(root, materialised_rows, library_root=library_root)
+            backend._prune_index_scope(root, materialised_rows, library_root=library_root)
             backend._ensure_links(root, materialised_rows, library_root=library_root)
         except IPhotoError as exc:
             self.errorRaised.emit(str(exc))

--- a/src/iPhoto/gui/services/library_update_service.py
+++ b/src/iPhoto/gui/services/library_update_service.py
@@ -461,7 +461,12 @@ class LibraryUpdateService(QObject):
             # mirror the historical facade behaviour before notifying listeners.
             backend._update_index_snapshot(root, materialised_rows, library_root=library_root)
             backend._prune_index_scope(root, materialised_rows, library_root=library_root)
-            backend._ensure_links(root, materialised_rows, library_root=library_root)
+            # Use backend.pair() so that library-relative rows produced by the
+            # worker are converted to album-relative before being passed to
+            # _ensure_links.  Calling _ensure_links directly with library-relative
+            # rows when library_root is set causes sync_live_roles_to_db to
+            # double-prefix the rel paths (e.g. "album/album/photo.heic").
+            backend.pair(root, library_root=library_root)
         except IPhotoError as exc:
             self.errorRaised.emit(str(exc))
             self.scanFinished.emit(root, False)

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -82,6 +82,7 @@ class VideoArea(QWidget):
     fullscreenExitRequested = Signal()
     playbackStateChanged = Signal(bool)
     playbackFinished = Signal()
+    mediaLoadFailed = Signal(Path, str)
     nextItemRequested = Signal()
     prevItemRequested = Signal()
     positionChanged = Signal(int)
@@ -188,6 +189,7 @@ class VideoArea(QWidget):
         self._player.durationChanged.connect(self._on_duration_changed)
         self._player.playbackStateChanged.connect(self._on_playback_state_changed)
         self._player.mediaStatusChanged.connect(self._on_media_status_changed)
+        self._player.errorOccurred.connect(self._on_error_occurred)
         # --- End Media Player Setup ---
 
         self._overlay_margin = 48
@@ -1024,6 +1026,15 @@ class VideoArea(QWidget):
                 end_pos=int(duration),
                 hold_pos=max(0, int(duration) - VIDEO_COMPLETE_HOLD_BACKSTEP_MS),
             )
+
+    def _on_error_occurred(self, _error: object, message: str) -> None:
+        source = self._current_source
+        if source is None:
+            return
+        detail = message.strip() if isinstance(message, str) and message.strip() else (
+            "An unknown media playback error occurred."
+        )
+        self.mediaLoadFailed.emit(source, detail)
 
     def _display_position(self, position: int) -> int:
         """Return the timeline position that should be exposed to the UI."""

--- a/src/iPhoto/index_sync_service.py
+++ b/src/iPhoto/index_sync_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from .cache.index_store import get_global_repository
 from .cache.lock import FileLock
@@ -110,30 +110,33 @@ def update_index_snapshot(
 
 def ensure_links(
     root: Path, rows: List[dict], library_root: Optional[Path] = None
-) -> None:
-    """Ensure links.json and DB are synchronized with the given rows.
+) -> List[LiveGroup]:
+    """Ensure DB live-role state is current and refresh the derived links snapshot.
     
     Args:
         root: The album root directory.
         rows: List of asset rows (with album-relative paths).
         library_root: If provided, use this as the database root.
     """
+    groups, payload = compute_links_payload(rows)
+    sync_live_roles_to_db(root, groups, library_root=library_root)
+
     work_dir = root / WORK_DIR_NAME
     links_path = work_dir / "links.json"
-    groups, payload = compute_links_payload(rows)
-
     if links_path.exists():
         try:
             existing: Dict[str, object] = read_json(links_path)
         except ManifestInvalidError:
             existing = {}
         if existing == payload:
-            sync_live_roles_to_db(root, groups, library_root=library_root)
-            return
+            return groups
 
     LOGGER.info("Updating links.json for %s", root)
-    write_links(root, payload)
-    sync_live_roles_to_db(root, groups, library_root=library_root)
+    try:
+        write_links(root, payload)
+    except Exception as exc:  # pragma: no cover - derived snapshot failure must not break runtime state
+        LOGGER.warning("Failed to update derived links.json for %s: %s", root, exc)
+    return groups
 
 
 def compute_links_payload(rows: List[dict]) -> tuple[List[LiveGroup], Dict[str, object]]:
@@ -191,10 +194,61 @@ def sync_live_roles_to_db(
         store.apply_live_role_updates(updates)
 
 
+def prune_index_scope(
+    root: Path,
+    materialised_rows: Iterable[dict],
+    library_root: Optional[Path] = None,
+) -> int:
+    """Delete rows under *root* that were not rediscovered by the completed scan.
+
+    Scans remain additive-only at the low-level merge layer. This helper applies
+    deletion semantics explicitly at the rescan boundary, scoped strictly to the
+    completed scan root so sibling albums remain untouched.
+    """
+
+    db_root = library_root if library_root else root
+    store = get_global_repository(db_root)
+    album_path = compute_album_path(root, library_root)
+
+    fresh_rels = {
+        rel_key
+        for rel_key in (
+            normalise_rel_key(row.get("rel"))
+            for row in materialised_rows
+        )
+        if rel_key is not None
+    }
+
+    if album_path:
+        scoped_rows = store.read_album_assets(
+            album_path,
+            include_subalbums=True,
+            sort_by_date=False,
+            filter_hidden=False,
+        )
+    else:
+        scoped_rows = store.read_all(sort_by_date=False, filter_hidden=False)
+
+    removable: List[str] = []
+    for row in scoped_rows:
+        rel_key = normalise_rel_key(row.get("rel"))
+        if rel_key is None:
+            continue
+        if rel_key not in fresh_rels:
+            removable.append(rel_key)
+
+    if not removable:
+        return 0
+
+    store.remove_rows(removable)
+    return len(removable)
+
+
 __all__ = [
     "compute_links_payload",
     "ensure_links",
     "load_incremental_index_cache",
+    "prune_index_scope",
     "sync_live_roles_to_db",
     "update_index_snapshot",
     "write_links",

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -276,16 +276,30 @@ class ScanCoordinatorMixin:
         # Clear worker reference before downstream listeners react so a completed
         # scan does not still appear in-flight while final post-processing runs.
         locker = QMutexLocker(self._scan_buffer_lock)
+        worker = self._current_scanner_worker
         self._current_scanner_worker = None
         face_scanner = self._current_face_scanner
         del locker
+
+        if worker is None:
+            if self._live_scan_root is None:
+                self.scanFinished.emit(root, True)
+            return
         if face_scanner is not None:
             face_scanner.finish_input()
+
+        if worker.cancelled:
+            self.scanFinished.emit(root, True)
+            return
+        if worker.failed:
+            self.scanFinished.emit(root, False)
+            return
 
         # Persist Live Photo pairings once a scan completes so the database and
         # links.json reflect the latest scan results.
         try:
             from .. import app as backend
+            backend._prune_index_scope(root, rows, library_root=self._root)
             backend.pair(root, library_root=self._root)
         except Exception as exc:
             LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -310,7 +310,7 @@ class ScanCoordinatorMixin:
             face_scanner.finish_input()
 
         if worker.cancelled:
-            self.scanFinished.emit(root, True)a
+            self.scanFinished.emit(root, True)
             return
         if worker.failed:
             self.scanFinished.emit(root, False)

--- a/src/iPhoto/library/workers/scanner_worker.py
+++ b/src/iPhoto/library/workers/scanner_worker.py
@@ -128,7 +128,10 @@ class ScannerWorker(QRunnable):
             chunk: List[dict] = []
 
             # Load existing index for incremental scanning
-            existing_index = load_incremental_index_cache(self._library_root)
+            existing_index = load_incremental_index_cache(
+                self._root,
+                library_root=self._library_root,
+            )
 
             # The new scan_album implementation handles parallel discovery and processing.
             # We initialize the generator but execution (and thread starting) happens on iteration.

--- a/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
+++ b/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from iPhoto.gui.coordinators.main_coordinator import MainCoordinator
 
@@ -92,6 +93,7 @@ def test_connect_signals_wires_location_scan_updates_from_library() -> None:
     coordinator._status_bar = MagicMock()
     coordinator._asset_list_vm = MagicMock()
     coordinator._playback = MagicMock()
+    coordinator._player_view_controller = MagicMock()
     coordinator._detail_vm = MagicMock()
     coordinator._navigation = MagicMock()
     coordinator._dialog = MagicMock()
@@ -118,3 +120,30 @@ def test_connect_signals_wires_location_scan_updates_from_library() -> None:
     coordinator._context.library.scanFinished.connect.assert_any_call(
         coordinator._gallery_vm.handle_location_scan_finished
     )
+
+
+def test_handle_media_load_failed_prunes_row_and_refreshes_collection(tmp_path: Path) -> None:
+    coordinator = MainCoordinator.__new__(MainCoordinator)
+    library_root = tmp_path / "library"
+    library_root.mkdir()
+    failed_path = library_root / "Album" / "motion.mov"
+    failed_path.parent.mkdir(parents=True)
+
+    repository = MagicMock()
+    repository.get_by_path.return_value = SimpleNamespace(id="asset-1")
+
+    coordinator._media_failure_cleanup_paths = set()
+    coordinator._dialog = MagicMock()
+    coordinator._gallery_store = MagicMock()
+    coordinator._logger = MagicMock()
+    coordinator._context = MagicMock()
+    coordinator._context.asset_runtime.repository = repository
+    coordinator._context.library.root.return_value = library_root
+
+    with patch("iPhoto.gui.coordinators.main_coordinator.backend.pair") as pair_mock:
+        coordinator._handle_media_load_failed(failed_path, "decoder failed")
+
+    coordinator._dialog.show_error.assert_called_once()
+    repository.delete.assert_called_once_with("asset-1")
+    pair_mock.assert_called_once_with(failed_path.parent, library_root=library_root)
+    coordinator._gallery_store.reload_current_selection.assert_called_once_with()

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -160,6 +160,34 @@ def test_handle_presentation_changed_rerenders_same_asset_when_reload_token_chan
     coordinator._clear_play_profile.assert_not_called()
 
 
+def test_preserve_live_presentation_keeps_existing_motion_during_same_asset_refresh(
+    tmp_path: Path,
+) -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    motion_path = tmp_path / "motion.mov"
+    motion_path.write_bytes(b"\x00")
+
+    previous = DetailPresentation(
+        **{
+            **_make_presentation(path="/fake/photo.heic", is_video=False, is_live=True).__dict__,
+            "live_motion_rel": Path("motion.mov"),
+            "live_motion_abs": motion_path,
+        }
+    )
+    current = _make_presentation(path="/fake/photo.heic", is_video=False, is_live=False)
+
+    preserved = PlaybackCoordinator._preserve_live_presentation(
+        coordinator,
+        previous,
+        current,
+    )
+
+    assert preserved.is_live is True
+    assert preserved.live_motion_abs == motion_path
+    assert preserved.live_motion_rel == Path("motion.mov")
+    assert preserved.info["live_partner_rel"] == "motion.mov"
+
+
 def test_handle_rotate_requested_routes_video_rotation_through_video_area() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
     coordinator._adjustment_committer = Mock(commit=Mock(return_value=True))

--- a/tests/test_app_live_sync.py
+++ b/tests/test_app_live_sync.py
@@ -1,11 +1,25 @@
 
-import pytest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+
+import pytest
+
+from iPhoto import app as backend
 from iPhoto.app import _sync_live_roles_to_db
-from iPhoto.models.types import LiveGroup
-from iPhoto.cache.index_store import IndexStore
+from iPhoto.cache.index_store import (
+    IndexStore,
+    get_global_repository,
+    reset_global_repository,
+)
 from iPhoto.config import WORK_DIR_NAME
+from iPhoto.models.types import LiveGroup
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_repo() -> None:
+    reset_global_repository()
+    yield
+    reset_global_repository()
 
 @pytest.fixture
 def temp_album(tmp_path):
@@ -122,3 +136,44 @@ def test_sync_live_roles_scoped_to_library_prefix(tmp_path):
     assert data["album/photo.jpg"]["live_partner_rel"] == "album/video.mov"
     assert data["album/video.mov"]["live_partner_rel"] == "album/photo.jpg"
     assert data["other/keep.jpg"]["live_role"] == 1
+
+
+def test_pair_keeps_db_live_roles_when_derived_snapshot_write_fails(tmp_path: Path) -> None:
+    album_root = tmp_path / "album"
+    album_root.mkdir()
+    (album_root / WORK_DIR_NAME).mkdir()
+
+    store = get_global_repository(album_root)
+    store.write_rows(
+        [
+            {
+                "rel": "photo.heic",
+                "id": "photo",
+                "mime": "image/heic",
+                "content_id": "CID-1",
+                "dt": "2024-01-01T00:00:00Z",
+            },
+            {
+                "rel": "motion.mov",
+                "id": "motion",
+                "mime": "video/quicktime",
+                "content_id": "CID-1",
+                "dt": "2024-01-01T00:00:00Z",
+                "dur": 1.5,
+            },
+            {"rel": "other.jpg", "id": "other"},
+        ]
+    )
+
+    with patch(
+        "iPhoto.index_sync_service.write_links",
+        side_effect=RuntimeError("disk full"),
+    ):
+        groups = backend.pair(album_root)
+
+    assert len(groups) == 1
+    data = {row["rel"]: row for row in store.read_all(filter_hidden=False)}
+    assert data["photo.heic"]["live_partner_rel"] == "motion.mov"
+    assert data["motion.mov"]["live_partner_rel"] == "photo.heic"
+    assert data["motion.mov"]["live_role"] == 1
+    assert data["other.jpg"]["live_partner_rel"] is None

--- a/tests/test_index_sync_service.py
+++ b/tests/test_index_sync_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from iPhoto.cache.index_store import get_global_repository, reset_global_repository
+from iPhoto.index_sync_service import ensure_links, prune_index_scope
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_repo() -> None:
+    reset_global_repository()
+    yield
+    reset_global_repository()
+
+
+def test_prune_index_scope_removes_only_rows_within_scan_prefix(tmp_path: Path) -> None:
+    library_root = tmp_path / "library"
+    album_a = library_root / "album-a"
+    album_b = library_root / "album-b"
+    album_a.mkdir(parents=True)
+    album_b.mkdir(parents=True)
+
+    store = get_global_repository(library_root)
+    store.write_rows(
+        [
+            {"rel": "album-a/keep.jpg", "id": "keep"},
+            {"rel": "album-a/stale.jpg", "id": "stale"},
+            {"rel": "album-a/motion.mov", "id": "motion", "live_role": 1},
+            {"rel": "album-b/other.jpg", "id": "other"},
+        ]
+    )
+
+    removed = prune_index_scope(
+        album_a,
+        [{"rel": "album-a/keep.jpg", "id": "keep"}],
+        library_root=library_root,
+    )
+
+    assert removed == 2
+    remaining = {row["rel"] for row in store.read_all(filter_hidden=False)}
+    assert remaining == {"album-a/keep.jpg", "album-b/other.jpg"}
+
+
+def test_ensure_links_keeps_db_live_roles_when_derived_snapshot_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    album_root = tmp_path / "album"
+    album_root.mkdir()
+
+    store = get_global_repository(album_root)
+    store.write_rows(
+        [
+            {"rel": "photo.heic", "id": "photo"},
+            {"rel": "motion.mov", "id": "motion"},
+            {"rel": "other.jpg", "id": "other"},
+        ]
+    )
+
+    rows = [
+        {
+            "rel": "photo.heic",
+            "mime": "image/heic",
+            "content_id": "CID-1",
+            "dt": "2024-01-01T00:00:00Z",
+        },
+        {
+            "rel": "motion.mov",
+            "mime": "video/quicktime",
+            "content_id": "CID-1",
+            "dt": "2024-01-01T00:00:00Z",
+            "dur": 1.5,
+        },
+    ]
+
+    monkeypatch.setattr(
+        "iPhoto.index_sync_service.write_links",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("disk full")),
+    )
+
+    ensure_links(album_root, rows)
+
+    data = {row["rel"]: row for row in store.read_all(filter_hidden=False)}
+    assert data["photo.heic"]["live_partner_rel"] == "motion.mov"
+    assert data["motion.mov"]["live_partner_rel"] == "photo.heic"
+    assert data["motion.mov"]["live_role"] == 1
+    assert data["other.jpg"]["live_partner_rel"] is None

--- a/tests/test_library_manager.py
+++ b/tests/test_library_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -97,3 +98,29 @@ def test_ensure_manifest_generates_defaults(tmp_path: Path) -> None:
     data = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert data["title"] == "NoManifest"
     assert data["schema"] == "iPhoto/album@1"
+
+
+def test_scan_finished_skips_prune_when_worker_failed(tmp_path: Path, qapp: QApplication) -> None:
+    root = tmp_path / "Library"
+    root.mkdir()
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    class _Worker:
+        cancelled = False
+        failed = True
+
+    spy = QSignalSpy(manager.scanFinished)
+    manager._current_scanner_worker = _Worker()
+
+    with (
+        patch("iPhoto.app._prune_index_scope") as prune_mock,
+        patch("iPhoto.app.pair") as pair_mock,
+    ):
+        manager._on_scan_finished(root, [])
+        qapp.processEvents()
+
+    prune_mock.assert_not_called()
+    pair_mock.assert_not_called()
+    assert spy.count() == 1
+    assert spy.at(0)[1] is False


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the iPhoto application's backend and GUI, focusing on better error handling, improved type annotations, and more robust synchronization of live photo pairings. The most significant changes include enhanced error recovery for media loading failures, a more reliable update of live photo pairings, and improved handling of Live Photo presentation during asset refreshes. Additionally, there are various code cleanups and type annotation updates to modernize and clarify the codebase.

**Error Handling and User Experience Improvements:**

* Added robust error handling for media load failures in the GUI: when a media file fails to load, the user is notified, the broken asset is removed from the index, and live photo pairings are refreshed if necessary. This prevents repeated error dialogs and ensures the UI stays in sync with the underlying data. (Fe25bb10L399R522, [[1]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R85) [[2]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R192) [[3]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R1030-R1038)
* Improved the handling of Live Photo presentations so that if a rescan temporarily loses the pairing, the UI preserves the Live state as long as the motion file still exists, providing a smoother user experience during incremental updates. [[1]](diffhunk://#diff-235448618eddf1c66bfb1f83a50d2a8878b889db9695728c4d979be67514b466R355-R356) [[2]](diffhunk://#diff-235448618eddf1c66bfb1f83a50d2a8878b889db9695728c4d979be67514b466R380-R416)

**Backend Synchronization and Refactoring:**

* Refactored the `ensure_links` function to always update the database with live-role state and only update the `links.json` file if necessary, returning the updated live groups for better integration with callers. [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL312-R319) [[2]](diffhunk://#diff-4768faf61c1cdf9ac7462cd5e3009f020cfe648503a7fc4813ec5d7a16caa895L113-R139)
* Added a call to `prune_index_scope` after index updates to remove stale entries, ensuring the index remains consistent with the actual file system state. [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaR199) [[2]](diffhunk://#diff-f2db218de2d7858145a2548197912cd8f630b2b9d41718bd2d8ebb910990f930R463)

**Type Annotation and Code Cleanup:**

* Updated type annotations throughout the backend to use modern Python type hinting (e.g., `list[Path]` instead of `List[Path]`, `Path | None` instead of `Optional[Path]`), and cleaned up imports for clarity and maintainability. [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL5-L26) [[2]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL154-R162) [[3]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL218-R225) [[4]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL244-R261) [[5]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL274-R281)
* Simplified path normalization logic and volume preference restoration in the main coordinator for improved reliability and readability. [[1]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecL608-R648) [[2]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecL659-R699)

These changes collectively improve the reliability, maintainability, and user experience of the application.

---

**References:**  
Fe25bb10L399R522, [[1]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R85) [[2]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R192) [[3]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R1030-R1038) [[4]](diffhunk://#diff-235448618eddf1c66bfb1f83a50d2a8878b889db9695728c4d979be67514b466R355-R356) [[5]](diffhunk://#diff-235448618eddf1c66bfb1f83a50d2a8878b889db9695728c4d979be67514b466R380-R416) [[6]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL312-R319) [[7]](diffhunk://#diff-4768faf61c1cdf9ac7462cd5e3009f020cfe648503a7fc4813ec5d7a16caa895L113-R139) [[8]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaR199) [[9]](diffhunk://#diff-f2db218de2d7858145a2548197912cd8f630b2b9d41718bd2d8ebb910990f930R463) [[10]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL5-L26) [[11]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL154-R162) [[12]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL218-R225) [[13]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL244-R261) [[14]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL274-R281) [[15]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecL608-R648) [[16]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecL659-R699)