### PR TITLE
Fix album dashboard renaming and refresh cover issues

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -73,6 +73,36 @@ Includes: `pytest`, `pytest-mock`, `pytest-qt`, `ruff`, `black`, `mypy`, `types-
 
 ---
 
+## Album Naming Rules
+
+Album creation and rename flows must reject directory names reserved for
+internal library infrastructure. Today the reserved names are:
+
+- `.iPhoto`
+- `.Trash`
+- `exported`
+
+These names are intentionally hidden by the library scan layer and therefore
+must never be accepted as user album names. If a create/rename flow allows one
+of them, the album can appear to "disappear" because the directory still exists
+on disk but is filtered out of the visible album tree/dashboard.
+
+Implementation rules:
+
+- Keep the validation in the library layer so every entry point stays aligned
+  (`album dashboard`, sidebar menus, and any future CLI/API path).
+- Keep the reserved-name list in a single shared source of truth used by both
+  name validation and album discovery.
+- Raise a normal `LibraryError` path such as `AlbumOperationError` with a clear
+  user-facing message; UI surfaces should only display the warning and should
+  not duplicate the rule locally.
+- Add regression coverage when touching album naming logic:
+  library tests should verify reserved names are rejected and existing albums
+  remain listed, while UI tests should verify reserved-name rename attempts show
+  a warning instead of removing the album from the dashboard.
+
+---
+
 ## Maps Extension Development Workflow
 
 ### What the maps extension is

--- a/docs/development.md
+++ b/docs/development.md
@@ -386,6 +386,30 @@ can inherit that translucency and render with a transparent background.
 - When adding a new right-click surface, add or update a focused GUI test that
   verifies the menu is styled and that important actions are present.
 
+#### Unified Right-Click Menu Rules
+
+The app now treats sidebar, dashboard, and gallery context menus as one shared
+interaction system. When you add or change a right-click entry, keep these
+rules aligned across surfaces:
+
+- Use `MenuContext` + `populate_menu()` for declarative menus whenever the
+  surface already participates in the shared menu system.
+- Right-clicking an asset in gallery must first sync selection to the clicked
+  row before computing menu visibility, so selection-scoped actions operate on
+  the intended asset.
+- Album-cover actions must resolve paths relative to the active album root
+  before calling `facade.set_cover(...)`. Do not assume `AssetDTO.rel_path`
+  already matches the current album root.
+- `Rename…` is the canonical label for rename actions. Use the same ellipsis
+  style and the same empty-name validation across sidebar and pinned-item menus.
+- Pinned-item rename is a sidebar-local alias. Persist it through
+  `PinnedItemsService` instead of mutating the underlying album/person/group
+  entity name.
+- `Pin`/`Unpin` and `Rename…` should stay adjacent on sidebar-driven menus so
+  users can manage the same entity without hunting across different surfaces.
+- Any regression around menu visibility or per-surface action parity needs a
+  targeted test in the menu/controller/widget layer that owns that surface.
+
 ### People UI Conventions
 
 #### Reusable person-picker popup

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -104,6 +104,9 @@ class MainCoordinator(QObject):
             window.ui.people_page.set_pinned_service(self._pinned_items_service)
         if hasattr(window.ui, "albums_dashboard_page"):
             window.ui.albums_dashboard_page.set_pinned_service(self._pinned_items_service)
+            self._facade.albumCoverUpdated.connect(
+                window.ui.albums_dashboard_page.update_album_cover
+            )
 
         # Inject ViewModel provider into Facade for legacy operations (restore/delete)
         if self._facade:

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -398,6 +398,7 @@ class MainCoordinator(QObject):
         """Connect application signals."""
         ui = self._window.ui
         self._context.library.treeUpdated.connect(self._on_library_tree_updated)
+        self._context.library.albumRenamed.connect(self._on_album_renamed)
         self._facade.scanChunkReady.connect(self._gallery_store.handle_scan_chunk)
         self._facade.scanFinished.connect(self._gallery_store.handle_scan_finished)
         self._context.library.scanChunkReady.connect(self._gallery_vm.handle_location_scan_chunk)
@@ -538,6 +539,10 @@ class MainCoordinator(QObject):
         playback = getattr(self, "_playback", None)
         if playback is not None:
             playback.set_people_library_root(root)
+
+    def _on_album_renamed(self, old_path: Path, new_path: Path) -> None:
+        self._thumbnail_service.remap_album_paths(old_path, new_path)
+        self._gallery_vm.handle_album_renamed(old_path, new_path)
 
     def _handle_media_load_failed(self, path: Path, message: str) -> None:
         path_key = str(path)

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -541,6 +541,12 @@ class MainCoordinator(QObject):
             playback.set_people_library_root(root)
 
     def _on_album_renamed(self, old_path: Path, new_path: Path) -> None:
+        self._pinned_items_service.remap_album_path(
+            old_path,
+            new_path,
+            library_root=self._context.library.root(),
+            fallback_label=new_path.name,
+        )
         self._thumbnail_service.remap_album_paths(old_path, new_path)
         self._gallery_vm.handle_album_renamed(old_path, new_path)
 

--- a/src/iPhoto/gui/facade.py
+++ b/src/iPhoto/gui/facade.py
@@ -33,6 +33,7 @@ class AppFacade(QObject):
     """Expose high-level album operations to the GUI layer."""
 
     albumOpened = Signal(Path)
+    albumCoverUpdated = Signal(Path, Path)
     assetUpdated = Signal(Path)
     indexUpdated = Signal(Path)
     linksUpdated = Signal(Path)
@@ -298,7 +299,10 @@ class AppFacade(QObject):
         album = self._require_album()
         if album is None:
             return False
-        return self._metadata_service.set_album_cover(album, rel)
+        success = self._metadata_service.set_album_cover(album, rel)
+        if success:
+            self.albumCoverUpdated.emit(album.root, album.root / rel)
+        return success
 
     def bind_library(self, library: "LibraryManager") -> None:
         """Remember the library manager so static collections stay in sync."""

--- a/src/iPhoto/gui/services/album_metadata_service.py
+++ b/src/iPhoto/gui/services/album_metadata_service.py
@@ -39,7 +39,11 @@ class AlbumMetadataService(QObject):
     # ------------------------------------------------------------------
     # Public API used by :class:`~iPhoto.gui.facade.AppFacade`
     # ------------------------------------------------------------------
-    def set_album_cover(self, album: Album, rel: str) -> bool:
+    def set_album_cover(
+        self,
+        album: Album,
+        rel: str,
+    ) -> bool:
         """Set *rel* as cover for *album* and persist the change."""
 
         if not rel:

--- a/src/iPhoto/gui/services/pinned_items_service.py
+++ b/src/iPhoto/gui/services/pinned_items_service.py
@@ -20,6 +20,7 @@ class PinnedSidebarItem:
     kind: str
     item_id: str
     label: str
+    custom_label: bool = False
 
 
 class PinnedItemsService(QObject):
@@ -48,9 +49,17 @@ class PinnedItemsService(QObject):
             kind = str(entry.get("kind") or "").strip()
             item_id = str(entry.get("item_id") or "").strip()
             label = str(entry.get("label") or "").strip()
+            custom_label = bool(entry.get("custom_label", False))
             if kind not in {"album", "person", "group"} or not item_id or not label:
                 continue
-            resolved.append(PinnedSidebarItem(kind=kind, item_id=item_id, label=label))
+            resolved.append(
+                PinnedSidebarItem(
+                    kind=kind,
+                    item_id=item_id,
+                    label=label,
+                    custom_label=custom_label,
+                )
+            )
         return resolved
 
     def is_pinned(self, *, kind: str, item_id: str, library_root: Path | None) -> bool:
@@ -67,7 +76,12 @@ class PinnedItemsService(QObject):
         if normalized_id is None:
             return
         self._write_item(
-            PinnedSidebarItem(kind="album", item_id=normalized_id, label=label.strip()),
+            PinnedSidebarItem(
+                kind="album",
+                item_id=normalized_id,
+                label=label.strip(),
+                custom_label=False,
+            ),
             library_root=library_root,
         )
 
@@ -76,7 +90,12 @@ class PinnedItemsService(QObject):
         if normalized_id is None:
             return
         self._write_item(
-            PinnedSidebarItem(kind="person", item_id=normalized_id, label=label.strip()),
+            PinnedSidebarItem(
+                kind="person",
+                item_id=normalized_id,
+                label=label.strip(),
+                custom_label=False,
+            ),
             library_root=library_root,
         )
 
@@ -85,9 +104,53 @@ class PinnedItemsService(QObject):
         if normalized_id is None:
             return
         self._write_item(
-            PinnedSidebarItem(kind="group", item_id=normalized_id, label=label.strip()),
+            PinnedSidebarItem(
+                kind="group",
+                item_id=normalized_id,
+                label=label.strip(),
+                custom_label=False,
+            ),
             library_root=library_root,
         )
+
+    def rename_item(
+        self,
+        *,
+        kind: str,
+        item_id: str | Path,
+        label: str,
+        library_root: Path | None,
+    ) -> bool:
+        normalized_id = self._normalize_item_id(kind, item_id)
+        library_key = self._library_key(library_root)
+        target_label = str(label or "").strip()
+        if normalized_id is None or library_key is None or not target_label:
+            return False
+
+        payload = self._payload()
+        entries = payload.get(library_key, [])
+        updated = False
+        rewritten: list[dict[str, object]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            entry_kind = str(entry.get("kind") or "").strip()
+            entry_item_id = str(entry.get("item_id") or "").strip()
+            if entry_kind == kind and entry_item_id == normalized_id:
+                next_entry = dict(entry)
+                next_entry["label"] = target_label
+                next_entry["custom_label"] = True
+                rewritten.append(next_entry)
+                updated = True
+                continue
+            rewritten.append(dict(entry))
+
+        if not updated:
+            return False
+
+        payload[library_key] = rewritten
+        self._persist(payload)
+        return True
 
     def unpin(self, *, kind: str, item_id: str, library_root: Path | None) -> None:
         normalized_id = self._normalize_item_id(kind, item_id)
@@ -150,16 +213,17 @@ class PinnedItemsService(QObject):
                 "kind": item.kind,
                 "item_id": item.item_id,
                 "label": item.label,
+                "custom_label": item.custom_label,
             },
         )
         payload[library_key] = filtered
         self._persist(payload)
 
-    def _payload(self) -> dict[str, list[dict[str, str]]]:
+    def _payload(self) -> dict[str, list[dict[str, object]]]:
         stored = self._settings.get(self._SETTINGS_KEY, {}) or {}
         if not isinstance(stored, dict):
             return {}
-        payload: dict[str, list[dict[str, str]]] = {}
+        payload: dict[str, list[dict[str, object]]] = {}
         for library_key, entries in stored.items():
             try:
                 normalized_key = str(Path(str(library_key)).expanduser().resolve())
@@ -170,7 +234,7 @@ class PinnedItemsService(QObject):
             payload[normalized_key] = [entry for entry in entries if isinstance(entry, dict)]
         return payload
 
-    def _persist(self, payload: dict[str, list[dict[str, str]]]) -> None:
+    def _persist(self, payload: dict[str, list[dict[str, object]]]) -> None:
         self._settings.set(self._SETTINGS_KEY, payload)
         self.changed.emit()
 

--- a/src/iPhoto/gui/services/pinned_items_service.py
+++ b/src/iPhoto/gui/services/pinned_items_service.py
@@ -187,6 +187,63 @@ class PinnedItemsService(QObject):
     def prune_missing_album(self, album_path: Path, *, library_root: Path | None) -> None:
         self.unpin(kind="album", item_id=str(album_path), library_root=library_root)
 
+    def remap_album_path(
+        self,
+        old_path: Path,
+        new_path: Path,
+        *,
+        library_root: Path | None,
+        fallback_label: str | None = None,
+    ) -> bool:
+        old_id = self._normalize_item_id("album", old_path)
+        new_id = self._normalize_item_id("album", new_path)
+        library_key = self._library_key(library_root)
+        if old_id is None or new_id is None or library_key is None:
+            return False
+
+        payload = self._payload()
+        entries = payload.get(library_key, [])
+        rewritten: list[dict[str, object]] = []
+        updated = False
+        has_new_id = False
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            entry_kind = str(entry.get("kind") or "").strip()
+            entry_item_id = str(entry.get("item_id") or "").strip()
+            next_entry = dict(entry)
+            if entry_kind == "album" and entry_item_id == new_id:
+                has_new_id = True
+            if entry_kind == "album" and entry_item_id == old_id:
+                next_entry["item_id"] = new_id
+                if not bool(next_entry.get("custom_label", False)):
+                    label = str(fallback_label or new_path.name).strip()
+                    if label:
+                        next_entry["label"] = label
+                updated = True
+            rewritten.append(next_entry)
+
+        if not updated:
+            return False
+
+        if has_new_id:
+            deduped: list[dict[str, object]] = []
+            seen_new = False
+            for entry in rewritten:
+                if (
+                    str(entry.get("kind") or "").strip() == "album"
+                    and str(entry.get("item_id") or "").strip() == new_id
+                ):
+                    if seen_new:
+                        continue
+                    seen_new = True
+                deduped.append(entry)
+            rewritten = deduped
+
+        payload[library_key] = rewritten
+        self._persist(payload)
+        return True
+
     def prune_missing_entity(self, *, kind: str, item_id: str, library_root: Path | None) -> None:
         self.unpin(kind=kind, item_id=item_id, library_root=library_root)
 

--- a/src/iPhoto/gui/services/pinned_items_service.py
+++ b/src/iPhoto/gui/services/pinned_items_service.py
@@ -205,18 +205,20 @@ class PinnedItemsService(QObject):
         entries = payload.get(library_key, [])
         rewritten: list[dict[str, object]] = []
         updated = False
-        has_new_id = False
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
             entry_kind = str(entry.get("kind") or "").strip()
             entry_item_id = str(entry.get("item_id") or "").strip()
             next_entry = dict(entry)
-            if entry_kind == "album" and entry_item_id == new_id:
-                has_new_id = True
-            if entry_kind == "album" and entry_item_id == old_id:
-                next_entry["item_id"] = new_id
-                if not bool(next_entry.get("custom_label", False)):
+            remapped_id = (
+                self._remap_album_item_id(entry_item_id, old_id, new_id)
+                if entry_kind == "album"
+                else None
+            )
+            if remapped_id is not None:
+                next_entry["item_id"] = remapped_id
+                if remapped_id == new_id and not bool(next_entry.get("custom_label", False)):
                     label = str(fallback_label or new_path.name).strip()
                     if label:
                         next_entry["label"] = label
@@ -226,23 +228,48 @@ class PinnedItemsService(QObject):
         if not updated:
             return False
 
-        if has_new_id:
-            deduped: list[dict[str, object]] = []
-            seen_new = False
-            for entry in rewritten:
-                if (
-                    str(entry.get("kind") or "").strip() == "album"
-                    and str(entry.get("item_id") or "").strip() == new_id
-                ):
-                    if seen_new:
-                        continue
-                    seen_new = True
-                deduped.append(entry)
-            rewritten = deduped
+        rewritten = self._dedupe_entries(rewritten)
 
         payload[library_key] = rewritten
         self._persist(payload)
         return True
+
+    def _remap_album_item_id(
+        self,
+        item_id: str,
+        old_id: str,
+        new_id: str,
+    ) -> str | None:
+        if item_id == old_id:
+            return new_id
+        try:
+            rel = Path(item_id).resolve().relative_to(Path(old_id).resolve())
+        except (OSError, ValueError):
+            try:
+                rel = Path(item_id).relative_to(Path(old_id))
+            except ValueError:
+                return None
+        if rel.as_posix() in ("", "."):
+            return new_id
+        try:
+            return str((Path(new_id) / rel).resolve())
+        except OSError:
+            return str(Path(new_id) / rel)
+
+    @staticmethod
+    def _dedupe_entries(entries: list[dict[str, object]]) -> list[dict[str, object]]:
+        deduped: list[dict[str, object]] = []
+        seen: set[tuple[str, str]] = set()
+        for entry in entries:
+            kind = str(entry.get("kind") or "").strip()
+            item_id = str(entry.get("item_id") or "").strip()
+            if kind and item_id:
+                key = (kind, item_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+            deduped.append(entry)
+        return deduped
 
     def prune_missing_entity(self, *, kind: str, item_id: str, library_root: Path | None) -> None:
         self.unpin(kind=kind, item_id=item_id, library_root=library_root)

--- a/src/iPhoto/gui/ui/controllers/context_menu_controller.py
+++ b/src/iPhoto/gui/ui/controllers/context_menu_controller.py
@@ -4,20 +4,18 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from functools import partial
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import (
     QAbstractItemModel,
-    QCoreApplication,
     QMimeData,
+    QItemSelectionModel,
     QModelIndex,
     QObject,
     QPoint,
     QUrl,
-    Qt,
-    QItemSelectionModel,
 )
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QMenu
@@ -51,11 +49,11 @@ class ContextMenuController(QObject):
         status_bar: StatusBarController,
         notification_toast: NotificationToast,
         selection_controller: SelectionController | None,
-        navigation: "NavigationCoordinator | None",
+        navigation: NavigationCoordinator | None,
         export_callback: Callable[[], None],
         prepare_paths_for_mutation: Callable[[list[Path]], None] | None = None,
-        gallery_viewmodel: "GalleryViewModel | None" = None,
-        parent: Optional[QObject] = None,
+        gallery_viewmodel: GalleryViewModel | None = None,
+        parent: QObject | None = None,
     ) -> None:
         super().__init__(parent)
         self._grid_view = grid_view
@@ -425,7 +423,7 @@ class ContextMenuController(QObject):
 
         success = False
         if context.entity_kind == "album":
-            success = self._facade.set_cover(asset.rel_path.as_posix())
+            success = self._facade.set_cover(self._album_cover_rel_path(context, asset))
         elif context.entity_kind == "person" and context.entity_id:
             service = self._people_service_for_context(context)
             face_id = service.resolve_cluster_cover_face(context.entity_id, asset.id)
@@ -433,7 +431,10 @@ class ContextMenuController(QObject):
         elif context.entity_kind == "group" and context.entity_id:
             service = self._people_service_for_context(context)
             group_asset_id = service.resolve_group_cover_asset(context.entity_id, asset.id)
-            success = bool(group_asset_id) and service.set_group_cover(context.entity_id, group_asset_id)
+            success = bool(group_asset_id) and service.set_group_cover(
+                context.entity_id,
+                group_asset_id,
+            )
 
         if success:
             self._toast.show_toast("Cover Updated")
@@ -442,6 +443,15 @@ class ContextMenuController(QObject):
             "Unable to set cover for the selected item.",
             3000,
         )
+
+    def _album_cover_rel_path(self, context: MenuContext, asset) -> str:
+        album_root = context.active_root
+        if album_root is not None:
+            try:
+                return asset.abs_path.relative_to(album_root).as_posix()
+            except (OSError, ValueError):
+                pass
+        return asset.rel_path.as_posix()
 
     def _people_service_for_context(self, context: MenuContext) -> PeopleService:
         return PeopleService(context.active_root)

--- a/src/iPhoto/gui/ui/menus/album_sidebar_menu.py
+++ b/src/iPhoto/gui/ui/menus/album_sidebar_menu.py
@@ -19,7 +19,6 @@ from ..widgets import dialogs
 from ....errors import LibraryError
 from ....library.manager import LibraryManager
 from ....library.tree import AlbumNode
-from ...services.pinned_items_service import PinnedSidebarItem
 from ..models.album_tree_model import AlbumTreeItem, AlbumTreeModel, NodeType
 from .style import apply_menu_style
 
@@ -156,6 +155,8 @@ class AlbumSidebarContextMenu(QMenu):
             NodeType.PINNED_PERSON,
             NodeType.PINNED_GROUP,
         }:
+            self.addAction("Rename…", self._prompt_rename_pinned_item)
+            self.addSeparator()
             self.addAction("Unpin", self._unpin_sidebar_item)
         if self._item.node_type == NodeType.ACTION:
             self.addAction("Set Basic Library…", self._on_bind_library)
@@ -194,6 +195,32 @@ class AlbumSidebarContextMenu(QMenu):
         pinned_service.unpin(
             kind=pinned_item.kind,
             item_id=pinned_item.item_id,
+            library_root=library_root,
+        )
+
+    def _prompt_rename_pinned_item(self) -> None:
+        pinned_service = self._model._pinned_service
+        pinned_item = self._item.pinned_item
+        library_root = self._library.root()
+        if pinned_service is None or pinned_item is None or library_root is None:
+            return
+
+        name, ok = _create_styled_input_dialog(
+            self.parentWidget(),
+            "Rename Pinned Item",
+            "New pinned label:",
+            text=self._item.title or pinned_item.label,
+        )
+        if not ok:
+            return
+        target_name = name.strip()
+        if not target_name:
+            dialogs.show_warning(self.parentWidget(), "Pinned label cannot be empty.")
+            return
+        pinned_service.rename_item(
+            kind=pinned_item.kind,
+            item_id=pinned_item.item_id,
+            label=target_name,
             library_root=library_root,
         )
 

--- a/src/iPhoto/gui/ui/models/album_tree_model.py
+++ b/src/iPhoto/gui/ui/models/album_tree_model.py
@@ -390,7 +390,11 @@ class AlbumTreeModel(QAbstractItemModel):
             except (TypeError, ValueError):
                 return None
             album = album_lookup.get(album_path)
-            title = album.title if album is not None else pinned_item.label
+            title = (
+                pinned_item.label
+                if pinned_item.custom_label
+                else (album.title if album is not None else pinned_item.label)
+            )
             return AlbumTreeItem(
                 title,
                 NodeType.PINNED_ALBUM,
@@ -399,7 +403,9 @@ class AlbumTreeModel(QAbstractItemModel):
             )
         if pinned_item.kind == "person":
             summary = person_lookup.get(pinned_item.item_id)
-            title = str(getattr(summary, "name", "") or "").strip() or pinned_item.label
+            title = pinned_item.label if pinned_item.custom_label else (
+                str(getattr(summary, "name", "") or "").strip() or pinned_item.label
+            )
             return AlbumTreeItem(
                 title,
                 NodeType.PINNED_PERSON,
@@ -407,7 +413,9 @@ class AlbumTreeModel(QAbstractItemModel):
             )
         if pinned_item.kind == "group":
             summary = group_lookup.get(pinned_item.item_id)
-            title = str(getattr(summary, "name", "") or "").strip() or pinned_item.label
+            title = pinned_item.label if pinned_item.custom_label else (
+                str(getattr(summary, "name", "") or "").strip() or pinned_item.label
+            )
             return AlbumTreeItem(
                 title,
                 NodeType.PINNED_GROUP,

--- a/src/iPhoto/gui/ui/widgets/albums_dashboard.py
+++ b/src/iPhoto/gui/ui/widgets/albums_dashboard.py
@@ -40,17 +40,20 @@ from PySide6.QtWidgets import (
 )
 
 from iPhoto.gui.services.pinned_items_service import PinnedItemsService
-from ....utils.pathutils import ensure_work_dir
 from ....cache.index_store import get_global_repository
 from ....config import WORK_DIR_NAME
+from ....errors import LibraryError
 from ....media_classifier import get_media_type, MediaType
 from ....models.album import Album
+from ....utils.pathutils import ensure_work_dir
+from ..menus.album_sidebar_menu import _create_styled_input_dialog
 from ..tasks.thumbnail_loader import ThumbnailJob, generate_cache_path, stat_mtime_ns
-from .flow_layout import FlowLayout
 from ..icon import load_icon
 from ..menus.core import MenuActionSpec, MenuContext, populate_menu
 from ..menus.style import apply_menu_style
 from ..theme_manager import DARK_THEME
+from . import dialogs
+from .flow_layout import FlowLayout
 
 if TYPE_CHECKING:
     from ....library.manager import LibraryManager
@@ -415,7 +418,7 @@ class AlbumDataWorker(QRunnable):
 class DashboardThumbnailLoader(QObject):
     """Simplified thumbnail loader for dashboard cards."""
 
-    thumbnailReady = Signal(Path, QPixmap)  # album_root, pixmap
+    thumbnailReady = Signal(Path, Path, QPixmap)  # album_root, source_path, pixmap
     _delivered = Signal(tuple, QImage, str)  # key (album_root_str, rel, width, height, stamp), image, rel
 
     def __init__(self, parent: QObject | None = None, library_root: Optional[Path] = None) -> None:
@@ -454,7 +457,7 @@ class DashboardThumbnailLoader(QObject):
         if cache_path.exists():
             pixmap = QPixmap(str(cache_path))
             if not pixmap.isNull():
-                self.thumbnailReady.emit(album_root, pixmap)
+                self.thumbnailReady.emit(album_root, image_path, pixmap)
                 return
 
         # Store mapping
@@ -512,7 +515,7 @@ class DashboardThumbnailLoader(QObject):
 
         pixmap = QPixmap.fromImage(image)
         if not pixmap.isNull():
-            self.thumbnailReady.emit(album_root, pixmap)
+            self.thumbnailReady.emit(album_root, Path(rel), pixmap)
 
     def _album_root_str(self, album_root: Path) -> str:
         cached = self._resolved_roots.get(album_root)
@@ -537,6 +540,8 @@ class AlbumsDashboard(QWidget):
         self._library = library
         self._pinned_service: PinnedItemsService | None = None
         self._cards: dict[Path, AlbumCard] = {}
+        self._album_nodes: dict[Path, AlbumNode] = {}
+        self._requested_cover_paths: dict[Path, Path] = {}
         # Track refresh generation to prevent race conditions
         # Python integers can grow arbitrarily large, so overflow is not a concern
         self._current_generation = 0
@@ -607,6 +612,8 @@ class AlbumsDashboard(QWidget):
                 item.widget().deleteLater()
 
         self._cards.clear()
+        self._album_nodes.clear()
+        self._requested_cover_paths.clear()
 
         albums = self._library.list_albums()
 
@@ -629,6 +636,7 @@ class AlbumsDashboard(QWidget):
             card.menuRequested.connect(self._show_card_menu)
             self.flow_layout.addWidget(card)
             self._cards[album.path] = card
+            self._album_nodes[album.path] = album
 
             # Fetch data with current generation, using library root for global DB
             worker = AlbumDataWorker(album, self._loader_signals, current_gen, library_root=library_root)
@@ -649,10 +657,14 @@ class AlbumsDashboard(QWidget):
 
         # Load cover
         if cover_path:
+            self._requested_cover_paths[root] = cover_path
             self._thumb_loader.request_with_absolute_key(root, cover_path, QSize(512, 512))
 
-    def _on_thumbnail_ready(self, album_root: Path, pixmap: QPixmap) -> None:
-        card = self._cards.get(album_root)
+    def _on_thumbnail_ready(self, album_root: Path, source_path: Path, pixmap: QPixmap) -> None:
+        expected = self._requested_cover_paths.get(album_root)
+        if expected is not None and not self._paths_equal(expected, source_path):
+            return
+        card = self._card_for_album_root(album_root)
         if card:
             card.set_cover_image(pixmap)
 
@@ -675,6 +687,16 @@ class AlbumsDashboard(QWidget):
         menu = self._build_card_menu(card)
         menu.exec(global_pos)
 
+    def update_album_cover(self, album_root: Path, cover_path: Path) -> None:
+        card = self._card_for_album_root(album_root)
+        if card is None or not cover_path.exists():
+            return
+        self._requested_cover_paths[card.path] = cover_path
+        pixmap = QPixmap(str(cover_path))
+        if not pixmap.isNull():
+            card.set_cover_image(pixmap)
+        self._thumb_loader.request_with_absolute_key(card.path, cover_path, QSize(512, 512))
+
     def _build_card_menu(self, card: AlbumCard) -> QMenu:
         menu = QMenu(self)
         apply_menu_style(menu, self)
@@ -688,6 +710,11 @@ class AlbumsDashboard(QWidget):
                 active_root=card.path,
             ),
             action_specs=[
+                MenuActionSpec(
+                    action_id="rename_album",
+                    label="Rename…",
+                    on_trigger=lambda _ctx: self._prompt_rename_album(card),
+                ),
                 MenuActionSpec(
                     action_id="toggle_album_pin",
                     label="Unpin Album" if self._is_album_pinned(card.path) else "Pin Album",
@@ -718,6 +745,27 @@ class AlbumsDashboard(QWidget):
             library_root=library_root,
         )
 
+    def _prompt_rename_album(self, card: AlbumCard) -> None:
+        album = self._album_node_for_path(card.path)
+        if album is None:
+            return
+        name, ok = _create_styled_input_dialog(
+            self,
+            "Rename Album",
+            "New album name:",
+            text=card.title,
+        )
+        if not ok:
+            return
+        target_name = name.strip()
+        if not target_name:
+            dialogs.show_warning(self, "Album name cannot be empty.")
+            return
+        try:
+            self._library.rename_album(album, target_name)
+        except LibraryError as exc:  # pragma: no cover - GUI feedback
+            dialogs.show_warning(self, str(exc))
+
     def _is_album_pinned(self, album_path: Path) -> bool:
         if self._pinned_service is None:
             return False
@@ -729,6 +777,32 @@ class AlbumsDashboard(QWidget):
 
     def _pin_actions_available(self) -> bool:
         return self._pinned_service is not None and self._library.root() is not None
+
+    def _card_for_album_root(self, album_root: Path) -> AlbumCard | None:
+        card = self._cards.get(album_root)
+        if card is not None:
+            return card
+        for path, existing in self._cards.items():
+            if self._paths_equal(path, album_root):
+                return existing
+        return None
+
+    def _album_node_for_path(self, album_path: Path) -> AlbumNode | None:
+        album = self._album_nodes.get(album_path)
+        if album is not None:
+            return album
+        for path, existing in self._album_nodes.items():
+            if self._paths_equal(path, album_path):
+                return existing
+        return None
+
+    def _paths_equal(self, first: Path, second: Path) -> bool:
+        if first == second:
+            return True
+        try:
+            return first.resolve() == second.resolve()
+        except OSError:
+            return False
 
     def _apply_theme(self) -> None:
         app = QGuiApplication.instance()

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -401,13 +401,16 @@ class GalleryViewModel(BaseViewModel):
         if self.current_section.value not in {"album", "pinned_album"}:
             return
         active_root = self.active_root.value
-        if active_root is None or not self._paths_equal(active_root, old_path):
+        if active_root is None:
+            return
+        retargeted_path = self._retarget_renamed_path(active_root, old_path, new_path)
+        if retargeted_path is None:
             return
 
         section = self.current_section.value
         static_selection = self.static_selection.value
-        album = self._facade.open_album(new_path)
-        retargeted_root = album.root if album else new_path
+        album = self._facade.open_album(retargeted_path)
+        retargeted_root = album.root if album else retargeted_path
         if album:
             self._context.remember_album(album.root)
 
@@ -588,3 +591,24 @@ class GalleryViewModel(BaseViewModel):
             return first.resolve() == second.resolve()
         except OSError:
             return False
+
+    def _retarget_renamed_path(
+        self,
+        active_root: Path,
+        old_path: Path,
+        new_path: Path,
+    ) -> Path | None:
+        if self._paths_equal(active_root, old_path):
+            return new_path
+
+        for use_resolve in (True, False):
+            try:
+                active_candidate = active_root.resolve() if use_resolve else active_root
+                old_candidate = old_path.resolve() if use_resolve else old_path
+                rel = active_candidate.relative_to(old_candidate)
+            except (OSError, ValueError):
+                continue
+            if rel.as_posix() in ("", "."):
+                return new_path
+            return new_path / rel
+        return None

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -397,6 +397,29 @@ class GalleryViewModel(BaseViewModel):
         if self._location_session.mode == "map":
             self.map_assets_changed.emit(self._location_session.full_assets(), root)
 
+    def handle_album_renamed(self, old_path: Path, new_path: Path) -> None:
+        if self.current_section.value not in {"album", "pinned_album"}:
+            return
+        active_root = self.active_root.value
+        if active_root is None or not self._paths_equal(active_root, old_path):
+            return
+
+        section = self.current_section.value
+        static_selection = self.static_selection.value
+        album = self._facade.open_album(new_path)
+        retargeted_root = album.root if album else new_path
+        if album:
+            self._context.remember_album(album.root)
+
+        query = AssetQuery(album_path=self._album_path_for_query(retargeted_root))
+        query.include_subalbums = True
+        self._load_query(
+            section=section,
+            static_selection=static_selection,
+            root=retargeted_root,
+            query=query,
+        )
+
     def on_library_tree_updated(self) -> bool:
         self._location_session.invalidate()
         if self.is_location_context_active():
@@ -557,3 +580,11 @@ class GalleryViewModel(BaseViewModel):
             scan_root_resolved == root_resolved
             or root_resolved in scan_root_resolved.parents
         )
+
+    def _paths_equal(self, first: Path, second: Path) -> bool:
+        if first == second:
+            return True
+        try:
+            return first.resolve() == second.resolve()
+        except OSError:
+            return False

--- a/src/iPhoto/infrastructure/services/thumbnail_cache_service.py
+++ b/src/iPhoto/infrastructure/services/thumbnail_cache_service.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 from typing import Dict, Optional, Set
 
 import numpy as np
@@ -155,6 +156,37 @@ class ThumbnailCacheService(QObject):
                 disk_file.unlink()
             except OSError:
                 pass
+
+    def remap_album_paths(self, old_root: Path, new_root: Path, *, size: QSize | None = None) -> None:
+        """Copy cached thumbnails from an album's old path to its renamed path."""
+
+        if size is None:
+            size = QSize(512, 512)
+        if not new_root.exists():
+            return
+        try:
+            paths = [path for path in new_root.rglob("*") if path.is_file()]
+        except OSError:
+            return
+
+        for new_path in paths:
+            try:
+                rel = new_path.relative_to(new_root)
+            except ValueError:
+                continue
+            old_path = old_root / rel
+            old_key = self._cache_key(old_path, size)
+            new_key = self._cache_key(new_path, size)
+            if old_key in self._memory_cache and new_key not in self._memory_cache:
+                self._memory_cache[new_key] = self._memory_cache[old_key]
+
+            old_disk_file = self._disk_cache_path / f"{old_key}.jpg"
+            new_disk_file = self._disk_cache_path / f"{new_key}.jpg"
+            if old_disk_file.exists() and not new_disk_file.exists():
+                try:
+                    shutil.copy2(old_disk_file, new_disk_file)
+                except OSError:
+                    pass
 
     def _cache_key(self, path: Path, size: QSize) -> str:
         # Simple hash of path + size

--- a/src/iPhoto/library/album_operations.py
+++ b/src/iPhoto/library/album_operations.py
@@ -24,6 +24,16 @@ if TYPE_CHECKING:
     pass
 
 
+_RESERVED_LIBRARY_DIR_NAMES = frozenset(
+    name.casefold()
+    for name in (
+        WORK_DIR_NAME,
+        RECENTLY_DELETED_DIR_NAME,
+        EXPORT_DIR_NAME,
+    )
+)
+
+
 class AlbumOperationsMixin:
     """Mixin providing album CRUD operations for LibraryManager."""
 
@@ -54,8 +64,9 @@ class AlbumOperationsMixin:
     def rename_album(self, node: AlbumNode, new_name: str) -> None:
         parent = node.path.parent
         target = self._validate_new_name(parent, new_name)
+        original_path = node.path
         try:
-            node.path.rename(target)
+            original_path.rename(target)
         except FileExistsError as exc:
             raise AlbumNameConflictError(f"An album named '{new_name}' already exists.") from exc
         except OSError as exc:  # pragma: no cover - defensive guard
@@ -63,6 +74,7 @@ class AlbumOperationsMixin:
         # ``Album.open`` now normalises and persists manifest updates so the
         # metadata stays aligned with the renamed directory immediately.
         Album.open(target)
+        self.albumRenamed.emit(original_path, target)
         self._refresh_tree()
 
     def ensure_manifest(self, node: AlbumNode) -> Path:
@@ -145,10 +157,16 @@ class AlbumOperationsMixin:
             raise AlbumOperationError("Album name cannot be empty.")
         if Path(candidate).name != candidate:
             raise AlbumOperationError("Album name must not contain path separators.")
+        if self._is_reserved_album_dir_name(candidate):
+            raise AlbumOperationError(f"Album name '{candidate}' is reserved for internal use.")
         target = parent / candidate
         if target.exists():
             raise AlbumNameConflictError(f"An album named '{candidate}' already exists.")
         return target
+
+    @staticmethod
+    def _is_reserved_album_dir_name(name: str) -> bool:
+        return str(name or "").strip().casefold() in _RESERVED_LIBRARY_DIR_NAMES
 
     def _find_manifest(self, path: Path) -> Path | None:
         for name in ALBUM_MANIFEST_NAMES:
@@ -196,13 +214,9 @@ class AlbumOperationsMixin:
         for entry in entries:
             if not entry.is_dir():
                 continue
-            if entry.name == WORK_DIR_NAME:
-                continue
-            if entry.name == RECENTLY_DELETED_DIR_NAME:
+            if self._is_reserved_album_dir_name(entry.name):
                 # The trash folder should stay hidden from the regular album list
-                # so that it only appears through the dedicated "Recently Deleted"
-                # entry in the sidebar.
-                continue
-            if entry.name == EXPORT_DIR_NAME:
+                # so that it only appears through the dedicated sidebar route, and
+                # internal/export folders never show up as user albums.
                 continue
             yield entry

--- a/src/iPhoto/library/manager.py
+++ b/src/iPhoto/library/manager.py
@@ -50,6 +50,7 @@ class LibraryManager(
     """Manage the Basic Library tree, file-system helpers, and scanning state."""
 
     treeUpdated = Signal()
+    albumRenamed = Signal(Path, Path)
     errorRaised = Signal(str)
 
     # Scanner signals exposed for the facade

--- a/src/iPhoto/settings/schema.py
+++ b/src/iPhoto/settings/schema.py
@@ -29,6 +29,7 @@ SETTINGS_SCHEMA: dict[str, Any] = {
                         },
                         "item_id": {"type": "string"},
                         "label": {"type": "string"},
+                        "custom_label": {"type": "boolean"},
                     },
                     "additionalProperties": False,
                 },
@@ -148,6 +149,7 @@ def merge_with_defaults(data: dict[str, Any] | None) -> dict[str, Any]:
                         kind = str(entry.get("kind") or "").strip()
                         item_id = str(entry.get("item_id") or "").strip()
                         label = str(entry.get("label") or "").strip()
+                        custom_label = bool(entry.get("custom_label", False))
                         if kind not in {"album", "person", "group"}:
                             continue
                         if not item_id or not label:
@@ -157,6 +159,7 @@ def merge_with_defaults(data: dict[str, Any] | None) -> dict[str, Any]:
                                 "kind": kind,
                                 "item_id": item_id,
                                 "label": label,
+                                "custom_label": custom_label,
                             }
                         )
                     normalised[resolved_key] = normalised_entries

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -87,6 +87,33 @@ def test_album_rename_retargets_current_gallery_query(tmp_path: Path) -> None:
     assert vm.active_root.value == new_album
 
 
+def test_parent_album_rename_retargets_open_child_album(tmp_path: Path) -> None:
+    old_parent = tmp_path / "Trips"
+    old_child = old_parent / "Paris"
+    new_parent = tmp_path / "Renamed Trips"
+    new_child = new_parent / "Paris"
+    old_child.mkdir(parents=True)
+    new_child.mkdir(parents=True)
+    vm, store, context, facade, _asset_service = _make_vm(library_root=tmp_path)
+    facade.open_album.return_value = SimpleNamespace(root=old_child)
+    vm.open_album(old_child)
+    store.load_selection.reset_mock()
+    context.remember_album.reset_mock()
+    facade.open_album.return_value = SimpleNamespace(root=new_child)
+
+    vm.handle_album_renamed(old_parent, new_parent)
+
+    facade.open_album.assert_called_with(new_child)
+    context.remember_album.assert_called_once_with(new_child)
+    store.load_selection.assert_called_once()
+    active_root = store.load_selection.call_args.args[0]
+    query = store.load_selection.call_args.kwargs["query"]
+    assert active_root == new_child
+    assert query.album_path == "Renamed Trips/Paris"
+    assert query.include_subalbums is True
+    assert vm.active_root.value == new_child
+
+
 def test_open_all_photos_loads_root_query(tmp_path: Path) -> None:
     vm, store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
 

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -62,6 +62,31 @@ def test_open_album_loads_recursive_album_query(tmp_path: Path) -> None:
     context.remember_album.assert_called_once_with(album)
 
 
+def test_album_rename_retargets_current_gallery_query(tmp_path: Path) -> None:
+    old_album = tmp_path / "Trips"
+    new_album = tmp_path / "Renamed Trips"
+    old_album.mkdir()
+    new_album.mkdir()
+    vm, store, context, facade, _asset_service = _make_vm(library_root=tmp_path)
+    facade.open_album.return_value = SimpleNamespace(root=old_album)
+    vm.open_album(old_album)
+    store.load_selection.reset_mock()
+    context.remember_album.reset_mock()
+    facade.open_album.return_value = SimpleNamespace(root=new_album)
+
+    vm.handle_album_renamed(old_album, new_album)
+
+    facade.open_album.assert_called_with(new_album)
+    context.remember_album.assert_called_once_with(new_album)
+    store.load_selection.assert_called_once()
+    active_root = store.load_selection.call_args.args[0]
+    query = store.load_selection.call_args.kwargs["query"]
+    assert active_root == new_album
+    assert query.album_path == "Renamed Trips"
+    assert query.include_subalbums is True
+    assert vm.active_root.value == new_album
+
+
 def test_open_all_photos_loads_root_query(tmp_path: Path) -> None:
     vm, store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
 

--- a/tests/test_album_sidebar.py
+++ b/tests/test_album_sidebar.py
@@ -199,8 +199,60 @@ def test_sidebar_pinned_item_context_menu_offers_unpin(tmp_path: Path, qapp: QAp
         sidebar._set_pending_selection,
         sidebar.bindLibraryRequested.emit,
     )
-    assert [action.text() for action in menu.actions()] == ["Unpin"]
+    assert [action.text() for action in menu.actions() if not action.isSeparator()] == [
+        "Rename…",
+        "Unpin",
+    ]
 
-    menu.actions()[0].trigger()
+    menu.actions()[-1].trigger()
     qapp.processEvents()
     assert not pinned_service.items_for_library(root)
+
+
+def test_sidebar_pinned_item_context_menu_can_rename(tmp_path: Path, qapp: QApplication) -> None:
+    root = tmp_path / "Library"
+    root.mkdir()
+    manager = LibraryManager()
+    manager.bind_path(root)
+    qapp.processEvents()
+
+    settings = SettingsManager(path=tmp_path / "settings.json")
+    settings.load()
+    pinned_service = PinnedItemsService(settings)
+    pinned_service.pin_person("person-a", "Alice", library_root=root)
+
+    sidebar = AlbumSidebar(manager)
+    sidebar.set_pinned_service(pinned_service)
+    qapp.processEvents()
+
+    pinned_item = pinned_service.items_for_library(root)[0]
+    pinned_index = sidebar.tree_model().index_for_pinned_item(pinned_item)
+    item = sidebar.tree_model().item_from_index(pinned_index)
+    assert item is not None
+
+    from unittest.mock import patch
+
+    with patch(
+        "iPhoto.gui.ui.menus.album_sidebar_menu._create_styled_input_dialog",
+        return_value=("VIP Alice", True),
+    ):
+        menu = AlbumSidebarContextMenu(
+            sidebar,
+            sidebar._tree,
+            sidebar.tree_model(),
+            manager,
+            item,
+            sidebar._set_pending_selection,
+            sidebar.bindLibraryRequested.emit,
+        )
+        menu.actions()[0].trigger()
+
+    qapp.processEvents()
+
+    renamed = pinned_service.items_for_library(root)[0]
+    assert renamed.label == "VIP Alice"
+    assert renamed.custom_label is True
+
+    refreshed_index = sidebar.tree_model().index_for_pinned_item(renamed)
+    assert refreshed_index.isValid()
+    assert sidebar.tree_model().data(refreshed_index) == "VIP Alice"

--- a/tests/test_album_sidebar.py
+++ b/tests/test_album_sidebar.py
@@ -168,6 +168,51 @@ def test_sidebar_album_context_menu_offers_pin_and_unpin(tmp_path: Path, qapp: Q
     assert menu.actions()[0].text() == "Unpin Album"
 
 
+def test_sidebar_pinned_album_survives_album_rename(tmp_path: Path, qapp: QApplication) -> None:
+    root = tmp_path / "Library"
+    album_dir = root / "Trip"
+    album_dir.mkdir(parents=True)
+    _write_manifest(album_dir, "Trip")
+
+    manager = LibraryManager()
+    manager.bind_path(root)
+    qapp.processEvents()
+
+    settings = SettingsManager(path=tmp_path / "settings.json")
+    settings.load()
+    pinned_service = PinnedItemsService(settings)
+    pinned_service.pin_album(album_dir, "Trip", library_root=root)
+
+    sidebar = AlbumSidebar(manager)
+    sidebar.set_pinned_service(pinned_service)
+    manager.albumRenamed.connect(
+        lambda old, new: pinned_service.remap_album_path(
+            old,
+            new,
+            library_root=root,
+            fallback_label=new.name,
+        )
+    )
+    qapp.processEvents()
+
+    album = next(node for node in manager.list_albums() if node.path == album_dir)
+    manager.rename_album(album, "Renamed Trip")
+    qapp.processEvents()
+
+    new_album = root / "Renamed Trip"
+    pinned = pinned_service.items_for_library(root)
+    assert len(pinned) == 1
+    assert pinned[0].item_id == str(new_album.resolve())
+
+    refreshed_index = sidebar.tree_model().index_for_pinned_item(pinned[0])
+    refreshed_item = sidebar.tree_model().item_from_index(refreshed_index)
+    assert refreshed_item is not None
+    assert refreshed_item.node_type == NodeType.PINNED_ALBUM
+    assert refreshed_item.album is not None
+    assert refreshed_item.album.path == new_album
+    assert sidebar.tree_model().data(refreshed_index) == "Renamed Trip"
+
+
 def test_sidebar_pinned_item_context_menu_offers_unpin(tmp_path: Path, qapp: QApplication) -> None:
     root = tmp_path / "Library"
     root.mkdir()

--- a/tests/test_library_manager.py
+++ b/tests/test_library_manager.py
@@ -14,7 +14,7 @@ pytest.importorskip("PySide6.QtTest", reason="Qt test helpers not available", ex
 from PySide6.QtTest import QSignalSpy
 from PySide6.QtWidgets import QApplication
 
-from iPhoto.errors import AlbumDepthError, LibraryUnavailableError
+from iPhoto.errors import AlbumDepthError, AlbumOperationError, LibraryUnavailableError
 from iPhoto.library.manager import LibraryManager
 
 
@@ -71,8 +71,12 @@ def test_create_and_rename_album(tmp_path: Path, qapp: QApplication) -> None:
     assert sub.level == 2
     with pytest.raises(AlbumDepthError):
         manager.create_subalbum(sub, "TooDeep")
+    rename_spy = QSignalSpy(manager.albumRenamed)
+    old_sub_path = sub.path
     manager.rename_album(sub, "Arrival")
     qapp.processEvents()
+    assert rename_spy.count() == 1
+    assert rename_spy.at(0) == [old_sub_path, created.path / "Arrival"]
     refreshed_parent = next(
         node for node in manager.list_albums() if node.path == created.path
     )
@@ -85,6 +89,36 @@ def test_create_and_rename_album(tmp_path: Path, qapp: QApplication) -> None:
     )
     data = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert data["title"] == "Arrival"
+
+
+@pytest.mark.parametrize("reserved_name", [".iPhoto", ".Trash", "exported"])
+def test_reserved_album_names_are_rejected_for_create_and_rename(
+    tmp_path: Path, qapp: QApplication, reserved_name: str
+) -> None:
+    root = tmp_path / "Library"
+    root.mkdir()
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    created = manager.create_album("Trips")
+    child = manager.create_subalbum(created, "Day1")
+
+    with pytest.raises(AlbumOperationError, match="reserved for internal use"):
+        manager.create_album(reserved_name)
+    with pytest.raises(AlbumOperationError, match="reserved for internal use"):
+        manager.create_subalbum(created, reserved_name)
+    with pytest.raises(AlbumOperationError, match="reserved for internal use"):
+        manager.rename_album(created, reserved_name)
+    with pytest.raises(AlbumOperationError, match="reserved for internal use"):
+        manager.rename_album(child, reserved_name)
+
+    qapp.processEvents()
+
+    albums = manager.list_albums()
+    assert any(node.path == created.path and node.title == "Trips" for node in albums)
+    refreshed_parent = next(node for node in albums if node.path == created.path)
+    refreshed_children = manager.list_children(refreshed_parent)
+    assert any(kid.path == child.path and kid.title == "Day1" for kid in refreshed_children)
 
 
 def test_ensure_manifest_generates_defaults(tmp_path: Path) -> None:

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -79,3 +79,30 @@ def test_pinned_items_roundtrip_is_scoped_by_library(tmp_path: Path, qapp: QAppl
 
     stored = json.loads(settings_path.read_text(encoding="utf-8"))
     assert "pinned_items_by_library" in stored
+
+
+def test_pinned_item_rename_persists_custom_label_flag(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    manager = SettingsManager(path=settings_path)
+    manager.load()
+    service = PinnedItemsService(manager)
+
+    library_root = tmp_path / "Library"
+    library_root.mkdir()
+
+    service.pin_person("person-a", "Alice", library_root=library_root)
+    assert service.rename_item(
+        kind="person",
+        item_id="person-a",
+        label="VIP Alice",
+        library_root=library_root,
+    )
+
+    items = service.items_for_library(library_root)
+    assert len(items) == 1
+    assert items[0].label == "VIP Alice"
+    assert items[0].custom_label is True
+
+    stored = json.loads(settings_path.read_text(encoding="utf-8"))
+    library_key = str(library_root.resolve())
+    assert stored["pinned_items_by_library"][library_key][0]["custom_label"] is True

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -106,3 +106,38 @@ def test_pinned_item_rename_persists_custom_label_flag(tmp_path: Path) -> None:
     stored = json.loads(settings_path.read_text(encoding="utf-8"))
     library_key = str(library_root.resolve())
     assert stored["pinned_items_by_library"][library_key][0]["custom_label"] is True
+
+
+def test_pinned_album_path_remap_preserves_custom_label(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    manager = SettingsManager(path=settings_path)
+    manager.load()
+    service = PinnedItemsService(manager)
+
+    library_root = tmp_path / "Library"
+    old_album = library_root / "Trips"
+    new_album = library_root / "Renamed Trips"
+    old_album.mkdir(parents=True)
+    new_album.mkdir()
+
+    service.pin_album(old_album, "Trips", library_root=library_root)
+    assert service.rename_item(
+        kind="album",
+        item_id=old_album,
+        label="Best Trips",
+        library_root=library_root,
+    )
+
+    assert service.remap_album_path(
+        old_album,
+        new_album,
+        library_root=library_root,
+        fallback_label="Renamed Trips",
+    )
+
+    items = service.items_for_library(library_root)
+    assert len(items) == 1
+    assert items[0].kind == "album"
+    assert items[0].item_id == str(new_album.resolve())
+    assert items[0].label == "Best Trips"
+    assert items[0].custom_label is True

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -141,3 +141,34 @@ def test_pinned_album_path_remap_preserves_custom_label(tmp_path: Path) -> None:
     assert items[0].item_id == str(new_album.resolve())
     assert items[0].label == "Best Trips"
     assert items[0].custom_label is True
+
+
+def test_pinned_child_album_path_remaps_when_parent_is_renamed(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    manager = SettingsManager(path=settings_path)
+    manager.load()
+    service = PinnedItemsService(manager)
+
+    library_root = tmp_path / "Library"
+    old_parent = library_root / "Trips"
+    old_child = old_parent / "Paris"
+    new_parent = library_root / "Renamed Trips"
+    new_child = new_parent / "Paris"
+    old_child.mkdir(parents=True)
+    new_child.mkdir(parents=True)
+
+    service.pin_album(old_child, "Paris", library_root=library_root)
+
+    assert service.remap_album_path(
+        old_parent,
+        new_parent,
+        library_root=library_root,
+        fallback_label="Renamed Trips",
+    )
+
+    items = service.items_for_library(library_root)
+    assert len(items) == 1
+    assert items[0].kind == "album"
+    assert items[0].item_id == str(new_child.resolve())
+    assert items[0].label == "Paris"
+    assert items[0].custom_label is False

--- a/tests/test_thumbnail_cache_service.py
+++ b/tests/test_thumbnail_cache_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QSize
+
+from iPhoto.infrastructure.services.thumbnail_cache_service import ThumbnailCacheService
+
+
+def test_thumbnail_cache_service_remaps_album_disk_cache(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "thumbs"
+    service = ThumbnailCacheService(cache_dir)
+    old_album = tmp_path / "Trips"
+    new_album = tmp_path / "Renamed Trips"
+    old_photo = old_album / "photo.jpg"
+    new_photo = new_album / "photo.jpg"
+    new_photo.parent.mkdir(parents=True)
+    new_photo.write_bytes(b"image")
+
+    size = QSize(512, 512)
+    old_key = service._cache_key(old_photo, size)
+    new_key = service._cache_key(new_photo, size)
+    old_cache_file = cache_dir / f"{old_key}.jpg"
+    new_cache_file = cache_dir / f"{new_key}.jpg"
+    old_cache_file.write_bytes(b"cached-thumbnail")
+
+    service.remap_album_paths(old_album, new_album, size=size)
+
+    assert new_cache_file.read_bytes() == b"cached-thumbnail"

--- a/tests/ui/controllers/test_context_menu_cover.py
+++ b/tests/ui/controllers/test_context_menu_cover.py
@@ -152,3 +152,33 @@ def test_non_cover_gallery_menu_hides_set_as_cover(
 
     actions_added = [args[0] for args, _ in mock_qmenu_cls.return_value.addAction.call_args_list]
     assert "Set as Cover" not in actions_added
+
+
+def test_album_cover_uses_active_album_relative_path() -> None:
+    asset = _make_asset("asset-1", "Trips/day1/a.jpg")
+    album_root = Path("/library/Trips")
+    controller, deps = _make_controller(
+        context=MenuContext(
+            surface="gallery",
+            selection_kind="assets",
+            gallery_section="album",
+            entity_kind="album",
+            entity_id=str(album_root),
+            active_root=album_root,
+        ),
+        selected_assets=[asset],
+    )
+
+    controller._set_as_cover(
+        MenuContext(
+            surface="gallery",
+            selection_kind="assets",
+            selected_assets=(asset,),
+            gallery_section="album",
+            entity_kind="album",
+            entity_id=str(album_root),
+            active_root=album_root,
+        )
+    )
+
+    deps["facade"].set_cover.assert_called_once_with("day1/a.jpg")

--- a/tests/ui/test_albums_dashboard.py
+++ b/tests/ui/test_albums_dashboard.py
@@ -19,8 +19,10 @@ from PySide6.QtCore import QSize
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QApplication
 
+from iPhoto.errors import AlbumOperationError
 from iPhoto.gui.services.pinned_items_service import PinnedItemsService
 from iPhoto.settings.manager import SettingsManager
+from iPhoto.library.manager import LibraryManager
 from iPhoto.gui.ui.widgets.albums_dashboard import (
     AlbumCard,
     AlbumsDashboard,
@@ -176,6 +178,65 @@ def test_albums_dashboard_rename_album_calls_library(qapp, mock_library, tmp_pat
             dashboard._prompt_rename_album(card)
 
     mock_library.rename_album.assert_called_once_with(album, "Renamed Trips")
+
+
+def test_albums_dashboard_successful_rename_refreshes_card_paths(qapp, tmp_path):
+    root = tmp_path / "Library"
+    root.mkdir()
+    manager = LibraryManager()
+    manager.bind_path(root)
+    album = manager.create_album("Trips")
+
+    with patch("PySide6.QtCore.QThreadPool.globalInstance"):
+        dashboard = AlbumsDashboard(manager)
+        qapp.processEvents()
+        card = dashboard._cards[album.path]
+
+        with patch(
+            "iPhoto.gui.ui.widgets.albums_dashboard._create_styled_input_dialog",
+            return_value=("Renamed Trips", True),
+        ):
+            dashboard._prompt_rename_album(card)
+            qapp.processEvents()
+
+    old_path = root / "Trips"
+    new_path = root / "Renamed Trips"
+    assert not old_path.exists()
+    assert new_path.exists()
+    assert old_path not in dashboard._cards
+    assert new_path in dashboard._cards
+    assert dashboard._cards[new_path].title_label.text() == "Renamed Trips"
+
+
+def test_albums_dashboard_reserved_rename_shows_warning(qapp, mock_library, tmp_path):
+    album = MagicMock()
+    album.title = "Trips"
+    album.path = tmp_path / "Trips"
+    album.path.mkdir()
+    mock_library.list_albums.return_value = [album]
+    mock_library.rename_album.side_effect = AlbumOperationError(
+        "Album name '.Trash' is reserved for internal use."
+    )
+
+    with patch("PySide6.QtCore.QThreadPool.globalInstance"):
+        dashboard = AlbumsDashboard(mock_library)
+        qapp.processEvents()
+        card = dashboard._cards[album.path]
+
+        with (
+            patch(
+                "iPhoto.gui.ui.widgets.albums_dashboard._create_styled_input_dialog",
+                return_value=(".Trash", True),
+            ),
+            patch("iPhoto.gui.ui.widgets.albums_dashboard.dialogs.show_warning") as show_warning,
+        ):
+            dashboard._prompt_rename_album(card)
+
+    mock_library.rename_album.assert_called_once_with(album, ".Trash")
+    show_warning.assert_called_once_with(
+        dashboard, "Album name '.Trash' is reserved for internal use."
+    )
+    assert album.path in dashboard._cards
 
 
 def test_albums_dashboard_updates_cover_preview_immediately(qapp, mock_library, tmp_path):

--- a/tests/ui/test_albums_dashboard.py
+++ b/tests/ui/test_albums_dashboard.py
@@ -15,11 +15,16 @@ pytest.importorskip(
 )
 
 from PySide6.QtCore import Qt
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QApplication
 
 from iPhoto.gui.services.pinned_items_service import PinnedItemsService
 from iPhoto.settings.manager import SettingsManager
-from iPhoto.gui.ui.widgets.albums_dashboard import AlbumCard, AlbumsDashboard
+from iPhoto.gui.ui.widgets.albums_dashboard import (
+    AlbumCard,
+    AlbumsDashboard,
+)
 
 @pytest.fixture
 def qapp():
@@ -123,7 +128,7 @@ def test_albums_dashboard_relays_signal(qtbot, mock_library):
         assert blocker.args == [album.path]
 
 
-def test_albums_dashboard_menu_uses_styled_pin_action(qtbot, mock_library, tmp_path):
+def test_albums_dashboard_menu_uses_styled_pin_action(qapp, mock_library, tmp_path):
     album = MagicMock()
     album.title = "Pinned Album"
     album.path = tmp_path / "album"
@@ -137,14 +142,60 @@ def test_albums_dashboard_menu_uses_styled_pin_action(qtbot, mock_library, tmp_p
     with patch("PySide6.QtCore.QThreadPool.globalInstance"):
         dashboard = AlbumsDashboard(mock_library)
         dashboard.set_pinned_service(pinned_service)
-        qtbot.addWidget(dashboard)
+        qapp.processEvents()
         card = dashboard._cards[album.path]
 
         menu = dashboard._build_card_menu(card)
+        action_labels = [action.text() for action in menu.actions() if not action.isSeparator()]
 
         assert menu.testAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        assert menu.actions()[0].text() == "Pin Album"
+        assert action_labels == ["Rename…", "Pin Album"]
 
         pinned_service.pin_album(album.path, album.title, library_root=tmp_path)
         menu = dashboard._build_card_menu(card)
-        assert menu.actions()[0].text() == "Unpin Album"
+        action_labels = [action.text() for action in menu.actions() if not action.isSeparator()]
+        assert action_labels == ["Rename…", "Unpin Album"]
+
+
+def test_albums_dashboard_rename_album_calls_library(qapp, mock_library, tmp_path):
+    album = MagicMock()
+    album.title = "Trips"
+    album.path = tmp_path / "Trips"
+    album.path.mkdir()
+    mock_library.list_albums.return_value = [album]
+
+    with patch("PySide6.QtCore.QThreadPool.globalInstance"):
+        dashboard = AlbumsDashboard(mock_library)
+        qapp.processEvents()
+        card = dashboard._cards[album.path]
+
+        with patch(
+            "iPhoto.gui.ui.widgets.albums_dashboard._create_styled_input_dialog",
+            return_value=("Renamed Trips", True),
+        ):
+            dashboard._prompt_rename_album(card)
+
+    mock_library.rename_album.assert_called_once_with(album, "Renamed Trips")
+
+
+def test_albums_dashboard_updates_cover_preview_immediately(qapp, mock_library, tmp_path):
+    album = MagicMock()
+    album.title = "Trips"
+    album.path = tmp_path / "Trips"
+    album.path.mkdir()
+    mock_library.list_albums.return_value = [album]
+    cover_path = album.path / "cover.png"
+    pixmap = QPixmap(8, 8)
+    pixmap.fill()
+    assert pixmap.save(str(cover_path))
+
+    with patch("PySide6.QtCore.QThreadPool.globalInstance"):
+        dashboard = AlbumsDashboard(mock_library)
+        qapp.processEvents()
+        card = dashboard._cards[album.path]
+
+        with patch.object(dashboard._thumb_loader, "request_with_absolute_key") as request_thumb:
+            dashboard.update_album_cover(album.path, cover_path)
+
+        assert card.image_view._pixmap is not None
+        request_thumb.assert_called_once_with(album.path, cover_path, QSize(512, 512))


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the right-click menu system, pinned sidebar item management, and album cover handling in the application. The most significant changes unify the context menu rules across different UI surfaces, add support for renaming pinned sidebar items with custom labels, and ensure album cover updates are correctly propagated and displayed. Additionally, the PR enhances the persistence and display logic for custom-pinned item labels and refines the album cover update signaling and thumbnail loading mechanisms.

**Unified Right-Click Menu System:**

- Added documentation outlining unified rules for context menus across sidebar, dashboard, and gallery, specifying consistent menu construction, selection sync, label conventions, and testing requirements.
- Refactored context menu controller to ensure album cover actions resolve paths relative to the active album root, preventing path mismatches. [[1]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1L428-R437) [[2]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1R447-R455)

**Pinned Sidebar Items and Custom Labels:**

- Added support for custom labels on pinned sidebar items, including a new `custom_label` attribute in `PinnedSidebarItem`, and updated serialization/deserialization logic to persist this flag. [[1]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaR23) [[2]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaR52-R62) [[3]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaL70-R84) [[4]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaL79-R98) [[5]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaL88-R154) [[6]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaR216-R226) [[7]](diffhunk://#diff-c86bce489a121f88b6483a8cf01e09172cc11fae10bc057c0bab3826527f90eaL173-R237)
- Implemented a `rename_item` method in `PinnedItemsService` to allow renaming pinned items and marking them with `custom_label=True`.
- Updated the album sidebar menu to add a "Rename…" action for pinned items, prompting the user for a new label and validating input. [[1]](diffhunk://#diff-64dd5e7d428140f429141468897d234d46e022dcb319d384c2046ad7ee626c66R158-R159) [[2]](diffhunk://#diff-64dd5e7d428140f429141468897d234d46e022dcb319d384c2046ad7ee626c66R201-R226)
- Modified the album tree model so that custom-labeled pinned items display their label instead of the default entity name. [[1]](diffhunk://#diff-be2f0ac2461aaf52c4170b88b22519e75d7121bb7cd738ed4efcdc89e1a03b92L393-R397) [[2]](diffhunk://#diff-be2f0ac2461aaf52c4170b88b22519e75d7121bb7cd738ed4efcdc89e1a03b92L402-R418)

**Album Cover Handling and Dashboard Thumbnails:**

- Added a new `albumCoverUpdated` signal to `AppFacade` and connected it to the dashboard page to update album covers in real-time. [[1]](diffhunk://#diff-9ecd44e07c3f8503398a242b0bf890f6a34e4fc4b697b26efb9405b447dfe8e5R36) [[2]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR107-R109) [[3]](diffhunk://#diff-9ecd44e07c3f8503398a242b0bf890f6a34e4fc4b697b26efb9405b447dfe8e5L301-R305)
- Modified the dashboard thumbnail loader to emit the source image path with each thumbnail, enabling more accurate updates when covers change. [[1]](diffhunk://#diff-87578818f66d255ed370d0c149c6e68ae83c9f8a2e21ebeb031f0f7643bce9c2L418-R421) [[2]](diffhunk://#diff-87578818f66d255ed370d0c149c6e68ae83c9f8a2e21ebeb031f0f7643bce9c2L457-R460)

**Code Modernization and Cleanup:**

- Updated type hints and imports for clarity and Python 3.9+ compatibility in several files, improving maintainability. [[1]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1L7-L20) [[2]](diffhunk://#diff-adba0d565903502017026a2c1a134505d951b6d5cdcff91e51eb2355b669dda1L54-R56) [[3]](diffhunk://#diff-64dd5e7d428140f429141468897d234d46e022dcb319d384c2046ad7ee626c66L22) [[4]](diffhunk://#diff-87578818f66d255ed370d0c149c6e68ae83c9f8a2e21ebeb031f0f7643bce9c2L43-R56)

These changes collectively improve the consistency, usability, and reliability of the app's right-click menus, pinned item management, and album cover updates.