### PR TITLE
Hide "Pinned" sidebar section when empty

### DIFF
--- a/src/iPhoto/gui/ui/models/album_tree_model.py
+++ b/src/iPhoto/gui/ui/models/album_tree_model.py
@@ -230,9 +230,10 @@ class AlbumTreeModel(QAbstractItemModel):
         self._root_item.add_child(AlbumTreeItem("──────────", NodeType.SEPARATOR))
 
         pinned_header = AlbumTreeItem("Pinned", NodeType.HEADER)
-        self._root_item.add_child(pinned_header)
         self._add_pinned_nodes(pinned_header, library_root)
-        self._root_item.add_child(AlbumTreeItem("──────────", NodeType.SEPARATOR))
+        if pinned_header.children:
+            self._root_item.add_child(pinned_header)
+            self._root_item.add_child(AlbumTreeItem("──────────", NodeType.SEPARATOR))
 
         # Promote the Albums section to a header-level entry so that it shares the
         # same visual hierarchy, font weight, and font size as the "Basic Library"

--- a/tests/test_album_tree_model.py
+++ b/tests/test_album_tree_model.py
@@ -134,3 +134,18 @@ def test_model_inserts_pinned_section_between_library_and_albums(tmp_path: Path,
     assert trips_index is not None
     assert model.data(alice_index, AlbumTreeRole.NODE_TYPE) == NodeType.PINNED_PERSON
     assert model.data(trips_index, AlbumTreeRole.NODE_TYPE) == NodeType.PINNED_ALBUM
+
+
+def test_model_omits_pinned_section_when_empty(tmp_path: Path, qapp: QApplication) -> None:
+    root = tmp_path / "Library"
+    root.mkdir()
+    _create_album(root, "Trips")
+    manager = LibraryManager()
+    manager.bind_path(root)
+    qapp.processEvents()
+
+    model = AlbumTreeModel(manager)
+    qapp.processEvents()
+
+    pinned_index = _find_child(model, QModelIndex(), "Pinned")
+    assert pinned_index is None


### PR DESCRIPTION
This PR hides the "Pinned" sidebar header and its trailing divider when there are no pinned items to show, ensuring a cleaner visual hierarchy.

---
*PR created automatically by Jules for task [8152954007404531965](https://jules.google.com/task/8152954007404531965) started by @OliverZhaohaibin*