### PR TITLE
Enhance people dashboard state and popup theming

### DIFF
--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -279,6 +279,8 @@ class MainCoordinator(QObject):
             selection_controller=self._selection_controller,
             navigation=self._navigation,
             export_callback=window.ui.export_selected_action.trigger,
+            people_cover_context_provider=self._gallery_vm.current_people_cluster_context,
+            set_people_cover_callback=self._set_people_cluster_cover,
             prepare_paths_for_mutation=self._prepare_paths_for_mutation,
             parent=self,
         )
@@ -422,6 +424,7 @@ class MainCoordinator(QObject):
         ui.rotate_left_button.clicked.connect(self._playback.rotate_current_asset)
         ui.favorite_button.clicked.connect(self._detail_vm.toggle_favorite)
         ui.toggle_face_names_action.toggled.connect(self._handle_face_name_toggle_changed)
+        ui.toggle_hidden_face_album_action.toggled.connect(self._handle_hidden_face_album_toggle_changed)
 
         # Info Button
         if hasattr(ui, "info_button"):
@@ -616,6 +619,17 @@ class MainCoordinator(QObject):
         )
         self._view_router.show_gallery()
 
+    def _set_people_cluster_cover(self, kind: str, entity_id: str, asset_id: str) -> bool:
+        library_root = self._context.library.root()
+        if library_root is None or not asset_id or not entity_id:
+            return False
+        service = PeopleService(library_root)
+        if kind == "person":
+            return service.set_cluster_cover_from_asset(entity_id, asset_id)
+        if kind == "group":
+            return service.set_group_cover(entity_id, asset_id)
+        return False
+
     def open_album_from_path(self, path: Path):
         self._navigation.open_album(path)
 
@@ -640,6 +654,14 @@ class MainCoordinator(QObject):
             show_face_names = bool(stored_face_names)
         ui.toggle_face_names_action.setChecked(show_face_names)
         self._playback.set_face_name_display_enabled(show_face_names)
+
+        stored_hidden_face_album = settings.get("ui.show_hidden_face_album", False)
+        if isinstance(stored_hidden_face_album, str):
+            show_hidden_face_album = stored_hidden_face_album.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            show_hidden_face_album = bool(stored_hidden_face_album)
+        ui.toggle_hidden_face_album_action.setChecked(show_hidden_face_album)
+        ui.people_page.set_show_hidden_people(show_hidden_face_album)
 
         # 2. Volume / Mute
         stored_volume = settings.get("ui.volume", 75)
@@ -674,6 +696,11 @@ class MainCoordinator(QObject):
         if self._context.settings.get("ui.show_face_names_in_detail") != checked:
             self._context.settings.set("ui.show_face_names_in_detail", checked)
         self._playback.set_face_name_display_enabled(checked)
+
+    def _handle_hidden_face_album_toggle_changed(self, checked: bool) -> None:
+        if self._context.settings.get("ui.show_hidden_face_album") != checked:
+            self._context.settings.set("ui.show_hidden_face_album", checked)
+        self._window.ui.people_page.set_show_hidden_people(checked)
 
     def _prepare_paths_for_mutation(self, paths: list[Path]) -> None:
         """Release preview/player handles before mutating files on disk."""

--- a/src/iPhoto/gui/ui/controllers/context_menu_controller.py
+++ b/src/iPhoto/gui/ui/controllers/context_menu_controller.py
@@ -22,6 +22,7 @@ from PySide6.QtGui import QGuiApplication, QPalette
 from PySide6.QtWidgets import QMenu
 
 from ...facade import AppFacade
+from ..models.roles import Roles
 from ..widgets.asset_grid import AssetGrid
 from ..widgets.notification_toast import NotificationToast
 from .selection_controller import SelectionController
@@ -46,6 +47,8 @@ class ContextMenuController(QObject):
         selection_controller: SelectionController | None,
         navigation: "NavigationCoordinator" | None,
         export_callback: Callable[[], None],
+        people_cover_context_provider: Callable[[], tuple[str, str] | None] | None = None,
+        set_people_cover_callback: Callable[[str, str, str], bool] | None = None,
         prepare_paths_for_mutation: Callable[[list[Path]], None] | None = None,
         parent: Optional[QObject] = None,
     ) -> None:
@@ -59,6 +62,8 @@ class ContextMenuController(QObject):
         self._selection_controller = selection_controller
         self._navigation = navigation
         self._export_callback = export_callback
+        self._people_cover_context_provider = people_cover_context_provider
+        self._set_people_cover_callback = set_people_cover_callback
         self._prepare_paths_for_mutation = prepare_paths_for_mutation
 
         self._grid_view.customContextMenuRequested.connect(self._handle_context_menu)
@@ -149,6 +154,21 @@ class ContextMenuController(QObject):
             copy_action.triggered.connect(self._copy_selection_to_clipboard)
             reveal_action.triggered.connect(self._reveal_selection_in_file_manager)
             export_action.triggered.connect(self._export_callback)
+            cover_context = self._current_people_cover_context()
+            asset_id = self._asset_id_for_index(index)
+            if cover_context is not None and asset_id is not None:
+                menu.addSeparator()
+                set_cover_action = menu.addAction(
+                    QCoreApplication.translate("MainWindow", "Set as Cover")
+                )
+                kind, entity_id = cover_context
+                set_cover_action.triggered.connect(
+                    lambda _checked=False, kind=kind, entity_id=entity_id, asset_id=asset_id: self._set_people_cover(
+                        kind,
+                        entity_id,
+                        asset_id,
+                    )
+                )
             is_recently_deleted = (
                 self._navigation.is_recently_deleted_view()
                 if self._navigation is not None
@@ -370,6 +390,37 @@ class ContextMenuController(QObject):
             return []
         rows = sorted({index.row() for index in selection_model.selectedIndexes() if index.isValid()})
         return self._selected_paths_provider(rows)
+
+    def _asset_id_for_index(self, index) -> str | None:
+        if not index.isValid():
+            return None
+        asset_id = index.data(Roles.ASSET_ID)
+        if asset_id is None:
+            return None
+        normalized = str(asset_id).strip()
+        return normalized or None
+
+    def _current_people_cover_context(self) -> tuple[str, str] | None:
+        if self._people_cover_context_provider is None:
+            return None
+        context = self._people_cover_context_provider()
+        if context is None:
+            return None
+        kind, entity_id = context
+        normalized_kind = str(kind).strip()
+        normalized_entity = str(entity_id).strip()
+        if not normalized_kind or not normalized_entity:
+            return None
+        return normalized_kind, normalized_entity
+
+    def _set_people_cover(self, kind: str, entity_id: str, asset_id: str) -> None:
+        if self._set_people_cover_callback is None:
+            return
+        changed = self._set_people_cover_callback(kind, entity_id, asset_id)
+        if changed:
+            self._toast.show_toast("Cover Updated")
+            return
+        self._status_bar.show_message("Unable to set cover for this item.", 3000)
 
     def _collect_move_targets(self) -> list[tuple[str, Path]]:
         """Build a list of (label, path) destinations excluding the currently open album."""

--- a/src/iPhoto/gui/ui/ui_main_window.py
+++ b/src/iPhoto/gui/ui/ui_main_window.py
@@ -124,6 +124,7 @@ class Ui_MainWindow(object):
         self.bind_library_action = self.main_header.bind_library_action
         self.toggle_filmstrip_action = self.main_header.toggle_filmstrip_action
         self.toggle_face_names_action = self.main_header.toggle_face_names_action
+        self.toggle_hidden_face_album_action = self.main_header.toggle_hidden_face_album_action
         self.export_all_edited_action = self.main_header.export_all_edited_action
         self.export_selected_action = self.main_header.export_selected_action
         self.export_destination_group = self.main_header.export_destination_group

--- a/src/iPhoto/gui/ui/widgets/dialogs.py
+++ b/src/iPhoto/gui/ui/widgets/dialogs.py
@@ -90,7 +90,8 @@ def _resolve_popup_theme_colors(parent: Optional[QWidget]) -> ThemeColors | None
     if app is not None and app.styleHints().colorScheme() == Qt.ColorScheme.Dark:
         return DARK_THEME
     if app is not None:
-        return LIGHT_THEME
+        window_color = QApplication.palette().color(QPalette.ColorRole.Window)
+        return DARK_THEME if window_color.lightness() < 128 else LIGHT_THEME
     return None
 
 
@@ -135,7 +136,6 @@ def show_information(parent: QWidget, message: str, *, title: str = "iPhoto") ->
     # show(), which can overwrite the palette we set just before display.
     popup.setPalette(_resolve_popup_palette_source(parent))
     popup.raise_()
-    popup.activateWindow()
     loop.exec()
 
 

--- a/src/iPhoto/gui/ui/widgets/dialogs.py
+++ b/src/iPhoto/gui/ui/widgets/dialogs.py
@@ -131,6 +131,9 @@ def show_information(parent: QWidget, message: str, *, title: str = "iPhoto") ->
     loop = QEventLoop()
     popup.destroyed.connect(loop.quit)
     popup.show()
+    # Some Linux/Qt combinations repolish top-level frameless windows during
+    # show(), which can overwrite the palette we set just before display.
+    popup.setPalette(_resolve_popup_palette_source(parent))
     popup.raise_()
     popup.activateWindow()
     loop.exec()

--- a/src/iPhoto/gui/ui/widgets/dialogs.py
+++ b/src/iPhoto/gui/ui/widgets/dialogs.py
@@ -6,8 +6,10 @@ from pathlib import Path
 from typing import Optional
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QPalette
-from PySide6.QtWidgets import QApplication, QFileDialog, QMessageBox, QWidget
+from PySide6.QtGui import QGuiApplication, QPalette
+from PySide6.QtWidgets import QApplication, QFileDialog, QInputDialog, QMessageBox, QWidget
+
+from ..theme_manager import DARK_THEME, LIGHT_THEME, ThemeColors
 
 
 def select_directory(parent: QWidget, caption: str, start: Optional[Path] = None) -> Optional[Path]:
@@ -40,6 +42,58 @@ def _apply_theme(box: QMessageBox, parent: Optional[QWidget]) -> None:
     box.setStyleSheet(stylesheet)
 
 
+def _resolve_popup_palette_source(parent: Optional[QWidget]) -> QPalette:
+    """Return the most appropriate palette source for popup surfaces."""
+
+    theme_colors = _resolve_popup_theme_colors(parent)
+    if theme_colors is not None:
+        palette = QPalette(QApplication.palette())
+        palette.setColor(QPalette.ColorRole.Window, theme_colors.window_background)
+        palette.setColor(QPalette.ColorRole.WindowText, theme_colors.text_primary)
+        palette.setColor(QPalette.ColorRole.Base, theme_colors.window_background)
+        palette.setColor(QPalette.ColorRole.AlternateBase, theme_colors.window_background)
+        palette.setColor(QPalette.ColorRole.ToolTipBase, theme_colors.window_background)
+        palette.setColor(QPalette.ColorRole.ToolTipText, theme_colors.text_primary)
+        palette.setColor(QPalette.ColorRole.Text, theme_colors.text_primary)
+        palette.setColor(QPalette.ColorRole.Button, theme_colors.window_background)
+        palette.setColor(QPalette.ColorRole.ButtonText, theme_colors.text_primary)
+        palette.setColor(QPalette.ColorRole.Mid, theme_colors.border_color)
+        return palette
+
+    if parent is not None:
+        main_window = parent.window()
+        if main_window is not None:
+            return QPalette(main_window.palette())
+        return QPalette(parent.palette())
+    return QPalette(QApplication.palette())
+
+
+def _resolve_popup_theme_colors(parent: Optional[QWidget]) -> ThemeColors | None:
+    """Resolve theme colors from the hosting window context when available."""
+
+    widget = parent.window() if parent is not None and parent.window() is not None else parent
+    coordinator = getattr(widget, "coordinator", None)
+    context = getattr(coordinator, "_context", None)
+    theme_manager = getattr(context, "theme", None)
+    if theme_manager is not None and hasattr(theme_manager, "get_effective_theme_mode"):
+        return DARK_THEME if theme_manager.get_effective_theme_mode() == "dark" else LIGHT_THEME
+
+    settings = getattr(context, "settings", None)
+    if settings is not None and hasattr(settings, "get"):
+        theme_setting = settings.get("ui.theme", "system")
+        if theme_setting == "dark":
+            return DARK_THEME
+        if theme_setting == "light":
+            return LIGHT_THEME
+
+    app = QGuiApplication.instance()
+    if app is not None and app.styleHints().colorScheme() == Qt.ColorScheme.Dark:
+        return DARK_THEME
+    if app is not None:
+        return LIGHT_THEME
+    return None
+
+
 def show_error(parent: QWidget, message: str, *, title: str = "iPhoto") -> None:
     """Display a blocking error message."""
 
@@ -64,6 +118,8 @@ def show_information(parent: QWidget, message: str, *, title: str = "iPhoto") ->
 
     popup = InformationPopup(parent, title=title, message=message)
     popup.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+    popup.setPalette(_resolve_popup_palette_source(parent))
+    popup.setBackgroundRole(QPalette.ColorRole.Window)
 
     if parent is not None:
         center = parent.geometry().center()
@@ -78,6 +134,95 @@ def show_information(parent: QWidget, message: str, *, title: str = "iPhoto") ->
     popup.raise_()
     popup.activateWindow()
     loop.exec()
+
+
+def _apply_input_dialog_theme(dialog: QInputDialog, parent: Optional[QWidget]) -> None:
+    """Apply the active popup theme to ``QInputDialog`` widgets."""
+
+    palette = _resolve_popup_palette_source(parent)
+    dialog.setPalette(palette)
+    dialog.setBackgroundRole(QPalette.ColorRole.Window)
+
+    bg = palette.color(QPalette.ColorRole.Window).name()
+    text_col = palette.color(QPalette.ColorRole.WindowText).name()
+    base = palette.color(QPalette.ColorRole.Base).name()
+    text_input = palette.color(QPalette.ColorRole.Text).name()
+    button = palette.color(QPalette.ColorRole.Button).name()
+    button_text = palette.color(QPalette.ColorRole.ButtonText).name()
+    border = palette.color(QPalette.ColorRole.Mid).name()
+
+    dialog.setStyleSheet(
+        f"""
+        QInputDialog {{
+            background-color: {bg};
+            color: {text_col};
+        }}
+        QLabel {{
+            color: {text_col};
+        }}
+        QLineEdit, QComboBox {{
+            background-color: {base};
+            color: {text_input};
+            border: 1px solid {border};
+            padding: 4px;
+        }}
+        QComboBox QAbstractItemView {{
+            background-color: {base};
+            color: {text_input};
+            border: 1px solid {border};
+            selection-background-color: {button};
+            selection-color: {button_text};
+        }}
+        QPushButton {{
+            background-color: {button};
+            color: {button_text};
+            border: 1px solid {border};
+            padding: 6px 16px;
+            min-width: 60px;
+        }}
+        QPushButton:hover {{
+            background-color: {base};
+        }}
+    """
+    )
+
+
+def prompt_text_input(
+    parent: QWidget | None,
+    title: str,
+    label: str,
+    *,
+    text: str = "",
+) -> tuple[str, bool]:
+    """Show a themed text input dialog."""
+
+    dialog = QInputDialog(parent)
+    dialog.setInputMode(QInputDialog.InputMode.TextInput)
+    dialog.setWindowTitle(title)
+    dialog.setLabelText(label)
+    dialog.setTextValue(text)
+    _apply_input_dialog_theme(dialog, parent)
+    accepted = dialog.exec() == QInputDialog.DialogCode.Accepted
+    return dialog.textValue(), accepted
+
+
+def prompt_item_selection(
+    parent: QWidget | None,
+    title: str,
+    label: str,
+    items: list[str],
+) -> tuple[str, bool]:
+    """Show a themed item-selection dialog."""
+
+    dialog = QInputDialog(parent)
+    dialog.setInputMode(QInputDialog.InputMode.TextInput)
+    dialog.setComboBoxItems(items)
+    dialog.setComboBoxEditable(False)
+    dialog.setWindowTitle(title)
+    dialog.setLabelText(label)
+    _apply_input_dialog_theme(dialog, parent)
+    accepted = dialog.exec() == QInputDialog.DialogCode.Accepted
+    return dialog.textValue(), accepted
 
 
 def show_warning(parent: QWidget, message: str, *, title: str = "iPhoto") -> None:

--- a/src/iPhoto/gui/ui/widgets/information_popup.py
+++ b/src/iPhoto/gui/ui/widgets/information_popup.py
@@ -45,10 +45,13 @@ class InformationPopup(QWidget):
             parent,
             Qt.WindowType.Window
             | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.Tool
             | Qt.WindowType.WindowStaysOnTopHint,
         )
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, False)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.setMinimumWidth(self._DEFAULT_WIDTH)
 
         self._drag_active = False

--- a/src/iPhoto/gui/ui/widgets/information_popup.py
+++ b/src/iPhoto/gui/ui/widgets/information_popup.py
@@ -144,6 +144,15 @@ class InformationPopup(QWidget):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_colour(candidate: QColor, fallback: QColor) -> QColor:
+        """Return an opaque colour derived from ``candidate`` or ``fallback``."""
+
+        colour = QColor(candidate) if candidate.isValid() else QColor(fallback)
+        if colour.alpha() != 255:
+            colour.setAlpha(255)
+        return colour
+
     def _apply_close_button_style(self) -> None:
         """Recompute hover/pressed colours from the current palette."""
         text = self.palette().color(QPalette.ColorRole.WindowText)
@@ -181,11 +190,17 @@ class InformationPopup(QWidget):
         path = QPainterPath()
         path.addRoundedRect(rect, radius, radius)
 
-        bg_color = self.palette().color(QPalette.ColorRole.Window)
+        bg_color = self._resolve_colour(
+            self.palette().color(QPalette.ColorRole.Window),
+            QColor("#EEF3F6"),
+        )
         painter.setPen(Qt.PenStyle.NoPen)
         painter.fillPath(path, bg_color)
 
-        border_color = self.palette().color(QPalette.ColorRole.Mid)
+        border_color = self._resolve_colour(
+            self.palette().color(QPalette.ColorRole.Mid),
+            QColor("#8A8F98"),
+        )
         border_color.setAlpha(80)
         painter.setPen(border_color)
         painter.setBrush(Qt.BrushStyle.NoBrush)

--- a/src/iPhoto/gui/ui/widgets/information_popup.py
+++ b/src/iPhoto/gui/ui/widgets/information_popup.py
@@ -75,7 +75,6 @@ class InformationPopup(QWidget):
             QSizePolicy.Policy.Expanding,
             QSizePolicy.Policy.Preferred,
         )
-        self._title_label.setStyleSheet("font-weight: bold; font-size: 14px;")
         title_layout.addWidget(self._title_label, 1)
 
         # Close button – reuses the main window's close-button appearance.
@@ -111,6 +110,7 @@ class InformationPopup(QWidget):
         )
         self._message_label.setContentsMargins(16, 8, 16, 16)
         root_layout.addWidget(self._message_label, 1)
+        self._apply_content_style()
 
     # ------------------------------------------------------------------
     # Public API
@@ -166,12 +166,30 @@ class InformationPopup(QWidget):
             f"QToolButton:pressed {{ background-color: {pressed.name(QColor.NameFormat.HexArgb)}; border-radius: 6px; }}"
         )
 
+    def _apply_content_style(self) -> None:
+        """Keep child widgets transparent and in sync with the popup palette."""
+
+        text = self._resolve_colour(
+            self.palette().color(QPalette.ColorRole.WindowText),
+            QColor("#2B2B2B"),
+        )
+        secondary = QColor(text)
+        secondary.setAlpha(220)
+        self._title_bar.setStyleSheet("background: transparent;")
+        self._title_label.setStyleSheet(
+            f"font-weight: bold; font-size: 14px; color: {text.name()}; background: transparent;"
+        )
+        self._message_label.setStyleSheet(
+            f"color: {secondary.name(QColor.NameFormat.HexArgb)}; background: transparent;"
+        )
+
     # ------------------------------------------------------------------
     # QWidget overrides
     # ------------------------------------------------------------------
     def changeEvent(self, event: QEvent) -> None:
         if event.type() == QEvent.Type.PaletteChange:
             self._apply_close_button_style()
+            self._apply_content_style()
         super().changeEvent(event)
 
     def paintEvent(self, event) -> None:  # type: ignore[override]

--- a/src/iPhoto/gui/ui/widgets/main_header.py
+++ b/src/iPhoto/gui/ui/widgets/main_header.py
@@ -98,6 +98,10 @@ class MainHeaderWidget(QWidget):
             "Show face names", main_window, checkable=True
         )
         self.toggle_face_names_action.setChecked(False)
+        self.toggle_hidden_face_album_action = QAction(
+            "Show Hidden Face Album", main_window, checkable=True
+        )
+        self.toggle_hidden_face_album_action.setChecked(False)
 
         self.share_action_group = QActionGroup(main_window)
         self.share_action_copy_file = QAction("Copy File", main_window, checkable=True)
@@ -168,6 +172,7 @@ class MainHeaderWidget(QWidget):
 
         view_menu = self.menu_bar.addMenu("&View")
         view_menu.addAction(self.toggle_face_names_action)
+        view_menu.addAction(self.toggle_hidden_face_album_action)
         view_menu.addSeparator()
         view_menu.addAction(self.toggle_filmstrip_action)
 

--- a/src/iPhoto/gui/ui/widgets/people_dashboard_cards.py
+++ b/src/iPhoto/gui/ui/widgets/people_dashboard_cards.py
@@ -281,6 +281,7 @@ class PeopleCard(QWidget):
 
 class GroupCard(QWidget):
     activated = Signal(str)
+    menuRequested = Signal(str, object)
     _CARD_INSET = 4
     _SHADOW_SAFE_BOTTOM = 18
 
@@ -507,3 +508,7 @@ class GroupCard(QWidget):
             event.accept()
             return
         super().mouseReleaseEvent(event)
+
+    def contextMenuEvent(self, event) -> None:  # noqa: N802
+        self.menuRequested.emit(self.group_id, event.globalPos())
+        event.accept()

--- a/src/iPhoto/gui/ui/widgets/people_dashboard_dialogs.py
+++ b/src/iPhoto/gui/ui/widgets/people_dashboard_dialogs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QPoint, QRect, QRectF, Qt, Signal
-from PySide6.QtGui import QColor, QFont, QLinearGradient, QPainter, QPainterPath, QPen, QPixmap
+from PySide6.QtGui import QColor, QFont, QGuiApplication, QLinearGradient, QPainter, QPainterPath, QPen, QPixmap
 from PySide6.QtWidgets import (
     QDialog,
     QFrame,
@@ -45,6 +45,7 @@ class MergeConfirmDialog(QDialog):
     ) -> None:
         super().__init__(parent.window() if parent is not None else None)
         self._people_count = max(2, int(people_count))
+        self._dark_mode = self._resolve_dark_mode(parent)
         self.setModal(True)
         self.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.FramelessWindowHint)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
@@ -55,17 +56,21 @@ class MergeConfirmDialog(QDialog):
 
         self._panel = QFrame(self)
         self._panel.setFixedWidth(356)
-        self._panel.setStyleSheet("""
-            QFrame {
-                background: rgba(255, 255, 255, 0.94);
-                border: 1px solid rgba(255, 255, 255, 0.65);
+        panel_bg = "rgba(23, 27, 39, 0.98)" if self._dark_mode else "rgba(255, 255, 255, 0.94)"
+        panel_border = "rgba(255, 255, 255, 0.08)" if self._dark_mode else "rgba(255, 255, 255, 0.65)"
+        self._panel.setStyleSheet(
+            f"""
+            QFrame {{
+                background: {panel_bg};
+                border: 1px solid {panel_border};
                 border-radius: 28px;
-            }
-            """)
+            }}
+            """
+        )
         panel_shadow = QGraphicsDropShadowEffect(self._panel)
         panel_shadow.setBlurRadius(40)
         panel_shadow.setOffset(0, 12)
-        panel_shadow.setColor(QColor(0, 0, 0, 46))
+        panel_shadow.setColor(QColor(0, 0, 0, 86 if self._dark_mode else 46))
         self._panel.setGraphicsEffect(panel_shadow)
 
         panel_layout = QVBoxLayout(self._panel)
@@ -87,7 +92,9 @@ class MergeConfirmDialog(QDialog):
         title_font = QFont("Segoe UI", 17, QFont.Weight.Bold)
         title_label.setFont(title_font)
         title_label.setMinimumHeight(max(56, title_label.heightForWidth(text_width)))
-        title_label.setStyleSheet("color: #111111; background: transparent;")
+        title_label.setStyleSheet(
+            f"color: {'#F6F7FB' if self._dark_mode else '#111111'}; background: transparent;"
+        )
 
         body_label = QLabel(resolved_body)
         body_label.setWordWrap(True)
@@ -97,12 +104,16 @@ class MergeConfirmDialog(QDialog):
         body_font = QFont("Segoe UI", 14, QFont.Weight.Medium)
         body_label.setFont(body_font)
         body_label.setMinimumHeight(max(46, body_label.heightForWidth(text_width)))
-        body_label.setStyleSheet("color: rgba(17, 17, 17, 0.84); background: transparent;")
+        body_label.setStyleSheet(
+            "background: transparent; "
+            f"color: {'#DDE3F3' if self._dark_mode else 'rgba(17, 17, 17, 0.84)'};"
+        )
 
         merge_button = QPushButton(confirm_text)
         merge_button.setCursor(Qt.CursorShape.PointingHandCursor)
         merge_button.setFixedHeight(42)
-        merge_button.setStyleSheet("""
+        merge_button.setStyleSheet(
+            """
             QPushButton {
                 background: #0A84FF;
                 color: white;
@@ -117,27 +128,30 @@ class MergeConfirmDialog(QDialog):
             QPushButton:pressed {
                 background: #006BE3;
             }
-            """)
+            """
+        )
 
         cancel_button = QPushButton("Cancel")
         cancel_button.setCursor(Qt.CursorShape.PointingHandCursor)
         cancel_button.setFixedHeight(40)
-        cancel_button.setStyleSheet("""
-            QPushButton {
-                background: rgba(243, 243, 244, 0.98);
-                color: #2E2E2E;
+        cancel_button.setStyleSheet(
+            f"""
+            QPushButton {{
+                background: {'rgba(255, 255, 255, 0.08)' if self._dark_mode else 'rgba(243, 243, 244, 0.98)'};
+                color: {'#F4F6FB' if self._dark_mode else '#2E2E2E'};
                 border: none;
                 border-radius: 20px;
                 font-size: 15px;
                 font-weight: 500;
-            }
-            QPushButton:hover {
-                background: rgba(235, 235, 236, 0.98);
-            }
-            QPushButton:pressed {
-                background: rgba(224, 224, 226, 0.98);
-            }
-            """)
+            }}
+            QPushButton:hover {{
+                background: {'rgba(255, 255, 255, 0.13)' if self._dark_mode else 'rgba(235, 235, 236, 0.98)'};
+            }}
+            QPushButton:pressed {{
+                background: {'rgba(255, 255, 255, 0.18)' if self._dark_mode else 'rgba(224, 224, 226, 0.98)'};
+            }}
+            """
+        )
 
         merge_button.clicked.connect(self.accept)
         cancel_button.clicked.connect(self.reject)
@@ -150,6 +164,28 @@ class MergeConfirmDialog(QDialog):
 
         root.addWidget(self._panel, 0, Qt.AlignmentFlag.AlignHCenter)
         root.addStretch(1)
+
+    @staticmethod
+    def _resolve_dark_mode(parent: QWidget | None) -> bool:
+        widget = parent.window() if parent is not None and parent.window() is not None else parent
+        coordinator = getattr(widget, "coordinator", None)
+        context = getattr(coordinator, "_context", None)
+        theme_manager = getattr(context, "theme", None)
+        if theme_manager is not None and hasattr(theme_manager, "get_effective_theme_mode"):
+            return theme_manager.get_effective_theme_mode() == "dark"
+
+        settings = getattr(context, "settings", None)
+        if settings is not None and hasattr(settings, "get"):
+            theme_setting = settings.get("ui.theme", "system")
+            if theme_setting == "dark":
+                return True
+            if theme_setting == "light":
+                return False
+
+        app = QGuiApplication.instance()
+        if app is not None and app.styleHints().colorScheme() == Qt.ColorScheme.Dark:
+            return True
+        return _widget_uses_dark_theme(widget)
 
     def _sync_geometry(self) -> None:
         parent = self.parentWidget()
@@ -166,7 +202,10 @@ class MergeConfirmDialog(QDialog):
     def paintEvent(self, _event) -> None:  # noqa: N802
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        painter.fillRect(self.rect(), QColor(22, 24, 29, 78))
+        painter.fillRect(
+            self.rect(),
+            QColor(8, 10, 16, 108) if self._dark_mode else QColor(22, 24, 29, 78),
+        )
 
     def mousePressEvent(self, event) -> None:  # noqa: N802
         if not self._panel.geometry().contains(event.position().toPoint()):

--- a/src/iPhoto/gui/ui/widgets/people_dashboard_dialogs.py
+++ b/src/iPhoto/gui/ui/widgets/people_dashboard_dialogs.py
@@ -34,7 +34,15 @@ from .people_dashboard_shared import (
 
 
 class MergeConfirmDialog(QDialog):
-    def __init__(self, people_count: int, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        people_count: int,
+        parent: QWidget | None = None,
+        *,
+        title_text: str | None = None,
+        body_text: str | None = None,
+        confirm_text: str = "Merge Photos",
+    ) -> None:
         super().__init__(parent.window() if parent is not None else None)
         self._people_count = max(2, int(people_count))
         self.setModal(True)
@@ -65,8 +73,13 @@ class MergeConfirmDialog(QDialog):
         panel_layout.setSpacing(16)
 
         text_width = self._panel.width() - 44
+        resolved_title = title_text or f"Merge All Photos of These\n{self._people_count} People?"
+        resolved_body = body_text or (
+            f"By merging photos of these {self._people_count} people, "
+            "they will be recognized as the same person."
+        )
 
-        title_label = QLabel(f"Merge All Photos of These\n{self._people_count} People?")
+        title_label = QLabel(resolved_title)
         title_label.setWordWrap(True)
         title_label.setTextFormat(Qt.TextFormat.PlainText)
         title_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
@@ -76,10 +89,7 @@ class MergeConfirmDialog(QDialog):
         title_label.setMinimumHeight(max(56, title_label.heightForWidth(text_width)))
         title_label.setStyleSheet("color: #111111; background: transparent;")
 
-        body_label = QLabel(
-            f"By merging photos of these {self._people_count} people, "
-            "they will be recognized as the same person."
-        )
+        body_label = QLabel(resolved_body)
         body_label.setWordWrap(True)
         body_label.setTextFormat(Qt.TextFormat.PlainText)
         body_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
@@ -89,7 +99,7 @@ class MergeConfirmDialog(QDialog):
         body_label.setMinimumHeight(max(46, body_label.heightForWidth(text_width)))
         body_label.setStyleSheet("color: rgba(17, 17, 17, 0.84); background: transparent;")
 
-        merge_button = QPushButton("Merge Photos")
+        merge_button = QPushButton(confirm_text)
         merge_button.setCursor(Qt.CursorShape.PointingHandCursor)
         merge_button.setFixedHeight(42)
         merge_button.setStyleSheet("""
@@ -168,6 +178,25 @@ class MergeConfirmDialog(QDialog):
     @classmethod
     def confirm(cls, people_count: int, parent: QWidget | None = None) -> bool:
         dialog = cls(people_count, parent)
+        return dialog.exec() == QDialog.DialogCode.Accepted
+
+    @classmethod
+    def confirm_custom(
+        cls,
+        *,
+        parent: QWidget | None = None,
+        title_text: str,
+        body_text: str,
+        confirm_text: str,
+        people_count: int = 2,
+    ) -> bool:
+        dialog = cls(
+            people_count,
+            parent,
+            title_text=title_text,
+            body_text=body_text,
+            confirm_text=confirm_text,
+        )
         return dialog.exec() == QDialog.DialogCode.Accepted
 
 

--- a/src/iPhoto/gui/ui/widgets/people_dashboard_widget.py
+++ b/src/iPhoto/gui/ui/widgets/people_dashboard_widget.py
@@ -415,7 +415,7 @@ class PeopleDashboardWidget(QWidget):
         merge_action = QAction("Merge Into...", menu)
         is_hidden = self._show_hidden_people and self._service.is_cluster_card_hidden(summary.person_id)
         hide_action = QAction(
-            "Unhide This People" if is_hidden else "Hide This People",
+            "Unhide This Person" if is_hidden else "Hide This Person",
             menu,
         )
         merge_action.setEnabled(len(self._summaries) > 1)

--- a/src/iPhoto/gui/ui/widgets/people_dashboard_widget.py
+++ b/src/iPhoto/gui/ui/widgets/people_dashboard_widget.py
@@ -10,7 +10,6 @@ from PySide6.QtWidgets import (
     QDialog,
     QFrame,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QMenu,
     QScrollArea,
@@ -22,6 +21,7 @@ from PySide6.QtWidgets import (
 from iPhoto.people.repository import PeopleGroupSummary, PersonSummary
 from iPhoto.people.service import PeopleService
 
+from . import dialogs
 from .flow_layout import FlowLayout
 from .people_dashboard_board import PeopleBoard
 from .people_dashboard_cards import GroupCard, PeopleCard
@@ -45,6 +45,7 @@ class _PeopleDashboardLoaderWorker(QRunnable):
         generation: int,
         index_version: int,
         library_root: Path | None,
+        show_hidden_people: bool,
         status_message: str | None,
         signals: _PeopleDashboardLoaderSignals,
     ) -> None:
@@ -52,6 +53,7 @@ class _PeopleDashboardLoaderWorker(QRunnable):
         self._generation = generation
         self._index_version = index_version
         self._library_root = library_root
+        self._show_hidden_people = bool(show_hidden_people)
         self._status_message = status_message
         self._signals = signals
 
@@ -68,7 +70,9 @@ class _PeopleDashboardLoaderWorker(QRunnable):
             )
             return
         service = PeopleService(self._library_root)
-        summaries, groups, pending = service.load_dashboard()
+        summaries, groups, pending = service.load_dashboard(
+            show_hidden_people=self._show_hidden_people
+        )
         self._signals.loaded.emit(
             self._generation,
             self._index_version,
@@ -88,6 +92,7 @@ class PeopleDashboardWidget(QWidget):
         super().__init__(parent)
         self._service = PeopleService()
         self._status_message: str | None = None
+        self._show_hidden_people = False
         self._summaries: list[PersonSummary] = []
         self._groups: list[PeopleGroupSummary] = []
         self._cards: dict[str, PeopleCard] = {}
@@ -222,6 +227,13 @@ class PeopleDashboardWidget(QWidget):
         self._status_message = message or None
         self._update_status_labels()
 
+    def set_show_hidden_people(self, show_hidden_people: bool) -> None:
+        normalized = bool(show_hidden_people)
+        if self._show_hidden_people == normalized:
+            return
+        self._show_hidden_people = normalized
+        self.reload(preserve_content=bool(self._summaries or self._groups))
+
     def schedule_index_refresh(self) -> None:
         self._index_version += 1
         if not self.isVisible():
@@ -256,6 +268,7 @@ class PeopleDashboardWidget(QWidget):
             generation=generation,
             index_version=index_version,
             library_root=library_root,
+            show_hidden_people=self._show_hidden_people,
             status_message=self._status_message,
             signals=self._load_signals,
         )
@@ -291,7 +304,7 @@ class PeopleDashboardWidget(QWidget):
         self._pending_index_refresh = False
         status_text = status_message if status_message else self._status_message
 
-        if self._summaries:
+        if self._summaries or self._groups:
             self._message.setText(
                 "Click a cluster or group card to open matching assets, "
                 "or drag cards close together to merge clusters."
@@ -329,6 +342,7 @@ class PeopleDashboardWidget(QWidget):
         for index, summary in enumerate(self._groups):
             card = GroupCard(summary=summary, seed_index=index, parent=self._groups_host)
             card.activated.connect(self.groupActivated.emit)
+            card.menuRequested.connect(self._show_group_card_menu)
             self._group_cards[summary.group_id] = card
             self._groups_layout.addWidget(card)
             card.load_cover_artwork()
@@ -381,6 +395,16 @@ class PeopleDashboardWidget(QWidget):
         menu = self._build_card_menu(summary)
         menu.exec(global_pos)
 
+    def _group_summary_for_group(self, group_id: str) -> PeopleGroupSummary | None:
+        return next((item for item in self._groups if item.group_id == group_id), None)
+
+    def _show_group_card_menu(self, group_id: str, global_pos) -> None:
+        summary = self._group_summary_for_group(group_id)
+        if summary is None:
+            return
+        menu = self._build_group_card_menu(summary)
+        menu.exec(global_pos)
+
     def _build_card_menu(self, summary: PersonSummary) -> QMenu:
         menu = QMenu(self)
         menu.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
@@ -389,19 +413,43 @@ class PeopleDashboardWidget(QWidget):
         rename_action = QAction(rename_text, menu)
         new_group_action = QAction("New Group", menu)
         merge_action = QAction("Merge Into...", menu)
+        is_hidden = self._show_hidden_people and self._service.is_cluster_card_hidden(summary.person_id)
+        hide_action = QAction(
+            "Unhide This People" if is_hidden else "Hide This People",
+            menu,
+        )
         merge_action.setEnabled(len(self._summaries) > 1)
         rename_action.triggered.connect(lambda: self._rename_person(summary))
         new_group_action.triggered.connect(lambda: self._open_group_dialog(summary.person_id))
         merge_action.triggered.connect(lambda: self._merge_person(summary))
+        if is_hidden:
+            hide_action.triggered.connect(lambda: self._unhide_person(summary))
+        else:
+            hide_action.triggered.connect(lambda: self._hide_person(summary))
         menu.addAction(rename_action)
         menu.addAction(new_group_action)
         menu.addSeparator()
         menu.addAction(merge_action)
+        menu.addAction(hide_action)
+        return menu
+
+    def _build_group_card_menu(self, summary: PeopleGroupSummary) -> QMenu:
+        menu = QMenu(self)
+        menu.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        menu.setStyleSheet(MENU_STYLE)
+        dissolve_action = QAction("Dissolve Group", menu)
+        dissolve_action.triggered.connect(lambda: self._dissolve_group(summary))
+        menu.addAction(dissolve_action)
         return menu
 
     def _rename_person(self, summary: PersonSummary) -> None:
         title = "Rename Person" if summary.name else "Name This Person"
-        text, accepted = QInputDialog.getText(self, title, "Name:", text=summary.name or "")
+        text, accepted = dialogs.prompt_text_input(
+            self,
+            title,
+            "Name:",
+            text=summary.name or "",
+        )
         if not accepted:
             return
         self._service.rename_cluster(summary.person_id, text.strip() or None)
@@ -417,12 +465,11 @@ class PeopleDashboardWidget(QWidget):
             return
 
         labels = [label for label, _ in choices]
-        selected, accepted = QInputDialog.getItem(
+        selected, accepted = dialogs.prompt_item_selection(
             self,
             "Merge Person",
             "Merge into:",
             labels,
-            editable=False,
         )
         if not accepted:
             return
@@ -430,6 +477,21 @@ class PeopleDashboardWidget(QWidget):
         if selected_id is None:
             return
         self._confirm_merge(summary.person_id, selected_id)
+
+    def _hide_person(self, summary: PersonSummary) -> None:
+        if not MergeConfirmDialog.confirm_custom(
+            parent=self,
+            title_text="Hide This Person?",
+            body_text="This person will be hidden from the People dashboard until you choose to show hidden face albums.",
+            confirm_text="Hide",
+        ):
+            return
+        if self._service.hide_cluster_card(summary.person_id):
+            self.reload(preserve_content=bool(self._summaries or self._groups))
+
+    def _unhide_person(self, summary: PersonSummary) -> None:
+        if self._service.unhide_cluster_card(summary.person_id):
+            self.reload(preserve_content=bool(self._summaries or self._groups))
 
     def _open_group_dialog(self, initial_person_id: str) -> None:
         if len(self._summaries) < 2:
@@ -446,8 +508,34 @@ class PeopleDashboardWidget(QWidget):
         if group is not None:
             self.reload(preserve_content=bool(self._summaries))
 
+    def _dissolve_group(self, summary: PeopleGroupSummary) -> None:
+        if not MergeConfirmDialog.confirm_custom(
+            parent=self,
+            title_text="Dissolve This Group?",
+            body_text="This will remove the group card. The people inside it will remain unchanged.",
+            confirm_text="Dissolve Group",
+        ):
+            return
+        if self._service.delete_group(summary.group_id):
+            self.reload(preserve_content=bool(self._summaries or self._groups))
+
     def _merge_cluster_pair(self, source_person_id: str, target_person_id: str) -> None:
         self._confirm_merge(source_person_id, target_person_id)
+
+    def _show_merge_hidden_state_warning(self) -> None:
+        dialogs.show_information(
+            self,
+            (
+                "People in hidden and visible states cannot be merged. "
+                "Please make both People cards hidden or visible first."
+            ),
+            title="Cannot Merge People",
+        )
+
+    def _has_mixed_hidden_state(self, source_person_id: str, target_person_id: str) -> bool:
+        source_hidden = self._service.is_cluster_card_hidden(source_person_id)
+        target_hidden = self._service.is_cluster_card_hidden(target_person_id)
+        return source_hidden != target_hidden
 
     def _confirm_merge(self, source_person_id: str, target_person_id: str) -> bool:
         if source_person_id == target_person_id:
@@ -456,6 +544,10 @@ class PeopleDashboardWidget(QWidget):
         source = self._summary_for_person(source_person_id)
         target = self._summary_for_person(target_person_id)
         if source is None or target is None:
+            return False
+
+        if self._has_mixed_hidden_state(source_person_id, target_person_id):
+            self._show_merge_hidden_state_warning()
             return False
 
         if not MergeConfirmDialog.confirm(2, self):
@@ -481,7 +573,7 @@ class PeopleDashboardWidget(QWidget):
     def _update_status_labels(self) -> None:
         if self._loading:
             return
-        if self._summaries:
+        if self._summaries or self._groups:
             self._message.setText(
                 "Click a cluster or group card to open matching assets, "
                 "or drag cards close together to merge clusters."

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -371,6 +371,17 @@ class GalleryViewModel(BaseViewModel):
     def is_in_cluster_gallery(self) -> bool:
         return self._cluster_gallery_origin is not None or self._location_session.mode == "cluster_gallery"
 
+    def current_people_cluster_context(
+        self,
+    ) -> tuple[Literal["person", "group"], str] | None:
+        if (
+            self._cluster_gallery_origin != "people"
+            or self._people_cluster_kind not in {"person", "group"}
+            or not self._people_cluster_id
+        ):
+            return None
+        return self._people_cluster_kind, self._people_cluster_id
+
     def cluster_gallery_back_tooltip(self) -> str:
         if self._cluster_gallery_origin == "people":
             return "Return to People"

--- a/src/iPhoto/people/face_repository.py
+++ b/src/iPhoto/people/face_repository.py
@@ -289,6 +289,11 @@ class FaceRepository:
             )
         return summaries
 
+    def get_hidden_person_ids(self, person_ids: Iterable[str]) -> set[str]:
+        if self._state_repo is None:
+            return set()
+        return self._state_repo.get_hidden_person_ids(person_ids)
+
     def get_asset_ids_by_person(self, person_id: str) -> list[str]:
         self.initialize()
         with closing(self._connect()) as conn:
@@ -411,6 +416,26 @@ class FaceRepository:
             thumbnail_path=row["thumbnail_path"],
         )
         return True
+
+    def set_person_cover_from_asset(self, person_id: str, asset_id: str) -> bool:
+        if not person_id or not asset_id:
+            return False
+        annotation = next(
+            (
+                item
+                for item in self.list_asset_face_annotations(asset_id)
+                if item.person_id == person_id and item.face_id
+            ),
+            None,
+        )
+        if annotation is None:
+            return False
+        return self.set_person_cover(person_id, annotation.face_id)
+
+    def set_person_hidden(self, person_id: str, hidden: bool) -> bool:
+        if self._state_repo is None:
+            return False
+        return self._state_repo.set_person_hidden(person_id, hidden)
 
     def set_person_order(self, person_ids: Iterable[str]) -> None:
         if self._state_repo is None:
@@ -543,6 +568,12 @@ class FaceRepository:
         if group is not None:
             self.refresh_group_assets(group.group_id)
         return group
+
+    def delete_group(self, group_id: str) -> bool:
+        if self._state_repo is None:
+            return False
+        self.initialize()
+        return self._state_repo.delete_group(group_id)
 
     def list_groups(self) -> list[PeopleGroupRecord]:
         if self._state_repo is None:

--- a/src/iPhoto/people/index_coordinator.py
+++ b/src/iPhoto/people/index_coordinator.py
@@ -166,6 +166,21 @@ class PeopleIndexCoordinator(QObject):
                 )
             return changed
 
+    def set_person_cover_from_asset(self, person_id: str, asset_id: str) -> bool:
+        if not person_id or not asset_id:
+            return False
+        with self._lock:
+            if self._shutdown_requested:
+                return False
+            repository = self._repository()
+            changed = repository.set_person_cover_from_asset(person_id, asset_id)
+            if changed:
+                self._emit_snapshot(
+                    changed_asset_ids=(asset_id,),
+                    changed_person_ids=(person_id,),
+                )
+            return changed
+
     def add_manual_face(
         self,
         face: FaceRecord,
@@ -289,6 +304,27 @@ class PeopleIndexCoordinator(QObject):
                 )
             return group
 
+    def delete_group(self, group_id: str) -> bool:
+        if not group_id:
+            return False
+        with self._lock:
+            if self._shutdown_requested:
+                return False
+            repository = self._repository()
+            group = repository.get_group(group_id)
+            if group is None:
+                return False
+            changed_asset_ids = tuple(repository.get_common_asset_ids_for_group(group_id))
+            changed = repository.delete_group(group_id)
+            if changed:
+                self._emit_snapshot(
+                    changed_asset_ids=changed_asset_ids,
+                    changed_person_ids=tuple(group.member_person_ids),
+                    changed_group_ids=(group_id,),
+                    group_redirects={group_id: None},
+                )
+            return changed
+
     def set_group_cover(self, group_id: str, asset_id: str) -> bool:
         if not group_id or not asset_id:
             return False
@@ -302,6 +338,18 @@ class PeopleIndexCoordinator(QObject):
                     changed_asset_ids=(asset_id,),
                     changed_group_ids=(group_id,),
                 )
+            return changed
+
+    def set_person_hidden(self, person_id: str, hidden: bool) -> bool:
+        if not person_id:
+            return False
+        with self._lock:
+            if self._shutdown_requested:
+                return False
+            repository = self._repository()
+            changed = repository.set_person_hidden(person_id, hidden)
+            if changed:
+                self._emit_snapshot(changed_person_ids=(person_id,))
             return changed
 
     def _repository(self) -> FaceRepository:

--- a/src/iPhoto/people/service.py
+++ b/src/iPhoto/people/service.py
@@ -102,12 +102,25 @@ class PeopleService:
         summaries_by_id = {summary.person_id: summary for summary in summary_list}
         return self._build_group_summaries(repository, repository.list_groups(), summaries_by_id)
 
-    def load_dashboard(self) -> tuple[list[PersonSummary], list[PeopleGroupSummary], int]:
+    def load_dashboard(
+        self,
+        *,
+        show_hidden_people: bool = False,
+    ) -> tuple[list[PersonSummary], list[PeopleGroupSummary], int]:
         repository = self.repository()
         if repository is None:
             return [], [], 0
-        summaries = repository.get_person_summaries()
-        groups = self.list_groups(repository=repository, summaries=summaries)
+        all_summaries = repository.get_person_summaries()
+        groups = self.list_groups(repository=repository, summaries=all_summaries)
+        if show_hidden_people:
+            summaries = list(all_summaries)
+        else:
+            hidden_person_ids = repository.get_hidden_person_ids(
+                summary.person_id for summary in all_summaries
+            )
+            summaries = [
+                summary for summary in all_summaries if summary.person_id not in hidden_person_ids
+            ]
         counts = self.face_status_counts()
         pending = counts.get("pending", 0) + counts.get("retry", 0)
         return summaries, groups, pending
@@ -137,10 +150,34 @@ class PeopleService:
             return False
         return get_people_index_coordinator(self._library_root).set_person_cover(person_id, face_id)
 
+    def set_cluster_cover_from_asset(self, person_id: str, asset_id: str) -> bool:
+        if self._library_root is None:
+            return False
+        return get_people_index_coordinator(self._library_root).set_person_cover_from_asset(
+            person_id,
+            asset_id,
+        )
+
     def set_group_cover(self, group_id: str, asset_id: str) -> bool:
         if self._library_root is None:
             return False
         return get_people_index_coordinator(self._library_root).set_group_cover(group_id, asset_id)
+
+    def hide_cluster_card(self, person_id: str) -> bool:
+        if self._library_root is None:
+            return False
+        return get_people_index_coordinator(self._library_root).set_person_hidden(person_id, True)
+
+    def unhide_cluster_card(self, person_id: str) -> bool:
+        if self._library_root is None:
+            return False
+        return get_people_index_coordinator(self._library_root).set_person_hidden(person_id, False)
+
+    def is_cluster_card_hidden(self, person_id: str) -> bool:
+        repository = self.repository()
+        if repository is None or not person_id:
+            return False
+        return person_id in repository.get_hidden_person_ids([person_id])
 
     def set_cluster_order(
         self,
@@ -157,6 +194,11 @@ class PeopleService:
             source_person_id,
             target_person_id,
         )
+
+    def delete_group(self, group_id: str) -> bool:
+        if self._library_root is None:
+            return False
+        return get_people_index_coordinator(self._library_root).delete_group(group_id)
 
     def cluster_asset_ids(self, person_id: str) -> list[str]:
         repository = self.repository()

--- a/src/iPhoto/people/state_repository.py
+++ b/src/iPhoto/people/state_repository.py
@@ -321,6 +321,54 @@ class FaceStateRepository:
                 conn.execute("DELETE FROM person_card_orders")
             conn.commit()
 
+    def get_hidden_person_ids(self, person_ids: Iterable[str]) -> set[str]:
+        unique_ids = _unique_person_ids(person_ids)
+        if not unique_ids:
+            return set()
+
+        self.initialize()
+        placeholders = ", ".join(["?"] * len(unique_ids))
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT person_id
+                FROM hidden_person_cards
+                WHERE person_id IN ({placeholders})
+                """,
+                unique_ids,
+            ).fetchall()
+        return {str(row["person_id"]) for row in rows if row["person_id"]}
+
+    def set_person_hidden(self, person_id: str, hidden: bool) -> bool:
+        if not person_id:
+            return False
+
+        self.initialize()
+        updated_at = _utc_now_iso()
+        with closing(self._connect()) as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM hidden_person_cards WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if hidden:
+                conn.execute(
+                    """
+                    INSERT INTO hidden_person_cards (person_id, updated_at)
+                    VALUES (?, ?)
+                    ON CONFLICT(person_id) DO UPDATE SET
+                        updated_at = excluded.updated_at
+                    """,
+                    (person_id, updated_at),
+                )
+                conn.commit()
+                return existing is None
+
+            if existing is None:
+                return False
+            conn.execute("DELETE FROM hidden_person_cards WHERE person_id = ?", (person_id,))
+            conn.commit()
+            return True
+
     def rename_person(self, person_id: str, name_or_none: str | None) -> None:
         self.initialize()
         updated_at = _utc_now_iso()
@@ -472,6 +520,25 @@ class FaceStateRepository:
                     (target_person_id, merged_order, updated_at),
                 )
             conn.execute("DELETE FROM person_card_orders WHERE person_id = ?", (source_person_id,))
+            source_hidden = conn.execute(
+                "SELECT 1 FROM hidden_person_cards WHERE person_id = ?",
+                (source_person_id,),
+            ).fetchone()
+            target_hidden = conn.execute(
+                "SELECT 1 FROM hidden_person_cards WHERE person_id = ?",
+                (target_person_id,),
+            ).fetchone()
+            if source_hidden is not None or target_hidden is not None:
+                conn.execute(
+                    """
+                    INSERT INTO hidden_person_cards (person_id, updated_at)
+                    VALUES (?, ?)
+                    ON CONFLICT(person_id) DO UPDATE SET
+                        updated_at = excluded.updated_at
+                    """,
+                    (target_person_id, updated_at),
+                )
+            conn.execute("DELETE FROM hidden_person_cards WHERE person_id = ?", (source_person_id,))
             conn.execute("DELETE FROM person_profiles WHERE person_id = ?", (source_person_id,))
             group_redirects = self._remap_groups_for_merged_person(
                 conn,
@@ -636,6 +703,21 @@ class FaceStateRepository:
         self.initialize()
         with closing(self._connect()) as conn:
             return self._group_from_id(conn, group_id)
+
+    def delete_group(self, group_id: str) -> bool:
+        if not group_id:
+            return False
+        self.initialize()
+        with closing(self._connect()) as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM people_groups WHERE group_id = ?",
+                (group_id,),
+            ).fetchone()
+            if existing is None:
+                return False
+            conn.execute("DELETE FROM people_groups WHERE group_id = ?", (group_id,))
+            conn.commit()
+        return True
 
     def has_group_asset_cache(self, group_id: str) -> bool:
         if not group_id:
@@ -1026,6 +1108,12 @@ class FaceStateRepository:
             "CREATE INDEX IF NOT EXISTS idx_person_card_orders_sort_order "
             "ON person_card_orders(sort_order)"
         )
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS hidden_person_cards (
+                person_id TEXT PRIMARY KEY,
+                updated_at TEXT NOT NULL
+            )
+            """)
         conn.execute("""
             CREATE TABLE IF NOT EXISTS manual_faces (
                 face_id TEXT PRIMARY KEY,

--- a/src/iPhoto/settings/schema.py
+++ b/src/iPhoto/settings/schema.py
@@ -43,6 +43,7 @@ SETTINGS_SCHEMA: dict[str, Any] = {
                 },
                 "show_filmstrip": {"type": "boolean"},
                 "show_face_names_in_detail": {"type": "boolean"},
+                "show_hidden_face_album": {"type": "boolean"},
                 "wheel_action": {
                     "type": "string",
                     "enum": ["navigate", "zoom"],
@@ -71,6 +72,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
         "export_format": "jpg",
         "show_filmstrip": True,
         "show_face_names_in_detail": False,
+        "show_hidden_face_album": False,
         "wheel_action": "navigate",
     },
     "last_open_albums": [],

--- a/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
+++ b/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
@@ -73,6 +73,19 @@ def test_handle_face_name_toggle_changed_persists_setting_and_updates_playback()
     coordinator._playback.set_face_name_display_enabled.assert_called_once_with(True)
 
 
+def test_handle_hidden_face_album_toggle_changed_persists_setting_and_updates_people_page() -> None:
+    coordinator = MainCoordinator.__new__(MainCoordinator)
+    coordinator._context = MagicMock()
+    coordinator._context.settings.get.return_value = False
+    coordinator._context.settings.set = MagicMock()
+    coordinator._window = MagicMock(ui=MagicMock(people_page=MagicMock()))
+
+    coordinator._handle_hidden_face_album_toggle_changed(True)
+
+    coordinator._context.settings.set.assert_called_once_with("ui.show_hidden_face_album", True)
+    coordinator._window.ui.people_page.set_show_hidden_people.assert_called_once_with(True)
+
+
 def test_on_map_asset_activated_delegates_to_navigation() -> None:
     coordinator = MainCoordinator.__new__(MainCoordinator)
     coordinator._navigation = MagicMock()

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -330,6 +330,7 @@ def test_people_cluster_gallery_loads_query_and_returns_to_people(tmp_path: Path
     store.load_selection.assert_called_once_with(tmp_path, query=query)
     assert vm.static_selection.value == "People"
     assert vm.current_section.value == "people_cluster_gallery"
+    assert vm.current_people_cluster_context() is None
     assert vm.cluster_gallery_back_tooltip() == "Return to People"
     assert vm.is_in_cluster_gallery() is True
 
@@ -339,6 +340,16 @@ def test_people_cluster_gallery_loads_query_and_returns_to_people(tmp_path: Path
     assert vm.current_section.value == "people_dashboard"
     assert vm.static_selection.value == "People"
     assert vm.is_in_cluster_gallery() is False
+
+
+def test_people_cluster_gallery_exposes_current_context(tmp_path: Path) -> None:
+    vm, store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    query = AssetQuery(asset_ids=["asset-1"])
+
+    vm.open_people_cluster_gallery(query, kind="group", entity_id="group-1")
+
+    store.load_selection.assert_called_once_with(tmp_path, query=query)
+    assert vm.current_people_cluster_context() == ("group", "group-1")
 
 
 def test_people_cluster_gallery_retargets_after_snapshot_redirect(tmp_path: Path) -> None:
@@ -436,6 +447,31 @@ def test_people_cluster_gallery_retargets_after_snapshot_redirect(tmp_path: Path
     reloaded_query = store.load_selection.call_args.kwargs["query"]
     assert reloaded_query.asset_ids == ["asset-b", "asset-a"]
     assert vm.current_query.value.asset_ids == ["asset-b", "asset-a"]
+
+
+def test_people_group_gallery_returns_to_dashboard_when_group_deleted(tmp_path: Path) -> None:
+    vm, store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    routes = []
+    vm.route_requested.connect(routes.append)
+
+    vm.open_people_cluster_gallery(
+        AssetQuery(asset_ids=["asset-a"]),
+        kind="group",
+        entity_id="group-a",
+    )
+    store.load_selection.reset_mock()
+
+    event = PeopleSnapshotEvent(
+        library_root=tmp_path,
+        revision=1,
+        changed_group_ids=("group-a",),
+        group_redirects={"group-a": None},
+    )
+    vm.handle_people_snapshot_committed(event)
+
+    store.load_selection.assert_not_called()
+    assert routes == ["gallery", "people"]
+    assert vm.current_section.value == "people_dashboard"
 
 
 def test_toggle_favorite_row_updates_store_via_asset_service(tmp_path: Path) -> None:

--- a/tests/gui/widgets/test_people_dashboard_widget.py
+++ b/tests/gui/widgets/test_people_dashboard_widget.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import QObject, Qt, Signal
 from PySide6.QtGui import QColor, QImage, QPixmap
 from PySide6.QtWidgets import QApplication, QWidget
 
+from iPhoto.gui.ui.widgets import dialogs as widget_dialogs
 from iPhoto.gui.ui.widgets import people_dashboard_cards
 from iPhoto.gui.ui.widgets import people_dashboard_dialogs
 from iPhoto.gui.ui.widgets.people_dashboard import (
@@ -115,6 +116,268 @@ def test_people_card_menu_contains_new_group(qapp: QApplication) -> None:
 
     assert "New Group" in action_texts
     assert action_texts.index("New Group") < action_texts.index("Merge Into...")
+
+
+def test_people_card_menu_contains_hide_action(qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    widget._summaries = [
+        PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z"),
+        PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z"),
+    ]
+
+    menu = widget._build_card_menu(widget._summaries[0])
+    action_texts = [action.text() for action in menu.actions()]
+
+    assert "Hide This People" in action_texts
+
+
+def test_people_card_menu_switches_to_unhide_when_hidden_items_are_shown(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    widget._show_hidden_people = True
+    widget._summaries = [
+        PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z"),
+    ]
+    monkeypatch.setattr(widget._service, "is_cluster_card_hidden", lambda person_id: person_id == "person-a")
+
+    menu = widget._build_card_menu(widget._summaries[0])
+    action_texts = [action.text() for action in menu.actions()]
+
+    assert "Unhide This People" in action_texts
+
+
+def test_group_card_menu_contains_dissolve_action(qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    alice = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")
+    bob = PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z")
+    summary = PeopleGroupSummary(
+        group_id="group-ab",
+        name="Alice and Bob",
+        member_person_ids=("person-a", "person-b"),
+        members=(alice, bob),
+        asset_count=1,
+        cover_asset_path=None,
+        created_at="2024-01-01T00:00:02Z",
+    )
+
+    menu = widget._build_group_card_menu(summary)
+    action_texts = [action.text() for action in menu.actions()]
+
+    assert action_texts == ["Dissolve Group"]
+
+
+def test_hide_person_reuses_merge_confirm_dialog(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    summary = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")
+    calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        MergeConfirmDialog,
+        "confirm_custom",
+        staticmethod(
+            lambda **kwargs: calls.append(
+                (kwargs["title_text"], kwargs["body_text"], kwargs["confirm_text"])
+            )
+            or True
+        ),
+    )
+    monkeypatch.setattr(widget._service, "hide_cluster_card", lambda person_id: person_id == "person-a")
+    monkeypatch.setattr(widget, "reload", lambda **_kwargs: None)
+
+    widget._hide_person(summary)
+
+    assert calls == [
+        (
+            "Hide This Person?",
+            "This person will be hidden from the People dashboard until you choose to show hidden face albums.",
+            "Hide",
+        )
+    ]
+
+
+def test_dissolve_group_reuses_merge_confirm_dialog(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    alice = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")
+    bob = PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z")
+    summary = PeopleGroupSummary(
+        group_id="group-ab",
+        name="Alice and Bob",
+        member_person_ids=("person-a", "person-b"),
+        members=(alice, bob),
+        asset_count=1,
+        cover_asset_path=None,
+        created_at="2024-01-01T00:00:02Z",
+    )
+    calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        MergeConfirmDialog,
+        "confirm_custom",
+        staticmethod(
+            lambda **kwargs: calls.append(
+                (kwargs["title_text"], kwargs["body_text"], kwargs["confirm_text"])
+            )
+            or True
+        ),
+    )
+    monkeypatch.setattr(widget._service, "delete_group", lambda group_id: group_id == "group-ab")
+    monkeypatch.setattr(widget, "reload", lambda **_kwargs: None)
+
+    widget._dissolve_group(summary)
+
+    assert calls == [
+        (
+            "Dissolve This Group?",
+            "This will remove the group card. The people inside it will remain unchanged.",
+            "Dissolve Group",
+        )
+    ]
+
+
+def test_rename_person_uses_themed_input_dialog(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    summary = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")
+    prompts: list[tuple[str, str, str]] = []
+    rename_calls: list[tuple[str, str | None]] = []
+    reload_calls: list[bool] = []
+
+    monkeypatch.setattr(
+        widget_dialogs,
+        "prompt_text_input",
+        lambda _parent, title, label, *, text="": prompts.append((title, label, text))
+        or ("Alice Cooper", True),
+    )
+    monkeypatch.setattr(
+        widget._service,
+        "rename_cluster",
+        lambda person_id, name: rename_calls.append((person_id, name)),
+    )
+    monkeypatch.setattr(
+        widget,
+        "reload",
+        lambda *, preserve_content=False: reload_calls.append(preserve_content),
+    )
+    widget._summaries = [summary]
+
+    widget._rename_person(summary)
+
+    assert prompts == [("Rename Person", "Name:", "Alice")]
+    assert rename_calls == [("person-a", "Alice Cooper")]
+    assert reload_calls == [True]
+
+
+def test_merge_person_uses_themed_item_dialog(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    source = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")
+    target = PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z")
+    widget._summaries = [source, target]
+    prompts: list[tuple[str, str, tuple[str, ...]]] = []
+    merges: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        widget_dialogs,
+        "prompt_item_selection",
+        lambda _parent, title, label, items: prompts.append((title, label, tuple(items)))
+        or ("Bob (2 faces)", True),
+    )
+    monkeypatch.setattr(
+        widget,
+        "_confirm_merge",
+        lambda source_person_id, target_person_id: merges.append((source_person_id, target_person_id))
+        or True,
+    )
+
+    widget._merge_person(source)
+
+    assert prompts == [("Merge Person", "Merge into:", ("Bob (2 faces)",))]
+    assert merges == [("person-a", "person-b")]
+
+
+def test_merge_is_blocked_when_hidden_state_is_mixed(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    widget._summaries = [
+        PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z"),
+        PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z"),
+    ]
+
+    popups: list[tuple[str, str]] = []
+    confirm_calls: list[int] = []
+    merge_calls: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        widget._service,
+        "is_cluster_card_hidden",
+        lambda person_id: person_id == "person-a",
+    )
+    monkeypatch.setattr(
+        widget_dialogs,
+        "show_information",
+        lambda _parent, message, *, title="iPhoto": popups.append((title, message)),
+    )
+    monkeypatch.setattr(
+        MergeConfirmDialog,
+        "confirm",
+        staticmethod(lambda _people_count, _parent=None: confirm_calls.append(1) or True),
+    )
+    monkeypatch.setattr(
+        widget._service,
+        "merge_clusters",
+        lambda source_person_id, target_person_id: merge_calls.append(
+            (source_person_id, target_person_id)
+        )
+        or True,
+    )
+
+    merged = widget._confirm_merge("person-a", "person-b")
+
+    assert merged is False
+    assert confirm_calls == []
+    assert merge_calls == []
+    assert popups == [
+        (
+            "Cannot Merge People",
+            "People in hidden and visible states cannot be merged. "
+            "Please make both People cards hidden or visible first.",
+        )
+    ]
+
+
+def test_merge_continues_when_hidden_state_matches(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    widget._summaries = [
+        PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z"),
+        PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z"),
+    ]
+
+    confirm_calls: list[int] = []
+    merge_calls: list[tuple[str, str]] = []
+    reload_calls: list[bool] = []
+
+    monkeypatch.setattr(widget._service, "is_cluster_card_hidden", lambda _person_id: False)
+    monkeypatch.setattr(
+        MergeConfirmDialog,
+        "confirm",
+        staticmethod(lambda _people_count, _parent=None: confirm_calls.append(1) or True),
+    )
+    monkeypatch.setattr(
+        widget._service,
+        "merge_clusters",
+        lambda source_person_id, target_person_id: merge_calls.append(
+            (source_person_id, target_person_id)
+        )
+        or True,
+    )
+    monkeypatch.setattr(
+        widget,
+        "reload",
+        lambda *, preserve_content=False: reload_calls.append(preserve_content),
+    )
+
+    merged = widget._confirm_merge("person-a", "person-b")
+
+    assert merged is True
+    assert confirm_calls == [1]
+    assert merge_calls == [("person-a", "person-b")]
+    assert reload_calls == [True]
 
 
 def test_people_card_requests_thumbnail_artwork_immediately(
@@ -382,3 +645,50 @@ def test_status_message_updates_without_reloading_cards(qapp: QApplication) -> N
 
     assert widget._board.visible_cards()[0] is original_card
     assert "Click a cluster or group card" in widget._message.text()
+
+
+def test_groups_without_visible_people_still_show_scroll_content(qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    alice = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")
+    bob = PersonSummary("person-b", "Bob", "face-b", 2, None, "2024-01-01T00:00:01Z")
+
+    widget._on_load_completed(
+        generation=0,
+        index_version=0,
+        is_bound=True,
+        summaries=[],
+        groups=[
+            PeopleGroupSummary(
+                group_id="group-ab",
+                name="Alice and Bob",
+                member_person_ids=("person-a", "person-b"),
+                members=(alice, bob),
+                asset_count=1,
+                cover_asset_path=None,
+                created_at="2024-01-01T00:00:02Z",
+            )
+        ],
+        pending=0,
+        status_message=None,
+    )
+
+    assert widget._scroll.isHidden() is False
+    assert widget._empty.isHidden() is True
+    assert "group card" in widget._message.text().lower()
+
+
+def test_set_show_hidden_people_triggers_reload_only_on_change(monkeypatch, qapp: QApplication) -> None:
+    widget = PeopleDashboardWidget()
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        widget,
+        "reload",
+        lambda *, preserve_content=False: calls.append(bool(preserve_content)),
+    )
+    widget._summaries = [PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")]
+
+    widget.set_show_hidden_people(True)
+    widget.set_show_hidden_people(True)
+    widget.set_show_hidden_people(False)
+
+    assert calls == [True, True]

--- a/tests/gui/widgets/test_people_dashboard_widget.py
+++ b/tests/gui/widgets/test_people_dashboard_widget.py
@@ -128,7 +128,7 @@ def test_people_card_menu_contains_hide_action(qapp: QApplication) -> None:
     menu = widget._build_card_menu(widget._summaries[0])
     action_texts = [action.text() for action in menu.actions()]
 
-    assert "Hide This People" in action_texts
+    assert "Hide This Person" in action_texts
 
 
 def test_people_card_menu_switches_to_unhide_when_hidden_items_are_shown(monkeypatch, qapp: QApplication) -> None:
@@ -142,7 +142,7 @@ def test_people_card_menu_switches_to_unhide_when_hidden_items_are_shown(monkeyp
     menu = widget._build_card_menu(widget._summaries[0])
     action_texts = [action.text() for action in menu.actions()]
 
-    assert "Unhide This People" in action_texts
+    assert "Unhide This Person" in action_texts
 
 
 def test_group_card_menu_contains_dissolve_action(qapp: QApplication) -> None:

--- a/tests/gui/widgets/test_people_dashboard_widget.py
+++ b/tests/gui/widgets/test_people_dashboard_widget.py
@@ -233,6 +233,37 @@ def test_dissolve_group_reuses_merge_confirm_dialog(monkeypatch, qapp: QApplicat
     ]
 
 
+def test_merge_confirm_dialog_supports_light_and_dark_styles(qapp: QApplication) -> None:
+    class Theme:
+        def __init__(self, mode: str) -> None:
+            self.mode = mode
+
+        def get_effective_theme_mode(self) -> str:
+            return self.mode
+
+    light_shell = QWidget()
+    light_shell.coordinator = SimpleNamespace(
+        _context=SimpleNamespace(theme=Theme("light"), settings=None)
+    )
+    dark_shell = QWidget()
+    dark_shell.coordinator = SimpleNamespace(
+        _context=SimpleNamespace(theme=Theme("dark"), settings=None)
+    )
+
+    light_dialog = MergeConfirmDialog(2, parent=light_shell)
+    dark_dialog = MergeConfirmDialog(2, parent=dark_shell)
+
+    assert light_dialog._dark_mode is False
+    assert "rgba(255, 255, 255, 0.94)" in light_dialog._panel.styleSheet()
+    assert dark_dialog._dark_mode is True
+    assert "rgba(23, 27, 39, 0.98)" in dark_dialog._panel.styleSheet()
+
+    light_dialog.close()
+    dark_dialog.close()
+    light_shell.close()
+    dark_shell.close()
+
+
 def test_rename_person_uses_themed_input_dialog(monkeypatch, qapp: QApplication) -> None:
     widget = PeopleDashboardWidget()
     summary = PersonSummary("person-a", "Alice", "face-a", 3, None, "2024-01-01T00:00:00Z")

--- a/tests/test_information_popup.py
+++ b/tests/test_information_popup.py
@@ -89,6 +89,7 @@ def test_frameless_window_flags(qapp: QApplication) -> None:
     popup = InformationPopup()
     flags = popup.windowFlags()
     assert flags & Qt.WindowType.FramelessWindowHint
+    assert flags & Qt.WindowType.Tool
     popup.close()
 
 

--- a/tests/test_information_popup.py
+++ b/tests/test_information_popup.py
@@ -10,7 +10,7 @@ pytest.importorskip("PySide6", reason="PySide6 is required for GUI tests", exc_t
 pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets not available", exc_type=ImportError)
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QColor
+from PySide6.QtGui import QColor, QImage, QPalette
 from PySide6.QtWidgets import QApplication
 
 from iPhoto.gui.ui.widgets.information_popup import InformationPopup
@@ -245,4 +245,33 @@ def test_popup_resolves_transparent_palette_background_to_opaque(qapp: QApplicat
     assert resolved.red() == transparent_window.red()
     assert resolved.green() == transparent_window.green()
     assert resolved.blue() == transparent_window.blue()
+    popup.close()
+
+
+def test_popup_child_widgets_do_not_paint_black_background_in_light_mode(qapp: QApplication) -> None:
+    """The title bar and body should stay transparent over the painted light background."""
+
+    popup = InformationPopup(title="Notice", message="Blocked merge")
+    palette = QPalette(popup.palette())
+    palette.setColor(QPalette.ColorRole.Window, QColor("#F5F5F5"))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor("#2B2B2B"))
+    palette.setColor(QPalette.ColorRole.Mid, QColor("#808080"))
+    popup.setPalette(palette)
+    popup.resize(360, 140)
+    popup.show()
+    qapp.processEvents()
+
+    image = QImage(popup.size(), QImage.Format.Format_ARGB32_Premultiplied)
+    image.fill(Qt.GlobalColor.transparent)
+    popup.render(image)
+
+    title_bar_pixel = image.pixelColor(24, 16)
+    body_pixel = image.pixelColor(24, 72)
+
+    assert title_bar_pixel.red() > 200
+    assert title_bar_pixel.green() > 200
+    assert title_bar_pixel.blue() > 200
+    assert body_pixel.red() > 200
+    assert body_pixel.green() > 200
+    assert body_pixel.blue() > 200
     popup.close()

--- a/tests/test_information_popup.py
+++ b/tests/test_information_popup.py
@@ -10,6 +10,7 @@ pytest.importorskip("PySide6", reason="PySide6 is required for GUI tests", exc_t
 pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets not available", exc_type=ImportError)
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QApplication
 
 from iPhoto.gui.ui.widgets.information_popup import InformationPopup
@@ -136,3 +137,112 @@ def test_show_information_uses_information_popup(qapp: QApplication) -> None:
     assert captured[0]["title"] == "Test Title"
     assert captured[0]["message"] == "Test message"
     parent.close()
+
+
+def test_show_information_uses_dark_theme_context(qapp: QApplication) -> None:
+    """The popup should follow dark mode from the hosting window context."""
+
+    from types import SimpleNamespace
+
+    from PySide6.QtCore import QTimer
+    from PySide6.QtWidgets import QWidget
+
+    from iPhoto.gui.ui.widgets import dialogs
+
+    class Theme:
+        def get_effective_theme_mode(self) -> str:
+            return "dark"
+
+    shell = QWidget()
+    shell.coordinator = SimpleNamespace(
+        _context=SimpleNamespace(theme=Theme(), settings=None)
+    )
+
+    parent = QWidget(shell)
+    captured: list[tuple[str, str, str]] = []
+
+    def _check_and_close() -> None:
+        children = parent.findChildren(InformationPopup)
+        for child in children:
+            palette = child.palette()
+            captured.append(
+                (
+                    palette.color(QPalette.ColorRole.Window).name(),
+                    palette.color(QPalette.ColorRole.WindowText).name(),
+                    palette.color(QPalette.ColorRole.Mid).name(),
+                )
+            )
+            child.close()
+
+    QTimer.singleShot(50, _check_and_close)
+    dialogs.show_information(parent, "Test message", title="Test Title")
+
+    assert captured == [("#1c1c1e", "#f5f5f7", "#323236")]
+    parent.close()
+    shell.close()
+
+
+def test_show_information_prefers_window_theme_context_over_bad_palette(qapp: QApplication) -> None:
+    """The popup should follow light mode from window context even if the palette is wrong."""
+
+    from types import SimpleNamespace
+
+    from PySide6.QtCore import QTimer
+    from PySide6.QtGui import QColor, QPalette
+    from PySide6.QtWidgets import QWidget
+
+    from iPhoto.gui.ui.widgets import dialogs
+
+    class Theme:
+        def get_effective_theme_mode(self) -> str:
+            return "light"
+
+    shell = QWidget()
+    shell.coordinator = SimpleNamespace(
+        _context=SimpleNamespace(theme=Theme(), settings=None)
+    )
+    shell_palette = QPalette(shell.palette())
+    shell_palette.setColor(QPalette.ColorRole.Window, QColor("#000000"))
+    shell_palette.setColor(QPalette.ColorRole.WindowText, QColor("#FFFFFF"))
+    shell_palette.setColor(QPalette.ColorRole.Mid, QColor("#000000"))
+    shell.setPalette(shell_palette)
+
+    parent = QWidget(shell)
+    captured: list[tuple[str, str, str]] = []
+
+    def _check_and_close() -> None:
+        children = parent.findChildren(InformationPopup)
+        for child in children:
+            palette = child.palette()
+            captured.append(
+                (
+                    palette.color(QPalette.ColorRole.Window).name(),
+                    palette.color(QPalette.ColorRole.WindowText).name(),
+                    palette.color(QPalette.ColorRole.Mid).name(),
+                )
+            )
+            child.close()
+
+    QTimer.singleShot(50, _check_and_close)
+    dialogs.show_information(parent, "Test message", title="Test Title")
+
+    assert captured == [("#f5f5f5", "#2b2b2b", "#000000")]
+    parent.close()
+    shell.close()
+
+
+def test_popup_resolves_transparent_palette_background_to_opaque(qapp: QApplication) -> None:
+    """The popup should not keep a transparent window fill from the palette."""
+
+    popup = InformationPopup()
+
+    transparent_window = QColor("#EEF3F6")
+    transparent_window.setAlpha(0)
+
+    resolved = popup._resolve_colour(transparent_window, QColor("#000000"))
+
+    assert resolved.alpha() == 255
+    assert resolved.red() == transparent_window.red()
+    assert resolved.green() == transparent_window.green()
+    assert resolved.blue() == transparent_window.blue()
+    popup.close()

--- a/tests/test_people_repository.py
+++ b/tests/test_people_repository.py
@@ -99,7 +99,7 @@ def test_remove_faces_for_assets_deletes_affected_person_rows_first(tmp_path: Pa
     assert repository.get_person_summaries() == []
 
 
-def test_person_cover_persists_and_custom_cover_survives_rescan(tmp_path: Path) -> None:
+def test_person_cover_can_be_set_to_custom_face(tmp_path: Path) -> None:
     repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
     faces = [
         _face_record(

--- a/tests/test_people_repository.py
+++ b/tests/test_people_repository.py
@@ -138,11 +138,68 @@ def test_person_cover_persists_and_custom_cover_survives_rescan(tmp_path: Path) 
         == (tmp_path / "thumbnails/custom.jpg").resolve()
     )
 
-    repository.replace_all(faces, [person])
-    assert (
-        repository.get_person_summaries()[0].thumbnail_path
-        == (tmp_path / "thumbnails/custom.jpg").resolve()
-    )
+
+def test_set_person_cover_from_asset_uses_matching_face_on_asset(tmp_path: Path) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    faces = [
+        _face_record(
+            face_id="face-a",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            thumbnail_path="thumbnails/a.jpg",
+        ),
+        _face_record(
+            face_id="face-b",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            thumbnail_path="thumbnails/b.jpg",
+        ),
+    ]
+    persons = [
+        _person_record(person_id="person-a", key_face_id="face-a", face_count=1, name="Alice"),
+        _person_record(person_id="person-b", key_face_id="face-b", face_count=1, name="Bob"),
+    ]
+    repository.replace_all(faces, persons)
+
+    assert repository.set_person_cover_from_asset("person-b", "asset-shared") is True
+    assert repository.state_repository is not None
+    assert repository.state_repository.get_person_cover_thumbnail_map(["person-b"]) == {
+        "person-b": "thumbnails/b.jpg"
+    }
+    assert repository.set_person_cover_from_asset("person-a", "asset-missing") is False
+
+
+def test_hidden_person_ids_persist_and_follow_merge(tmp_path: Path) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    faces = [
+        _face_record(
+            face_id="face-a",
+            asset_id="asset-a",
+            asset_rel="album/a.jpg",
+            person_id="person-a",
+        ),
+        _face_record(
+            face_id="face-b",
+            asset_id="asset-b",
+            asset_rel="album/b.jpg",
+            person_id="person-b",
+        ),
+    ]
+    persons = [
+        _person_record(person_id="person-a", key_face_id="face-a", face_count=1, name="Alice"),
+        _person_record(person_id="person-b", key_face_id="face-b", face_count=1, name="Bob"),
+    ]
+    repository.replace_all(faces, persons)
+
+    assert repository.set_person_hidden("person-a", True) is True
+    assert repository.get_hidden_person_ids(["person-a", "person-b"]) == {"person-a"}
+
+    merged, _group_redirects = repository.merge_persons_with_redirects("person-a", "person-b")
+
+    assert merged is True
+    assert repository.get_hidden_person_ids(["person-a", "person-b"]) == {"person-b"}
 
 
 def test_person_card_order_persists_across_reload(tmp_path: Path) -> None:
@@ -334,6 +391,38 @@ def test_group_cover_can_be_customized_without_rescan_overwrite(tmp_path: Path) 
 
     repository.replace_all(faces, persons)
     assert repository.get_group_cover_asset_id(group.group_id) == "asset-older"
+
+
+def test_delete_group_removes_group_and_cached_assets(tmp_path: Path) -> None:
+    repository = FaceRepository(tmp_path / "face_index.db", tmp_path / "face_state.db")
+    faces = [
+        _face_record(
+            face_id="face-a",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+        ),
+        _face_record(
+            face_id="face-b",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+        ),
+    ]
+    persons = [
+        _person_record(person_id="person-a", key_face_id="face-a", face_count=1, name="Alice"),
+        _person_record(person_id="person-b", key_face_id="face-b", face_count=1, name="Bob"),
+    ]
+    repository.replace_all(faces, persons)
+
+    group = repository.create_group(["person-a", "person-b"])
+    assert group is not None
+    assert repository.get_common_asset_ids_for_group(group.group_id) == ["asset-shared"]
+
+    assert repository.delete_group(group.group_id) is True
+    assert repository.get_group(group.group_id) is None
+    assert repository.list_groups() == []
+    assert repository.get_common_asset_ids_for_group(group.group_id) == []
 
 
 def test_merge_persons_rewrites_group_memberships_and_deduplicates_groups(tmp_path: Path) -> None:

--- a/tests/test_people_service.py
+++ b/tests/test_people_service.py
@@ -36,7 +36,14 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _face_record(*, face_id: str, asset_id: str, asset_rel: str, person_id: str) -> FaceRecord:
+def _face_record(
+    *,
+    face_id: str,
+    asset_id: str,
+    asset_rel: str,
+    person_id: str,
+    thumbnail_path: str | None = None,
+) -> FaceRecord:
     embedding = np.asarray([1.0, 0.0, 0.0], dtype=np.float32)
     return FaceRecord(
         face_id=face_id,
@@ -50,7 +57,7 @@ def _face_record(*, face_id: str, asset_id: str, asset_rel: str, person_id: str)
         confidence=0.99,
         embedding=embedding,
         embedding_dim=int(embedding.shape[0]),
-        thumbnail_path=None,
+        thumbnail_path=thumbnail_path,
         person_id=person_id,
         detected_at=_now_iso(),
         image_width=400,
@@ -345,6 +352,108 @@ def test_people_service_uses_persisted_group_cover(tmp_path: Path) -> None:
     assert service.set_group_cover(group.group_id, "asset-older") is True
     listed = service.list_groups()
     assert listed[0].cover_asset_path == library_root / "album/older.jpg"
+
+
+def test_people_service_load_dashboard_hides_hidden_people_cards_only(tmp_path: Path) -> None:
+    library_root = tmp_path / "Library"
+    library_root.mkdir()
+
+    global_repo = get_global_repository(library_root)
+    global_repo.write_rows(
+        [
+            {"rel": "album/shared.jpg", "id": "asset-shared", "media_type": 0, "face_status": "done"},
+        ]
+    )
+
+    service = PeopleService(library_root)
+    repository = service.repository()
+    assert repository is not None
+    faces = [
+        _face_record(
+            face_id="face-a",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+        ),
+        _face_record(
+            face_id="face-b",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+        ),
+    ]
+    persons = [
+        _person_record(person_id="person-a", key_face_id="face-a", face_count=1, name="Alice"),
+        _person_record(person_id="person-b", key_face_id="face-b", face_count=1, name="Bob"),
+    ]
+    repository.replace_all(faces, persons)
+    group = service.create_group(["person-a", "person-b"])
+    assert group is not None
+
+    assert service.hide_cluster_card("person-a") is True
+
+    summaries, groups, pending = service.load_dashboard()
+
+    assert [summary.person_id for summary in summaries] == ["person-b"]
+    assert [item.group_id for item in groups] == [group.group_id]
+    assert groups[0].member_person_ids == ("person-a", "person-b")
+    assert pending == 0
+
+    summaries_all, groups_all, pending_all = service.load_dashboard(show_hidden_people=True)
+    assert [summary.person_id for summary in summaries_all] == ["person-a", "person-b"]
+    assert [item.group_id for item in groups_all] == [group.group_id]
+    assert pending_all == 0
+    assert service.is_cluster_card_hidden("person-a") is True
+    assert service.unhide_cluster_card("person-a") is True
+    assert service.is_cluster_card_hidden("person-a") is False
+
+
+def test_people_service_can_set_person_cover_from_asset_and_delete_group(tmp_path: Path) -> None:
+    library_root = tmp_path / "Library"
+    library_root.mkdir()
+
+    global_repo = get_global_repository(library_root)
+    global_repo.write_rows(
+        [
+            {"rel": "album/shared.jpg", "id": "asset-shared", "media_type": 0, "face_status": "done"},
+        ]
+    )
+
+    service = PeopleService(library_root)
+    repository = service.repository()
+    assert repository is not None
+    faces = [
+        _face_record(
+            face_id="face-a",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-a",
+            thumbnail_path="thumbnails/a.jpg",
+        ),
+        _face_record(
+            face_id="face-b",
+            asset_id="asset-shared",
+            asset_rel="album/shared.jpg",
+            person_id="person-b",
+            thumbnail_path="thumbnails/b.jpg",
+        ),
+    ]
+    persons = [
+        _person_record(person_id="person-a", key_face_id="face-a", face_count=1, name="Alice"),
+        _person_record(person_id="person-b", key_face_id="face-b", face_count=1, name="Bob"),
+    ]
+    repository.replace_all(faces, persons)
+
+    assert service.set_cluster_cover_from_asset("person-b", "asset-shared") is True
+    assert repository.state_repository is not None
+    assert repository.state_repository.get_person_cover_thumbnail_map(["person-b"]) == {
+        "person-b": "thumbnails/b.jpg"
+    }
+
+    group = service.create_group(["person-a", "person-b"])
+    assert group is not None
+    assert service.delete_group(group.group_id) is True
+    assert service.list_groups() == []
 
 
 def test_people_service_load_dashboard_reuses_cluster_snapshot_for_groups(tmp_path: Path) -> None:

--- a/tests/ui/controllers/test_context_menu_operations.py
+++ b/tests/ui/controllers/test_context_menu_operations.py
@@ -7,6 +7,7 @@ import pytest
 
 pytest.importorskip("PySide6", reason="PySide6 is required for context menu tests", exc_type=ImportError)
 
+from iPhoto.gui.ui.controllers import context_menu_controller as context_menu_module
 from iPhoto.gui.ui.controllers.context_menu_controller import ContextMenuController
 
 
@@ -69,3 +70,103 @@ def test_execute_move_to_album_prepares_paths_before_move() -> None:
     controller._execute_move_to_album(destination)
 
     assert events == ["prepare", f"move:{destination}"]
+
+
+def test_handle_context_menu_adds_people_cover_action_only_for_people_cluster_gallery(
+    monkeypatch,
+) -> None:
+    asset_path = Path("D:/library/photo.jpg")
+    recorded_labels: list[str] = []
+
+    class _FakeSignal:
+        def connect(self, _callback) -> None:
+            return None
+
+    class _FakeAction:
+        def __init__(self, text: str) -> None:
+            self._text = text
+            self.triggered = _FakeSignal()
+
+        def text(self) -> str:
+            return self._text
+
+        def setVisible(self, _visible: bool) -> None:
+            return None
+
+    class _FakeSubMenu:
+        def __init__(self) -> None:
+            self._menu_action = _FakeAction("Move to")
+
+        def addAction(self, text: str):
+            return _FakeAction(text)
+
+        def setEnabled(self, _enabled: bool) -> None:
+            return None
+
+        def menuAction(self):
+            return self._menu_action
+
+    class _FakeMenu:
+        def __init__(self, _parent) -> None:
+            self._actions: list[_FakeAction] = []
+
+        def setAttribute(self, *_args, **_kwargs) -> None:
+            return None
+
+        def setAutoFillBackground(self, *_args, **_kwargs) -> None:
+            return None
+
+        def setWindowFlags(self, flags):
+            return flags
+
+        def windowFlags(self):
+            return 0
+
+        def setPalette(self, *_args, **_kwargs) -> None:
+            return None
+
+        def setBackgroundRole(self, *_args, **_kwargs) -> None:
+            return None
+
+        def setStyleSheet(self, *_args, **_kwargs) -> None:
+            return None
+
+        def setGraphicsEffect(self, *_args, **_kwargs) -> None:
+            return None
+
+        def addAction(self, text: str):
+            action = _FakeAction(text)
+            self._actions.append(action)
+            return action
+
+        def addMenu(self, _text: str):
+            return _FakeSubMenu()
+
+        def addSeparator(self) -> None:
+            return None
+
+        def exec(self, _global_pos) -> None:
+            recorded_labels[:] = [action.text() for action in self._actions]
+
+    monkeypatch.setattr(context_menu_module, "QMenu", _FakeMenu)
+
+    controller, _facade = _make_controller(selected_paths=[asset_path])
+    controller._collect_move_targets = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+    selection_model = controller._grid_view.selectionModel.return_value
+    index = MagicMock()
+    index.isValid.return_value = True
+    index.row.return_value = 0
+    index.data.return_value = "asset-1"
+    selection_model.isSelected.return_value = True
+    controller._grid_view.indexAt.return_value = index
+    controller._grid_view.viewport.return_value.mapToGlobal.return_value = object()
+    controller._grid_view.window.return_value = None
+
+    controller._people_cover_context_provider = lambda: ("person", "person-a")
+    controller._handle_context_menu(MagicMock())
+    assert "Set as Cover" in recorded_labels
+
+    controller._people_cover_context_provider = lambda: None
+    controller._handle_context_menu(MagicMock())
+    assert "Set as Cover" not in recorded_labels


### PR DESCRIPTION
This pull request introduces several improvements to the iPhoto application's UI and user experience, focusing on enhanced theming support for dialogs and popups, new functionality for managing people cluster covers, and better state handling for hidden face albums. The changes are grouped into three main themes:

**1. Theming and UI Consistency Improvements**

* Added theme-aware palette and style application for popups and input dialogs, ensuring that dialogs (like information popups and input prompts) consistently match the application's current theme, including light/dark modes. This includes new utility functions (`_resolve_popup_palette_source`, `_apply_input_dialog_theme`, etc.) and applies these palettes to popups and dialogs. (`src/iPhoto/gui/ui/widgets/dialogs.py`, `src/iPhoto/gui/ui/widgets/information_popup.py`) [[1]](diffhunk://#diff-e38f62494ab73c9cda972f348dbb0c78b8f05d1adfb3d6c5b32b26f74d266574R45-R96) [[2]](diffhunk://#diff-e38f62494ab73c9cda972f348dbb0c78b8f05d1adfb3d6c5b32b26f74d266574R121-R122) [[3]](diffhunk://#diff-e38f62494ab73c9cda972f348dbb0c78b8f05d1adfb3d6c5b32b26f74d266574R134-R230) [[4]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR48-R54) [[5]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aL78) [[6]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR116) [[7]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR150-R158) [[8]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR172-R195)
* Updated `InformationPopup` to use `Qt.Tool` window type and improved its focus and appearance handling for better integration with the OS and application theme. (`src/iPhoto/gui/ui/widgets/information_popup.py`) [[1]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR48-R54) [[2]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR116) [[3]](diffhunk://#diff-e3ed56edb2250a8bd3e14acf88c481a308abe0b24dea80b55d9f920cfe299f4aR172-R195)

**2. People Cluster Cover Management**

* Added the ability to set the cover image for a person or group in the people album via the context menu. This includes new context menu actions, asset ID resolution, and callback integration with the main coordinator for updating the cover. (`src/iPhoto/gui/ui/controllers/context_menu_controller.py`, `src/iPhoto/gui/coordinators/main_coordinator.py`) [[1]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1R50-R51) [[2]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1R65-R66) [[3]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1R157-R171) [[4]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1R394-R424) [[5]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR282-R283) [[6]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR622-R632)

**3. Hidden Face Album State Handling**

* Added UI and coordinator logic to handle toggling the visibility of the hidden face album, including restoring the user's preference from settings and updating the UI accordingly. (`src/iPhoto/gui/coordinators/main_coordinator.py`, `src/iPhoto/gui/ui/ui_main_window.py`) [[1]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR427) [[2]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR658-R665) [[3]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR700-R704) [[4]](diffhunk://#diff-faf6bcc2ade5504d2ad01246f0373d7d587b2f8d74d626ff7844b2450dc83884R127)

These changes collectively improve the application's usability, visual consistency, and feature set, especially for users managing people albums and those using custom themes.