### PR TITLE
feat: implement index pruning logic to remove stale rows after rescan…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,10 @@ __marimo__/
 /demo/face-cluster/runtime/
 /demo/face-cluster/state/
 /.codex
+
+# --- auto-added untracked files (by assistant) ---
+# These were untracked when the user requested to add them to .gitignore
+PySide6-OsmAnd-SDK/
+src/iPhoto/extension/models/buffalo_s.zip
+src/iPhoto/extension/models/buffalo_s/
+

--- a/demo/face-cluster/pipeline.py
+++ b/demo/face-cluster/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections import Counter, defaultdict, deque
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -57,11 +58,17 @@ class FaceClusterPipeline:
     def __init__(
         self,
         *,
+        model_root: Path | None = None,
         model_pack: str = "buffalo_s",
         distance_threshold: float = 0.6,
         min_samples: int = 2,
         min_face_size: int = 40,
     ) -> None:
+        self._model_root = (
+            Path(model_root)
+            if model_root is not None
+            else Path(__file__).resolve().parents[2] / "src" / "extension" / "models"
+        )
         self._model_pack = model_pack
         self._distance_threshold = float(distance_threshold)
         self._min_samples = int(min_samples)
@@ -192,11 +199,21 @@ class FaceClusterPipeline:
                 "缺少 insightface 依赖。请先安装 demo 需要的 AI 依赖后再运行。"
             ) from exc
 
+        self._model_root.mkdir(parents=True, exist_ok=True)
+        insightface_root = self._model_root.parent.resolve()
+        os.environ["INSIGHTFACE_HOME"] = str(insightface_root)
         _patch_insightface_alignment_estimate()
         providers = _resolve_execution_providers()
         ctx_id = 0 if "CUDAExecutionProvider" in providers else -1
-        app = FaceAnalysis(name=self._model_pack, providers=providers)
-        app.prepare(ctx_id=ctx_id, det_size=(640, 640))
+        try:
+            app = FaceAnalysis(name=self._model_pack, root=str(insightface_root), providers=providers)
+            app.prepare(ctx_id=ctx_id, det_size=(640, 640))
+        except Exception as exc:
+            raise _build_face_analysis_init_error(
+                model_pack=self._model_pack,
+                model_dir=self._model_root.resolve(),
+                exc=exc,
+            ) from exc
         self._analysis_app = app
         return app
 
@@ -493,6 +510,26 @@ def _key_face_sort_key(face: FaceRecord) -> tuple[float, int]:
 
 def _quantize_value(value: float, step: int) -> int:
     return int(round(float(value) / float(step)) * step)
+
+
+def _build_face_analysis_init_error(
+    *,
+    model_pack: str,
+    model_dir: Path,
+    exc: Exception,
+) -> RuntimeError:
+    reason = str(exc).strip() or exc.__class__.__name__
+    model_pack_dir = model_dir / model_pack
+    if not model_pack_dir.exists():
+        return RuntimeError(
+            f"人脸聚类不可用：InsightFace 模型 '{model_pack}' 尚未缓存到 '{model_pack_dir}'，"
+            f"初始化/下载失败（{reason}）。请先让环境联网下载一次，或把已有的 "
+            f"'{model_pack}' 模型目录复制到这里后重试。"
+        )
+    return RuntimeError(
+        f"人脸聚类不可用：无法从 '{model_pack_dir}' 初始化 InsightFace 模型 "
+        f"'{model_pack}'（{reason}）。"
+    )
 
 
 def _resolve_execution_providers() -> list[str]:

--- a/src/iPhoto/cache/index_store/scan_merge.py
+++ b/src/iPhoto/cache/index_store/scan_merge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, Mapping
 
-from ...people import initial_face_status, normalize_face_status
+from ...people import FACE_STATUS_FAILED, initial_face_status, normalize_face_status
 
 _PRESERVED_SCAN_STATE_FIELDS = (
     "is_favorite",
@@ -46,7 +46,11 @@ def merge_scan_row(
     if existing_row is not None:
         existing_face_status = normalize_face_status(existing_row.get("face_status"))
 
-    if existing_face_status is not None and identity_unchanged:
+    if (
+        existing_face_status is not None
+        and existing_face_status != FACE_STATUS_FAILED
+        and identity_unchanged
+    ):
         merged["face_status"] = existing_face_status
     else:
         merged["face_status"] = initial_face_status(

--- a/src/iPhoto/people/pipeline.py
+++ b/src/iPhoto/people/pipeline.py
@@ -440,8 +440,16 @@ class FaceClusterPipeline:
         _patch_insightface_alignment_estimate()
         providers = _resolve_execution_providers()
         ctx_id = 0 if "CUDAExecutionProvider" in providers else -1
-        app = FaceAnalysis(name=self._model_pack, root=str(insightface_root), providers=providers)
-        app.prepare(ctx_id=ctx_id, det_size=(640, 640))
+        try:
+            app = FaceAnalysis(name=self._model_pack, root=str(insightface_root), providers=providers)
+            app.prepare(ctx_id=ctx_id, det_size=(640, 640))
+        except Exception as exc:
+            raise _build_face_analysis_init_error(
+                feature_name="Face scanning",
+                model_pack=self._model_pack,
+                model_dir=self._model_root.resolve(),
+                exc=exc,
+            ) from exc
         self._analysis_app = app
         return app
 
@@ -852,6 +860,28 @@ def _bbox_diagonal(bbox: tuple[int, int, int, int]) -> float:
 
 def _quantize_value(value: float, step: int) -> int:
     return int(round(float(value) / float(step)) * step)
+
+
+def _build_face_analysis_init_error(
+    *,
+    feature_name: str,
+    model_pack: str,
+    model_dir: Path,
+    exc: Exception,
+) -> RuntimeError:
+    reason = str(exc).strip() or exc.__class__.__name__
+    model_pack_dir = model_dir / model_pack
+    if not model_pack_dir.exists():
+        return RuntimeError(
+            f"{feature_name} unavailable: InsightFace model '{model_pack}' is not cached at "
+            f"'{model_pack_dir}'. Initialization/download failed ({reason}). "
+            f"Allow one download from github.com or copy an existing '{model_pack}' model "
+            f"folder into '{model_dir}', then retry."
+        )
+    return RuntimeError(
+        f"{feature_name} unavailable: failed to initialize InsightFace model "
+        f"'{model_pack}' from '{model_pack_dir}' ({reason})."
+    )
 
 
 def _resolve_execution_providers() -> list[str]:

--- a/tests/cache/test_global_repository.py
+++ b/tests/cache/test_global_repository.py
@@ -200,6 +200,34 @@ class TestGlobalRepositorySingleton:
         assert row["face_status"] == "pending"
         assert row["is_favorite"] == 1
 
+    def test_merge_scan_rows_resets_failed_face_status_for_same_asset(self, tmp_path: Path) -> None:
+        repo = get_global_repository(tmp_path)
+        repo.write_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-photo",
+                    "media_type": 0,
+                    "face_status": "failed",
+                }
+            ]
+        )
+
+        merged_rows = repo.merge_scan_rows(
+            [
+                {
+                    "rel": "album/photo.jpg",
+                    "id": "asset-photo",
+                    "media_type": 0,
+                    "bytes": 456,
+                }
+            ]
+        )
+
+        assert merged_rows[0]["face_status"] == "pending"
+        row = repo.get_rows_by_ids(["asset-photo"])["asset-photo"]
+        assert row["face_status"] == "pending"
+
     def test_merge_scan_rows_preserves_live_role_and_partner_rel_for_changed_asset_id(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_face_cluster_pipeline.py
+++ b/tests/test_face_cluster_pipeline.py
@@ -5,6 +5,7 @@ import sys
 from types import ModuleType
 
 import numpy as np
+import pytest
 
 
 _DEMO_FACE_CLUSTER = os.path.abspath(
@@ -24,6 +25,7 @@ from pipeline import (
 def _face(face_id: str, embedding: np.ndarray, confidence: float) -> FaceRecord:
     return FaceRecord(
         face_id=face_id,
+        face_key=face_id,
         asset_rel=f"{face_id}.jpg",
         box_x=0,
         box_y=0,
@@ -38,6 +40,35 @@ def _face(face_id: str, embedding: np.ndarray, confidence: float) -> FaceRecord:
         image_width=200,
         image_height=200,
     )
+
+
+def test_face_cluster_pipeline_reports_missing_cached_model_with_actionable_message(
+    monkeypatch, tmp_path
+) -> None:
+    class FakeFaceAnalysis:
+        def __init__(self, *, name: str, root: str, providers: list[str]) -> None:
+            raise RuntimeError("offline")
+
+    insightface_module = ModuleType("insightface")
+    app_module = ModuleType("insightface.app")
+    app_module.FaceAnalysis = FakeFaceAnalysis
+    insightface_module.app = app_module
+
+    monkeypatch.setitem(sys.modules, "insightface", insightface_module)
+    monkeypatch.setitem(sys.modules, "insightface.app", app_module)
+    monkeypatch.setattr("pipeline._patch_insightface_alignment_estimate", lambda: None)
+    monkeypatch.setattr("pipeline._resolve_execution_providers", lambda: ["CPUExecutionProvider"])
+
+    model_root = tmp_path / "models"
+    pipeline_module = __import__("pipeline")
+    pipeline_instance = pipeline_module.FaceClusterPipeline(model_root=model_root)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        pipeline_instance._ensure_face_analysis()
+
+    message = str(excinfo.value)
+    assert "尚未缓存" in message
+    assert str(model_root.resolve()) in message
 
 
 def test_run_dbscan_finds_two_clusters() -> None:

--- a/tests/test_face_cluster_pipeline.py
+++ b/tests/test_face_cluster_pipeline.py
@@ -63,6 +63,7 @@ def test_face_cluster_pipeline_reports_missing_cached_model_with_actionable_mess
     pipeline_module = __import__("pipeline")
     pipeline_instance = pipeline_module.FaceClusterPipeline(model_root=model_root)
 
+    monkeypatch.delenv("INSIGHTFACE_HOME", raising=False)
     with pytest.raises(RuntimeError) as excinfo:
         pipeline_instance._ensure_face_analysis()
 

--- a/tests/test_people_pipeline.py
+++ b/tests/test_people_pipeline.py
@@ -134,6 +134,38 @@ def test_face_pipeline_uses_shared_model_root(monkeypatch, tmp_path: Path) -> No
     assert os.environ["INSIGHTFACE_HOME"] == str((tmp_path / "extension").resolve())
 
 
+def test_face_pipeline_reports_missing_cached_model_with_actionable_message(
+    monkeypatch, tmp_path: Path
+) -> None:
+    class FakeFaceAnalysis:
+        def __init__(self, *, name: str, root: str, providers: list[str]) -> None:
+            raise RuntimeError("network unreachable")
+
+    insightface_module = ModuleType("insightface")
+    app_module = ModuleType("insightface.app")
+    app_module.FaceAnalysis = FakeFaceAnalysis
+    insightface_module.app = app_module
+
+    monkeypatch.setitem(sys.modules, "insightface", insightface_module)
+    monkeypatch.setitem(sys.modules, "insightface.app", app_module)
+    monkeypatch.setattr("iPhoto.people.pipeline._patch_insightface_alignment_estimate", lambda: None)
+    monkeypatch.setattr(
+        "iPhoto.people.pipeline._resolve_execution_providers",
+        lambda: ["CPUExecutionProvider"],
+    )
+
+    model_root = tmp_path / "extension" / "models"
+    pipeline = FaceClusterPipeline(model_root=model_root)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        pipeline._ensure_face_analysis()
+
+    message = str(excinfo.value)
+    assert "not cached" in message
+    assert str(model_root.resolve()) in message
+    assert "github.com" in message
+
+
 def test_build_person_records_marks_profiles_stable_at_three_samples() -> None:
     embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
     faces = [

--- a/tests/test_people_pipeline.py
+++ b/tests/test_people_pipeline.py
@@ -157,6 +157,7 @@ def test_face_pipeline_reports_missing_cached_model_with_actionable_message(
     model_root = tmp_path / "extension" / "models"
     pipeline = FaceClusterPipeline(model_root=model_root)
 
+    monkeypatch.delenv("INSIGHTFACE_HOME", raising=False)
     with pytest.raises(RuntimeError) as excinfo:
         pipeline._ensure_face_analysis()
 


### PR DESCRIPTION
This pull request improves error handling and robustness for face analysis model initialization in both the demo and main pipelines, and updates the scan merge logic to better handle failed face status. It also introduces comprehensive tests to ensure actionable error messages are provided when required models are missing or initialization fails.

**Error handling and actionable messages:**
- Added `_build_face_analysis_init_error` helper in both `demo/face-cluster/pipeline.py` and `src/iPhoto/people/pipeline.py` to generate clear, actionable error messages when the InsightFace model is missing or cannot be initialized, including instructions for resolving the issue. [[1]](diffhunk://#diff-7e56eb2df0ff9b93ec5634526cc6dcd0c19ab485b46b8f190c372b5d31962ad0R515-R534) [[2]](diffhunk://#diff-b20464b2c324dba32a5686f39b0d455e3737fdae3ae002c3d2acc40df848934aR865-R886)
- Updated `_ensure_face_analysis` in both pipelines to use the new error helper and wrap model initialization in a try/except block, ensuring users receive helpful feedback on failure. [[1]](diffhunk://#diff-7e56eb2df0ff9b93ec5634526cc6dcd0c19ab485b46b8f190c372b5d31962ad0R202-R216) [[2]](diffhunk://#diff-b20464b2c324dba32a5686f39b0d455e3737fdae3ae002c3d2acc40df848934aR443-R452)

**Scan merge logic improvements:**
- Modified `merge_scan_row` in `src/iPhoto/cache/index_store/scan_merge.py` to reset `face_status` to pending if the previous status was `failed`, even if the asset ID is unchanged, improving robustness when retrying failed scans.
- Imported `FACE_STATUS_FAILED` for use in the above logic.

**Testing enhancements:**
- Added tests in `tests/test_face_cluster_pipeline.py` and `tests/test_people_pipeline.py` to verify that missing or failed model initialization produces actionable error messages, including checks for correct message content and instructions. [[1]](diffhunk://#diff-8c02d3e15da4034a0fa2af9ca53848c966ce0333c419de5ee990cb7136182746R45-R73) [[2]](diffhunk://#diff-377ccaa93a9b1c24b6422a00963103456874e813be9c638b24380bf4c08eec07R137-R168)
- Added a test in `tests/cache/test_global_repository.py` to ensure that a failed `face_status` is reset to pending when merging scan rows for the same asset.

**Minor improvements:**
- Added `face_key` to the `_face` test helper for completeness.
- Imported `pytest` for new tests.
- Added missing `os` import in `demo/face-cluster/pipeline.py`.
- Allowed specifying `model_root` in `FaceClusterPipeline` for better testability and flexibility.