### PR TITLE
Enhance map extension download flow and window visibility management

### DIFF
--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -33,6 +33,9 @@ from iPhoto.gui.ui.controllers.context_menu_controller import ContextMenuControl
 from iPhoto.gui.ui.controllers.dialog_controller import DialogController
 from iPhoto.gui.ui.controllers.export_controller import ExportController
 from iPhoto.gui.ui.controllers.header_controller import HeaderController
+from iPhoto.gui.ui.controllers.map_extension_download_controller import (
+    MapExtensionDownloadController,
+)
 from iPhoto.gui.ui.controllers.preview_controller import PreviewController
 from iPhoto.gui.ui.controllers.selection_controller import SelectionController
 from iPhoto.gui.ui.controllers.share_controller import ShareController
@@ -47,6 +50,7 @@ from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAda
 from iPhoto.gui.viewmodels.gallery_viewmodel import GalleryViewModel
 from iPhoto.gui.services.pinned_items_service import PinnedItemsService
 from iPhoto.people.service import PeopleService
+from maps.map_sources import supports_map_extension_download
 
 if TYPE_CHECKING:
     from iPhoto.gui.ui.main_window import MainWindow
@@ -72,6 +76,13 @@ class MainCoordinator(QObject):
         self._facade = context.facade
         self._logger = logging.getLogger(__name__)
         self._media_failure_cleanup_paths: set[str] = set()
+        self._map_extension_download = MapExtensionDownloadController(
+            window,
+            context,
+            package_root=Path(__file__).resolve().parents[3] / "maps",
+        )
+        if hasattr(window.ui, "download_map_extension_action"):
+            window.ui.download_map_extension_action.setEnabled(supports_map_extension_download())
 
         # Resolve Services
         if self._container:
@@ -197,6 +208,9 @@ class MainCoordinator(QObject):
         # Manually attach info panel if available
         if hasattr(window.ui, "info_panel"):
             self._playback.set_info_panel(window.ui.info_panel)
+            window.ui.info_panel.downloadMapExtensionRequested.connect(
+                lambda: self._map_extension_download.start_download(source="info_panel")
+            )
 
         # 4. Theme Controller
         self._theme_controller = WindowThemeController(window.ui, window, context.theme)
@@ -321,6 +335,7 @@ class MainCoordinator(QObject):
         """Start the coordinator."""
         self._logger.info("MainCoordinator started")
         self._view_router.show_gallery()
+        self._map_extension_download.maybe_prompt_on_startup()
 
     # ------------------------------------------------------------------
     # Window manager integration (legacy interface)
@@ -435,6 +450,9 @@ class MainCoordinator(QObject):
         ui.open_album_action.triggered.connect(self._handle_open_album_dialog)
         ui.rescan_action.triggered.connect(self._status_bar.begin_scan)
         ui.rescan_action.triggered.connect(self._gallery_vm.rescan_current)
+        ui.download_map_extension_action.triggered.connect(
+            lambda: self._map_extension_download.start_download(source="settings")
+        )
         ui.edit_button.clicked.connect(self._detail_vm.request_edit)
         # ui.edit_rotate_left_button is handled by EditCoordinator in Edit Mode
         ui.rotate_left_button.clicked.connect(self._playback.rotate_current_asset)

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -108,6 +108,13 @@ def main(argv: list[str] | None = None) -> int:
     """Launch the Qt application and return the exit code."""
 
     _prefer_local_source_tree()
+    maps_package_root = Path(__file__).resolve().parents[2] / "maps"
+    try:
+        from maps.map_sources import apply_pending_osmand_extension_install
+
+        apply_pending_osmand_extension_install(maps_package_root)
+    except Exception:
+        _logger.warning("Failed to apply pending map extension install", exc_info=True)
 
     # Ensure the ``iPhoto`` root logger is configured before any component
     # creates a child logger.  ``get_logger()`` lazily attaches a StreamHandler

--- a/src/iPhoto/gui/ui/controllers/map_extension_download_controller.py
+++ b/src/iPhoto/gui/ui/controllers/map_extension_download_controller.py
@@ -1,0 +1,237 @@
+"""Shared UI controller for downloading and activating the map extension."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from PySide6.QtCore import QCoreApplication, QProcess, QThreadPool, Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QProgressBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from iPhoto.application.contracts.runtime_entry_contract import RuntimeEntryContract
+from iPhoto.gui.ui.tasks.map_extension_download_worker import (
+    MapExtensionDownloadRequest,
+    MapExtensionDownloadResult,
+    MapExtensionDownloadWorker,
+)
+from maps.map_sources import (
+    has_installed_osmand_extension,
+    has_pending_osmand_extension_install,
+    supports_map_extension_download,
+)
+
+LOGGER = logging.getLogger(__name__)
+_SHOW_STARTUP_PROMPT_KEY = "ui.show_map_extension_startup_prompt"
+
+
+class _MapExtensionProgressDialog(QDialog):
+    """Modal progress dialog used by every map-extension entry point."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Map Extension")
+        self.setModal(True)
+        self.setWindowFlag(Qt.WindowType.WindowContextHelpButtonHint, False)
+        self.setMinimumWidth(420)
+        self._allow_close = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(18, 18, 18, 18)
+        layout.setSpacing(12)
+
+        self._message_label = QLabel("Preparing map extension download...", self)
+        self._message_label.setWordWrap(True)
+        layout.addWidget(self._message_label)
+
+        self._progress_bar = QProgressBar(self)
+        self._progress_bar.setRange(0, 0)
+        self._progress_bar.setValue(0)
+        layout.addWidget(self._progress_bar)
+
+        footer = QHBoxLayout()
+        footer.addStretch(1)
+        self._status_label = QLabel("", self)
+        footer.addWidget(self._status_label)
+        layout.addLayout(footer)
+
+    def update_progress(self, current: int, total: int, message: str) -> None:
+        self._message_label.setText(message)
+        if total > 0:
+            self._progress_bar.setRange(0, total)
+            self._progress_bar.setValue(max(0, min(current, total)))
+            percent = int(round((current / total) * 100.0)) if total else 0
+            self._status_label.setText(f"{percent}%")
+        else:
+            self._progress_bar.setRange(0, 0)
+            self._status_label.clear()
+
+    def allow_close(self) -> None:
+        self._allow_close = True
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        if not self._allow_close:
+            event.ignore()
+            return
+        super().closeEvent(event)
+
+
+class MapExtensionDownloadController:
+    """Coordinate startup prompts, download progress, and restart requests."""
+
+    def __init__(
+        self,
+        parent: QWidget,
+        context: RuntimeEntryContract,
+        *,
+        package_root: Path,
+    ) -> None:
+        self._parent = parent
+        self._context = context
+        self._package_root = Path(package_root).resolve()
+        self._progress_dialog: _MapExtensionProgressDialog | None = None
+        self._download_inflight = False
+        self._latest_result: MapExtensionDownloadResult | None = None
+
+    def maybe_prompt_on_startup(self) -> None:
+        if not supports_map_extension_download():
+            return
+        if has_installed_osmand_extension(self._package_root):
+            return
+        if has_pending_osmand_extension_install(self._package_root):
+            return
+        if not bool(self._context.settings.get(_SHOW_STARTUP_PROMPT_KEY, True)):
+            return
+
+        message_box = QMessageBox(self._parent)
+        message_box.setIcon(QMessageBox.Icon.Question)
+        message_box.setWindowTitle("Map Extension")
+        message_box.setText("Download the offline map extension now?")
+        message_box.setInformativeText(
+            "The map extension enables the bundled offline OsmAnd map runtime."
+        )
+        download_button = message_box.addButton("Download", QMessageBox.ButtonRole.AcceptRole)
+        message_box.addButton("Not Now", QMessageBox.ButtonRole.RejectRole)
+        do_not_show_checkbox = QCheckBox("Do not show again", message_box)
+        message_box.setCheckBox(do_not_show_checkbox)
+        message_box.exec()
+
+        if message_box.clickedButton() is download_button:
+            self.start_download(source="startup")
+            return
+
+        if do_not_show_checkbox.isChecked():
+            self._context.settings.set(_SHOW_STARTUP_PROMPT_KEY, False)
+
+    def start_download(self, *, source: str) -> None:
+        del source
+        if self._download_inflight:
+            if self._progress_dialog is not None:
+                self._progress_dialog.raise_()
+                self._progress_dialog.activateWindow()
+            return
+
+        if not supports_map_extension_download():
+            QMessageBox.warning(
+                self._parent,
+                "Map Extension",
+                "Map extension downloads are unavailable on this platform.",
+            )
+            return
+
+        self._download_inflight = True
+        self._latest_result = None
+        self._progress_dialog = _MapExtensionProgressDialog(self._parent)
+        self._progress_dialog.show()
+        self._progress_dialog.raise_()
+        self._progress_dialog.activateWindow()
+
+        worker = MapExtensionDownloadWorker(
+            MapExtensionDownloadRequest(
+                package_root=self._package_root,
+                platform=sys.platform,
+            )
+        )
+        worker.signals.progress.connect(self._handle_progress)
+        worker.signals.ready.connect(self._handle_ready)
+        worker.signals.error.connect(self._handle_error)
+        worker.signals.finished.connect(self._handle_finished)
+        QThreadPool.globalInstance().start(worker, -1)
+
+    def _handle_progress(self, current: int, total: int, message: str) -> None:
+        if self._progress_dialog is not None:
+            self._progress_dialog.update_progress(int(current), int(total), str(message))
+
+    def _handle_ready(self, result: object) -> None:
+        if isinstance(result, MapExtensionDownloadResult):
+            self._latest_result = result
+        if self._progress_dialog is not None:
+            self._progress_dialog.update_progress(100, 100, "Map extension is ready. Restart required.")
+            self._progress_dialog.allow_close()
+            self._progress_dialog.close()
+            self._progress_dialog.deleteLater()
+            self._progress_dialog = None
+
+        restart_now = QMessageBox.question(
+            self._parent,
+            "Restart Required",
+            "Map extension download finished. Restart now to activate it?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes,
+        )
+        if restart_now == QMessageBox.StandardButton.Yes:
+            self._restart_application()
+
+    def _handle_error(self, message: str) -> None:
+        if self._progress_dialog is not None:
+            self._progress_dialog.allow_close()
+            self._progress_dialog.close()
+            self._progress_dialog.deleteLater()
+            self._progress_dialog = None
+        QMessageBox.critical(
+            self._parent,
+            "Map Extension",
+            str(message) or "Failed to download the map extension.",
+        )
+
+    def _handle_finished(self) -> None:
+        self._download_inflight = False
+
+    def _restart_application(self) -> None:
+        app = QCoreApplication.instance()
+        if app is None:
+            return
+
+        program, arguments = self._restart_command(app)
+        if not QProcess.startDetached(program, arguments):
+            QMessageBox.critical(
+                self._parent,
+                "Restart Failed",
+                "Failed to relaunch the application automatically. Please restart it manually.",
+            )
+            return
+
+        window = self._parent.window()
+        if window is not None:
+            window.close()
+        else:
+            app.quit()
+
+    def _restart_command(self, app: QCoreApplication) -> tuple[str, list[str]]:
+        if getattr(sys, "frozen", False):
+            program = app.applicationFilePath()
+            arguments = list(sys.argv[1:])
+            return program, arguments
+        return sys.executable, list(sys.argv)
+
+
+__all__ = ["MapExtensionDownloadController"]

--- a/src/iPhoto/gui/ui/controllers/map_extension_download_controller.py
+++ b/src/iPhoto/gui/ui/controllers/map_extension_download_controller.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from PySide6.QtCore import QCoreApplication, QProcess, QThreadPool, Qt
 from PySide6.QtWidgets import (
+    QApplication,
     QCheckBox,
     QDialog,
     QHBoxLayout,
@@ -101,6 +102,7 @@ class MapExtensionDownloadController:
         self._progress_dialog: _MapExtensionProgressDialog | None = None
         self._download_inflight = False
         self._latest_result: MapExtensionDownloadResult | None = None
+        self._temporarily_hidden_windows: list[QWidget] = []
 
     def maybe_prompt_on_startup(self) -> None:
         if not supports_map_extension_download():
@@ -150,6 +152,7 @@ class MapExtensionDownloadController:
 
         self._download_inflight = True
         self._latest_result = None
+        self._hide_blocking_top_level_windows()
         self._progress_dialog = _MapExtensionProgressDialog(self._parent)
         self._progress_dialog.show()
         self._progress_dialog.raise_()
@@ -188,6 +191,8 @@ class MapExtensionDownloadController:
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.Yes,
         )
+        if restart_now != QMessageBox.StandardButton.Yes:
+            self._restore_temporarily_hidden_windows()
         if restart_now == QMessageBox.StandardButton.Yes:
             self._restart_application()
 
@@ -197,6 +202,7 @@ class MapExtensionDownloadController:
             self._progress_dialog.close()
             self._progress_dialog.deleteLater()
             self._progress_dialog = None
+        self._restore_temporarily_hidden_windows()
         QMessageBox.critical(
             self._parent,
             "Map Extension",
@@ -232,6 +238,33 @@ class MapExtensionDownloadController:
             arguments = list(sys.argv[1:])
             return program, arguments
         return sys.executable, list(sys.argv)
+
+    def _hide_blocking_top_level_windows(self) -> None:
+        self._temporarily_hidden_windows.clear()
+        owner = self._parent.window()
+        if owner is None:
+            return
+
+        for widget in QApplication.topLevelWidgets():
+            if widget is owner or widget is self._progress_dialog:
+                continue
+            if widget.parentWidget() is not owner:
+                continue
+            if not widget.isVisible():
+                continue
+            if not bool(widget.windowFlags() & Qt.WindowType.WindowStaysOnTopHint):
+                continue
+            self._temporarily_hidden_windows.append(widget)
+            widget.hide()
+
+    def _restore_temporarily_hidden_windows(self) -> None:
+        while self._temporarily_hidden_windows:
+            widget = self._temporarily_hidden_windows.pop()
+            try:
+                widget.show()
+                widget.raise_()
+            except RuntimeError:
+                continue
 
 
 __all__ = ["MapExtensionDownloadController"]

--- a/src/iPhoto/gui/ui/controllers/map_extension_download_controller.py
+++ b/src/iPhoto/gui/ui/controllers/map_extension_download_controller.py
@@ -215,10 +215,12 @@ class MapExtensionDownloadController:
     def _restart_application(self) -> None:
         app = QCoreApplication.instance()
         if app is None:
+            self._restore_temporarily_hidden_windows()
             return
 
         program, arguments = self._restart_command(app)
         if not QProcess.startDetached(program, arguments):
+            self._restore_temporarily_hidden_windows()
             QMessageBox.critical(
                 self._parent,
                 "Restart Failed",

--- a/src/iPhoto/gui/ui/tasks/map_extension_download_worker.py
+++ b/src/iPhoto/gui/ui/tasks/map_extension_download_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import socket
 import shutil
 import tarfile
 import tempfile
@@ -22,6 +23,7 @@ from maps.map_sources import (
 
 _LOGGER = logging.getLogger(__name__)
 _CHUNK_SIZE = 1024 * 256
+_DOWNLOAD_TIMEOUT_SECONDS = 30
 
 
 @dataclass(frozen=True)
@@ -94,25 +96,36 @@ class MapExtensionDownloadWorker(QRunnable):
 
     def _download_archive(self, download_url: str, archive_path: Path) -> None:
         self.signals.progress.emit(0, 0, "Downloading map extension...")
-        with request.urlopen(download_url) as response, archive_path.open("wb") as handle:
-            total_header = response.headers.get("Content-Length", "").strip()
-            try:
-                total = int(total_header)
-            except ValueError:
-                total = 0
+        try:
+            with request.urlopen(download_url, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response, archive_path.open(
+                "wb"
+            ) as handle:
+                total_header = response.headers.get("Content-Length", "").strip()
+                try:
+                    total = int(total_header)
+                except ValueError:
+                    total = 0
 
-            received = 0
-            while True:
-                chunk = response.read(_CHUNK_SIZE)
-                if not chunk:
-                    break
-                handle.write(chunk)
-                received += len(chunk)
-                self.signals.progress.emit(
-                    received,
-                    total,
-                    "Downloading map extension...",
-                )
+                received = 0
+                while True:
+                    chunk = response.read(_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+                    received += len(chunk)
+                    self.signals.progress.emit(
+                        received,
+                        total,
+                        "Downloading map extension...",
+                    )
+        except TimeoutError as exc:
+            raise RuntimeError(
+                "Map extension download timed out. Please check your connection and try again."
+            ) from exc
+        except socket.timeout as exc:
+            raise RuntimeError(
+                "Map extension download timed out. Please check your connection and try again."
+            ) from exc
 
     def _extract_archive(self, archive_path: Path, extracted_root: Path) -> None:
         self.signals.progress.emit(95, 100, "Extracting map extension...")

--- a/src/iPhoto/gui/ui/tasks/map_extension_download_worker.py
+++ b/src/iPhoto/gui/ui/tasks/map_extension_download_worker.py
@@ -1,0 +1,165 @@
+"""Background worker that downloads and stages the map extension archive."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from urllib import request
+
+from PySide6.QtCore import QObject, QRunnable, Signal
+
+from maps.map_sources import (
+    default_osmand_download_url,
+    default_pending_osmand_extension_root,
+    default_osmand_tiles_root,
+    supports_map_extension_download,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_CHUNK_SIZE = 1024 * 256
+
+
+@dataclass(frozen=True)
+class MapExtensionDownloadRequest:
+    package_root: Path
+    platform: str
+
+
+@dataclass(frozen=True)
+class MapExtensionDownloadResult:
+    pending_root: Path
+
+
+class MapExtensionDownloadSignals(QObject):
+    progress = Signal(int, int, str)
+    ready = Signal(object)
+    error = Signal(str)
+    finished = Signal()
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+
+
+class MapExtensionDownloadWorker(QRunnable):
+    """Download the published archive and stage it for the next restart."""
+
+    def __init__(self, request_payload: MapExtensionDownloadRequest) -> None:
+        super().__init__()
+        self.setAutoDelete(True)
+        self._request = request_payload
+        self.signals = MapExtensionDownloadSignals()
+
+    def run(self) -> None:  # pragma: no cover - exercised by focused tests
+        try:
+            result = self._download_and_stage()
+            self.signals.ready.emit(result)
+        except Exception as exc:  # noqa: BLE001 - isolate worker failures
+            _LOGGER.exception("Failed to download map extension")
+            self.signals.error.emit(str(exc))
+        finally:
+            self.signals.finished.emit()
+
+    def _download_and_stage(self) -> MapExtensionDownloadResult:
+        if not supports_map_extension_download(self._request.platform):
+            raise RuntimeError("Map extension download is unavailable on this platform.")
+
+        download_url = default_osmand_download_url(self._request.platform)
+        if not download_url:
+            raise RuntimeError("Map extension download URL is unavailable.")
+
+        tiles_root = default_osmand_tiles_root(self._request.package_root)
+        tiles_root.mkdir(parents=True, exist_ok=True)
+        pending_root = default_pending_osmand_extension_root(self._request.package_root)
+
+        with tempfile.TemporaryDirectory(prefix="iphoto-map-extension-") as tmp_dir_str:
+            tmp_dir = Path(tmp_dir_str)
+            archive_name = "extension.zip" if self._request.platform == "win32" else "extension.tar.xz"
+            archive_path = tmp_dir / archive_name
+            extracted_root = tmp_dir / "extracted"
+            extracted_root.mkdir(parents=True, exist_ok=True)
+
+            self._download_archive(download_url, archive_path)
+            self._extract_archive(archive_path, extracted_root)
+            extension_root = extracted_root / "extension"
+            self._validate_extension_root(extension_root)
+            self._publish_pending_install(extension_root, pending_root)
+
+        self.signals.progress.emit(100, 100, "Download complete")
+        return MapExtensionDownloadResult(pending_root=pending_root)
+
+    def _download_archive(self, download_url: str, archive_path: Path) -> None:
+        self.signals.progress.emit(0, 0, "Downloading map extension...")
+        with request.urlopen(download_url) as response, archive_path.open("wb") as handle:
+            total_header = response.headers.get("Content-Length", "").strip()
+            try:
+                total = int(total_header)
+            except ValueError:
+                total = 0
+
+            received = 0
+            while True:
+                chunk = response.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                handle.write(chunk)
+                received += len(chunk)
+                self.signals.progress.emit(
+                    received,
+                    total,
+                    "Downloading map extension...",
+                )
+
+    def _extract_archive(self, archive_path: Path, extracted_root: Path) -> None:
+        self.signals.progress.emit(95, 100, "Extracting map extension...")
+        suffixes = archive_path.suffixes
+        if suffixes[-2:] == [".tar", ".xz"]:
+            with tarfile.open(archive_path, mode="r:xz") as archive:
+                archive.extractall(extracted_root)
+            return
+        if archive_path.suffix == ".zip":
+            with zipfile.ZipFile(archive_path) as archive:
+                archive.extractall(extracted_root)
+            return
+        raise RuntimeError(f"Unsupported map extension archive: {archive_path.name}")
+
+    def _validate_extension_root(self, extension_root: Path) -> None:
+        required_paths = (
+            extension_root / "World_basemap_2.obf",
+            extension_root / "rendering_styles" / "snowmobile.render.xml",
+            extension_root / "search" / "geonames.sqlite3",
+        )
+        for candidate in required_paths:
+            if not candidate.exists():
+                raise RuntimeError(
+                    "Downloaded map extension is incomplete: "
+                    f"missing '{candidate.relative_to(extension_root)}'."
+                )
+
+        helper_candidates = (
+            extension_root / "bin" / "osmand_render_helper.exe",
+            extension_root / "bin" / "osmand_render_helper_sdk.exe",
+        ) if self._request.platform == "win32" else (
+            extension_root / "bin" / "osmand_render_helper",
+            extension_root / "bin" / "osmand_render_helper_sdk",
+        )
+        if not any(candidate.is_file() for candidate in helper_candidates):
+            raise RuntimeError("Downloaded map extension is incomplete: helper binary is missing.")
+
+    def _publish_pending_install(self, extension_root: Path, pending_root: Path) -> None:
+        self.signals.progress.emit(99, 100, "Preparing restart...")
+        if pending_root.exists():
+            shutil.rmtree(pending_root)
+        shutil.move(str(extension_root), str(pending_root))
+
+
+__all__ = [
+    "MapExtensionDownloadRequest",
+    "MapExtensionDownloadResult",
+    "MapExtensionDownloadSignals",
+    "MapExtensionDownloadWorker",
+]

--- a/src/iPhoto/gui/ui/ui_main_window.py
+++ b/src/iPhoto/gui/ui/ui_main_window.py
@@ -122,6 +122,7 @@ class Ui_MainWindow(object):
         self.rescan_action = self.main_header.rescan_action
         self.rebuild_links_action = self.main_header.rebuild_links_action
         self.bind_library_action = self.main_header.bind_library_action
+        self.download_map_extension_action = self.main_header.download_map_extension_action
         self.toggle_filmstrip_action = self.main_header.toggle_filmstrip_action
         self.toggle_face_names_action = self.main_header.toggle_face_names_action
         self.toggle_hidden_people_action = self.main_header.toggle_hidden_people_action
@@ -326,6 +327,9 @@ class Ui_MainWindow(object):
         )
         self.bind_library_action.setText(
             QCoreApplication.translate("MainWindow", "Set Basic Library…", None)
+        )
+        self.download_map_extension_action.setText(
+            QCoreApplication.translate("MainWindow", "Download Map Extension…", None)
         )
         self.toggle_filmstrip_action.setText(
             QCoreApplication.translate("MainWindow", "Show Filmstrip", None)

--- a/src/iPhoto/gui/ui/widgets/info_panel.py
+++ b/src/iPhoto/gui/ui/widgets/info_panel.py
@@ -362,6 +362,7 @@ class InfoPanel(QWidget):
     locationQueryChanged = Signal(str)
     locationSuggestionActivated = Signal(object)
     locationConfirmRequested = Signal(str, object)
+    downloadMapExtensionRequested = Signal()
     _DRAG_EVENT_TYPES = frozenset(
         (
             QEvent.Type.MouseButtonPress,
@@ -513,6 +514,14 @@ class InfoPanel(QWidget):
         self._location_fallback_label.hide()
         self._location_layout.addWidget(self._location_fallback_label)
 
+        self._location_download_button = QPushButton("Download Map Extension", self._location_container)
+        self._location_download_button.setAutoDefault(False)
+        self._location_download_button.setDefault(False)
+        self._location_download_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._location_download_button.clicked.connect(self.downloadMapExtensionRequested.emit)
+        self._location_download_button.hide()
+        self._location_layout.addWidget(self._location_download_button, 0, Qt.AlignmentFlag.AlignLeft)
+
         self._location_editor_row = QWidget(self._location_container)
         self._location_editor_layout = QHBoxLayout(self._location_editor_row)
         self._location_editor_layout.setContentsMargins(0, 0, 0, 0)
@@ -622,6 +631,7 @@ class InfoPanel(QWidget):
         self._location_map.clear_location()
         self._location_map.hide()
         self._location_fallback_label.hide()
+        self._location_download_button.hide()
         self._location_editor_row.setVisible(self._location_capability_enabled)
         self._location_editor.clear()
         self._location_editor.setPlaceholderText("Assign a Location")
@@ -782,9 +792,11 @@ class InfoPanel(QWidget):
             self._location_map.hide()
             self._location_fallback_label.setText(self._location_fallback_text)
             self._location_fallback_label.show()
+            self._location_download_button.show()
             return
 
         self._location_fallback_label.hide()
+        self._location_download_button.hide()
         self._location_editor_row.show()
         gps = metadata.get("gps")
         location_text = metadata.get("location") or metadata.get("place")

--- a/src/iPhoto/gui/ui/widgets/main_header.py
+++ b/src/iPhoto/gui/ui/widgets/main_header.py
@@ -90,6 +90,7 @@ class MainHeaderWidget(QWidget):
         self.rescan_action = QAction("Rescan", main_window)
         self.rebuild_links_action = QAction("Rebuild Live Links", main_window)
         self.bind_library_action = QAction("Set Basic Library…", main_window)
+        self.download_map_extension_action = QAction("Download Map Extension…", main_window)
         self.toggle_filmstrip_action = QAction(
             "Show Filmstrip", main_window, checkable=True
         )
@@ -178,6 +179,7 @@ class MainHeaderWidget(QWidget):
 
         settings_menu = self.menu_bar.addMenu("&Settings")
         settings_menu.addAction(self.bind_library_action)
+        settings_menu.addAction(self.download_map_extension_action)
         settings_menu.addSeparator()
 
         appearance_menu = settings_menu.addMenu("Appearance")

--- a/src/iPhoto/settings/schema.py
+++ b/src/iPhoto/settings/schema.py
@@ -64,6 +64,7 @@ SETTINGS_SCHEMA: dict[str, Any] = {
                 "show_filmstrip": {"type": "boolean"},
                 "show_face_names_in_detail": {"type": "boolean"},
                 "show_hidden_people": {"type": "boolean"},
+                "show_map_extension_startup_prompt": {"type": "boolean"},
                 "wheel_action": {
                     "type": "string",
                     "enum": ["navigate", "zoom"],
@@ -94,6 +95,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
         "show_filmstrip": True,
         "show_face_names_in_detail": False,
         "show_hidden_people": False,
+        "show_map_extension_startup_prompt": True,
         "wheel_action": "navigate",
     },
     "last_open_albums": [],

--- a/src/maps/map_sources.py
+++ b/src/maps/map_sources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import shlex
 import sys
 from dataclasses import dataclass
@@ -15,6 +16,15 @@ DEFAULT_OSMAND_STYLE_FILENAME = "snowmobile.render.xml"
 DEFAULT_OSMAND_RESOURCES_ROOT = DEFAULT_OSMAND_EXTENSION_RELATIVE_ROOT
 DEFAULT_OSMAND_STYLE_PATH = DEFAULT_OSMAND_RESOURCES_ROOT / "rendering_styles" / DEFAULT_OSMAND_STYLE_FILENAME
 DEFAULT_OSMAND_SEARCH_RELATIVE_PATH = DEFAULT_OSMAND_EXTENSION_RELATIVE_ROOT / "search" / "geonames.sqlite3"
+DEFAULT_OSMAND_PENDING_EXTENSION_SUFFIX = ".pending"
+LINUX_MAP_EXTENSION_DOWNLOAD_URL = (
+    "https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/"
+    "releases/download/v5.0.0/extension.tar.xz"
+)
+WINDOWS_MAP_EXTENSION_DOWNLOAD_URL = (
+    "https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/"
+    "releases/download/v5.0.0/extension.zip"
+)
 ENV_OSMAND_HELPER = "IPHOTO_OSMAND_RENDER_HELPER"
 ENV_OSMAND_NATIVE_WIDGET_LIBRARY = "IPHOTO_OSMAND_NATIVE_WIDGET_LIBRARY"
 ENV_PREFER_OSMAND_NATIVE_WIDGET = "IPHOTO_PREFER_OSMAND_NATIVE_WIDGET"
@@ -196,11 +206,102 @@ def default_osmand_search_database(package_root: Path | None = None) -> Path:
     return (Path(root) / DEFAULT_OSMAND_SEARCH_RELATIVE_PATH).resolve()
 
 
+def default_osmand_tiles_root(package_root: Path | None = None) -> Path:
+    """Return the tiles root that hosts both legacy and extension map assets."""
+
+    root = package_root or _package_root()
+    return (Path(root) / "tiles").resolve()
+
+
 def has_usable_osmand_search_extension(package_root: Path | None = None) -> bool:
     """Return ``True`` when both the map assets and search DB are bundled."""
 
     root = package_root or _package_root()
     return _has_osmand_data_assets(root) and default_osmand_search_database(root).is_file()
+
+
+def default_pending_osmand_extension_root(package_root: Path | None = None) -> Path:
+    """Return the staging directory consumed on the next application launch."""
+
+    extension_root = default_osmand_extension_root(package_root)
+    return extension_root.with_name(extension_root.name + DEFAULT_OSMAND_PENDING_EXTENSION_SUFFIX)
+
+
+def default_osmand_download_url(platform: str | None = None) -> str | None:
+    """Return the published extension archive URL for *platform*."""
+
+    resolved_platform = sys.platform if platform is None else platform
+    if resolved_platform == "win32":
+        return WINDOWS_MAP_EXTENSION_DOWNLOAD_URL
+    if resolved_platform.startswith("linux"):
+        return LINUX_MAP_EXTENSION_DOWNLOAD_URL
+    return None
+
+
+def supports_map_extension_download(platform: str | None = None) -> bool:
+    """Return whether the current platform offers a published extension archive."""
+
+    return default_osmand_download_url(platform) is not None
+
+
+def has_pending_osmand_extension_install(package_root: Path | None = None) -> bool:
+    """Return ``True`` when a staged extension is waiting for restart."""
+
+    pending_root = default_pending_osmand_extension_root(package_root)
+    return pending_root.is_dir()
+
+
+def has_installed_osmand_extension(package_root: Path | None = None) -> bool:
+    """Return ``True`` when the packaged extension layout is complete."""
+
+    root = package_root or _package_root()
+    extension_root = default_osmand_extension_root(root)
+    if not (
+        _has_osmand_data_assets(root)
+        and default_osmand_search_database(root).is_file()
+        and extension_root.is_dir()
+    ):
+        return False
+
+    if not any(candidate.is_file() for candidate in _default_helper_candidates(root)):
+        return False
+
+    return True
+
+
+def apply_pending_osmand_extension_install(package_root: Path | None = None) -> bool:
+    """Promote a staged extension into place.
+
+    Returns ``True`` when a pending install existed and was promoted.
+    """
+
+    root = package_root or _package_root()
+    pending_root = default_pending_osmand_extension_root(root)
+    if not pending_root.exists():
+        return False
+
+    extension_root = default_osmand_extension_root(root)
+    backup_root = extension_root.with_name(extension_root.name + ".backup")
+
+    if backup_root.exists():
+        if backup_root.is_dir():
+            shutil.rmtree(backup_root)
+        else:
+            backup_root.unlink()
+
+    if extension_root.exists():
+        extension_root.replace(backup_root)
+
+    try:
+        pending_root.replace(extension_root)
+    except Exception:
+        if backup_root.exists() and not extension_root.exists():
+            backup_root.replace(extension_root)
+        raise
+    else:
+        if backup_root.exists():
+            shutil.rmtree(backup_root)
+    return True
 
 
 def _has_osmand_data_assets(package_root: Path) -> bool:
@@ -267,6 +368,7 @@ def _collect_candidate_paths(
 __all__ = [
     "DEFAULT_HELPER_RELATIVE_PATH",
     "DEFAULT_HELPER_RELATIVE_PATHS",
+    "DEFAULT_OSMAND_PENDING_EXTENSION_SUFFIX",
     "DEFAULT_OSMAND_SEARCH_RELATIVE_PATH",
     "DEFAULT_OSMAND_EXTENSION_RELATIVE_ROOT",
     "DEFAULT_NATIVE_WIDGET_RELATIVE_PATH_MSVC",
@@ -274,17 +376,26 @@ __all__ = [
     "DEFAULT_NATIVE_WIDGET_RELATIVE_PATHS",
     "DEFAULT_OSMAND_RESOURCES_ROOT",
     "DEFAULT_OSMAND_STYLE_PATH",
+    "LINUX_MAP_EXTENSION_DOWNLOAD_URL",
+    "WINDOWS_MAP_EXTENSION_DOWNLOAD_URL",
     "ENV_OSMAND_HELPER",
     "ENV_OSMAND_NATIVE_WIDGET_LIBRARY",
     "ENV_PREFER_OSMAND_NATIVE_WIDGET",
     "MapBackendMetadata",
     "MapSourceSpec",
+    "apply_pending_osmand_extension_install",
     "default_osmand_extension_root",
+    "default_osmand_tiles_root",
+    "default_osmand_download_url",
+    "default_pending_osmand_extension_root",
     "default_osmand_search_database",
+    "has_installed_osmand_extension",
+    "has_pending_osmand_extension_install",
     "has_usable_osmand_default",
     "has_usable_osmand_native_widget",
     "has_usable_osmand_search_extension",
     "prefer_osmand_native_widget",
     "resolve_osmand_helper_command",
     "resolve_osmand_native_widget_library",
+    "supports_map_extension_download",
 ]

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from iPhoto.gui.main import _configure_qt_opengl_defaults, _prepare_qt_runtime_for_maps
 
@@ -119,3 +120,95 @@ def test_prepare_qt_runtime_for_maps_allows_packaged_linux_wayland_opt_out(monke
     assert "QT_QPA_PLATFORM" not in os.environ
     assert "QT_OPENGL" not in os.environ
     assert "QT_XCB_GL_INTEGRATION" not in os.environ
+
+
+def test_main_applies_pending_map_extension_before_qt_setup(monkeypatch) -> None:
+    call_order: list[tuple[str, object]] = []
+    fake_color_role = type("ColorRole", (), {"Window": object(), "WindowText": object(), "ToolTipBase": object(), "ToolTipText": object()})
+
+    class _FakeColor:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        def isValid(self) -> bool:
+            return True
+
+        def setAlpha(self, _value: int) -> None:
+            return None
+
+        def lightness(self) -> int:
+            return 255
+
+    class _FakePalette:
+        ColorRole = fake_color_role
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        def color(self, _role):
+            return _FakeColor()
+
+        def setColor(self, *_args, **_kwargs) -> None:
+            return None
+
+    class _FakeApp:
+        def __init__(self, _args) -> None:
+            return None
+
+        def palette(self):
+            return _FakePalette()
+
+        def setPalette(self, *_args, **_kwargs) -> None:
+            return None
+
+        def exec(self) -> int:
+            return 0
+
+    monkeypatch.setattr(
+        "maps.map_sources.apply_pending_osmand_extension_install",
+        lambda root: call_order.append(("apply_pending", Path(root))),
+    )
+    monkeypatch.setattr("iPhoto.gui.main._prefer_local_source_tree", lambda: call_order.append(("prefer", None)))
+    monkeypatch.setattr("iPhoto.gui.main._prepare_qt_runtime_for_maps", lambda: call_order.append(("prepare_maps", None)))
+    monkeypatch.setattr("iPhoto.gui.main._configure_qt_opengl_defaults", lambda: call_order.append(("configure_gl", None)))
+    monkeypatch.setattr("iPhoto.gui.main.QApplication", _FakeApp)
+    monkeypatch.setattr("iPhoto.gui.main.QPalette", _FakePalette)
+    monkeypatch.setattr("iPhoto.gui.main.QColor", _FakeColor)
+    monkeypatch.setattr("iPhoto.gui.main.Qt", type("FakeQt", (), {"GlobalColor": type("GlobalColor", (), {"black": 0})(), "ApplicationAttribute": type("ApplicationAttribute", (), {})()}))
+    monkeypatch.setattr("iPhoto.gui.main.QTimer.singleShot", lambda _delay, _callback: None)
+
+    class _FakeRuntimeContext:
+        @staticmethod
+        def create(*, defer_startup: bool = False):
+            call_order.append(("create_context", defer_startup))
+            return type("FakeContext", (), {"resume_startup_tasks": lambda self: None})()
+
+    class _FakeWindow:
+        def __init__(self, _context):
+            self.ui = type("FakeUi", (), {"sidebar": type("FakeSidebar", (), {"select_all_photos": lambda *a, **k: None})()})()
+
+        def show(self) -> None:
+            call_order.append(("show", None))
+
+        def set_coordinator(self, _coordinator) -> None:
+            return None
+
+    class _FakeCoordinator:
+        def __init__(self, _window, _context):
+            return None
+
+        def start(self) -> None:
+            return None
+
+    monkeypatch.setattr("iPhoto.utils.logging.get_logger", lambda: None)
+    monkeypatch.setitem(__import__("sys").modules, "iPhoto.bootstrap.runtime_context", type("Mod", (), {"RuntimeContext": _FakeRuntimeContext})())
+    monkeypatch.setitem(__import__("sys").modules, "iPhoto.gui.coordinators.main_coordinator", type("Mod", (), {"MainCoordinator": _FakeCoordinator})())
+    monkeypatch.setitem(__import__("sys").modules, "iPhoto.gui.ui.main_window", type("Mod", (), {"MainWindow": _FakeWindow})())
+
+    from iPhoto.gui.main import main
+
+    main([])
+
+    assert call_order[0][0] == "prefer"
+    assert call_order[1][0] == "apply_pending"
+    assert call_order[2][0] == "prepare_maps"

--- a/tests/test_info_panel.py
+++ b/tests/test_info_panel.py
@@ -908,6 +908,38 @@ def test_info_panel_location_map_stays_square(
     panel.close()
 
 
+def test_info_panel_shows_download_button_when_location_extension_is_unavailable(
+    qapp: QApplication,
+) -> None:
+    del qapp
+    panel = InfoPanel()
+    panel.set_location_capability(
+        enabled=False,
+        fallback_text="Install the map extension to use Assign a Location.",
+    )
+    panel.set_asset_metadata({"rel": "img.jpg", "name": "img.jpg"})
+
+    assert not panel._location_fallback_label.isHidden()
+    assert not panel._location_download_button.isHidden()
+    assert panel._location_editor_row.isHidden()
+    panel.close()
+
+
+def test_info_panel_emits_download_request_from_fallback_button(qapp: QApplication) -> None:
+    panel = InfoPanel()
+    panel.set_location_capability(enabled=False)
+    panel.set_asset_metadata({"rel": "img.jpg", "name": "img.jpg"})
+    panel.show()
+    qapp.processEvents()
+
+    calls: list[str] = []
+    panel.downloadMapExtensionRequested.connect(lambda: calls.append("clicked"))
+    panel._location_download_button.click()
+
+    assert calls == ["clicked"]
+    panel.close()
+
+
 def test_info_panel_location_map_overlay_tracks_actual_embedded_map_size(
     qapp: QApplication,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_map_sources.py
+++ b/tests/test_map_sources.py
@@ -5,8 +5,12 @@ from maps.map_sources import (
     DEFAULT_HELPER_RELATIVE_PATHS,
     DEFAULT_NATIVE_WIDGET_RELATIVE_PATHS,
     MapSourceSpec,
+    apply_pending_osmand_extension_install,
     default_osmand_extension_root,
+    default_osmand_download_url,
+    default_pending_osmand_extension_root,
     has_usable_osmand_default,
+    has_installed_osmand_extension,
     resolve_osmand_native_widget_library,
     resolve_osmand_helper_command,
 )
@@ -15,13 +19,19 @@ from maps.map_sources import (
 def _create_extension_assets(package_root: Path) -> Path:
     extension_root = default_osmand_extension_root(package_root)
     (extension_root / "rendering_styles").mkdir(parents=True, exist_ok=True)
+    (extension_root / "search").mkdir(parents=True, exist_ok=True)
     (extension_root / "poi").mkdir(parents=True, exist_ok=True)
     (extension_root / "routing").mkdir(parents=True, exist_ok=True)
     (extension_root / "misc" / "icu4c").mkdir(parents=True, exist_ok=True)
+    (extension_root / "bin").mkdir(parents=True, exist_ok=True)
     (extension_root / "World_basemap_2.obf").write_bytes(b"obf")
     (extension_root / "rendering_styles" / "snowmobile.render.xml").write_text(
         "<renderingStyle />",
         encoding="utf-8",
+    )
+    (extension_root / "search" / "geonames.sqlite3").write_bytes(b"sqlite")
+    (extension_root / DEFAULT_HELPER_RELATIVE_PATHS[0].relative_to(Path("tiles") / "extension")).write_bytes(
+        b"helper"
     )
     return extension_root
 
@@ -102,12 +112,62 @@ def test_has_usable_osmand_default_requires_helper(tmp_path, monkeypatch) -> Non
     tiles_dir = package_root / "tiles"
     tiles_dir.mkdir(parents=True)
     extension_root = _create_extension_assets(package_root)
+    helper_path = extension_root / DEFAULT_HELPER_RELATIVE_PATHS[0].relative_to(Path("tiles") / "extension")
+    helper_path.unlink()
     monkeypatch.delenv(map_sources.ENV_OSMAND_HELPER, raising=False)
 
     assert has_usable_osmand_default(package_root) is False
 
     helper_path = package_root / DEFAULT_HELPER_RELATIVE_PATHS[0]
-    helper_path.parent.mkdir(parents=True)
+    helper_path.parent.mkdir(parents=True, exist_ok=True)
     helper_path.write_bytes(b"exe")
 
     assert has_usable_osmand_default(package_root) is True
+
+
+def test_default_osmand_download_url_matches_platform_variants() -> None:
+    assert default_osmand_download_url("linux") == (
+        "https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/"
+        "releases/download/v5.0.0/extension.tar.xz"
+    )
+    assert default_osmand_download_url("win32") == (
+        "https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/"
+        "releases/download/v5.0.0/extension.zip"
+    )
+    assert default_osmand_download_url("darwin") is None
+
+
+def test_has_installed_osmand_extension_requires_search_database_and_helper(tmp_path) -> None:
+    package_root = tmp_path / "maps"
+    _create_extension_assets(package_root)
+
+    assert has_installed_osmand_extension(package_root) is True
+
+    search_db = default_osmand_extension_root(package_root) / "search" / "geonames.sqlite3"
+    search_db.unlink()
+    assert has_installed_osmand_extension(package_root) is False
+
+
+def test_apply_pending_osmand_extension_install_promotes_staged_directory(tmp_path) -> None:
+    package_root = tmp_path / "maps"
+    extension_root = _create_extension_assets(package_root)
+    (extension_root / "marker.txt").write_text("old", encoding="utf-8")
+
+    pending_root = default_pending_osmand_extension_root(package_root)
+    pending_root.mkdir(parents=True, exist_ok=True)
+    (pending_root / "World_basemap_2.obf").write_bytes(b"new-obf")
+    (pending_root / "rendering_styles").mkdir()
+    (pending_root / "rendering_styles" / "snowmobile.render.xml").write_text(
+        "<renderingStyle />",
+        encoding="utf-8",
+    )
+    (pending_root / "search").mkdir()
+    (pending_root / "search" / "geonames.sqlite3").write_bytes(b"sqlite")
+    (pending_root / "bin").mkdir()
+    helper_name = DEFAULT_HELPER_RELATIVE_PATHS[0].name
+    (pending_root / "bin" / helper_name).write_bytes(b"helper")
+    (pending_root / "marker.txt").write_text("new", encoding="utf-8")
+
+    assert apply_pending_osmand_extension_install(package_root) is True
+    assert pending_root.exists() is False
+    assert (default_osmand_extension_root(package_root) / "marker.txt").read_text(encoding="utf-8") == "new"

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -49,6 +49,7 @@ def test_settings_manager_nested_updates_preserve_defaults(tmp_path: Path) -> No
     manager.set("ui.sidebar_width", 320)
     assert manager.get("ui.sidebar_width") == 320
     assert manager.get("ui.theme") == "system"
+    assert manager.get("ui.show_map_extension_startup_prompt") is True
 
 
 def test_pinned_items_roundtrip_is_scoped_by_library(tmp_path: Path, qapp: QApplication) -> None:


### PR DESCRIPTION
This pull request adds support for downloading and activating an offline map extension directly from the iPhoto application's UI. It introduces a new controller and background worker to manage the download process, integrates map extension actions into the main window and info panel, and ensures the extension can be installed and activated with user prompts and progress feedback.

**Map Extension Download Feature Integration:**

* Added `MapExtensionDownloadController` to coordinate map extension download prompts, progress dialogs, and application restarts. This includes a modal progress dialog and logic for handling user prompts on startup, from the settings menu, and from the info panel. (`src/iPhoto/gui/ui/controllers/map_extension_download_controller.py`)
* Introduced `MapExtensionDownloadWorker` and related dataclasses/signals to handle the background download, extraction, validation, and staging of the map extension archive. (`src/iPhoto/gui/ui/tasks/map_extension_download_worker.py`)

**UI and Coordinator Wiring:**

* Integrated the map extension download action into the main coordinator, connecting it to the settings menu and info panel, and ensuring the user is prompted on startup if appropriate. (`src/iPhoto/gui/coordinators/main_coordinator.py`) [[1]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR36-R38) [[2]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR53) [[3]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR79-R85) [[4]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR211-R213) [[5]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR338) [[6]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR453-R455)
* Updated the main window UI to include a "Download Map Extension…" action and ensured it is properly labeled and accessible. (`src/iPhoto/gui/ui/ui_main_window.py`) [[1]](diffhunk://#diff-faf6bcc2ade5504d2ad01246f0373d7d587b2f8d74d626ff7844b2450dc83884R125) [[2]](diffhunk://#diff-faf6bcc2ade5504d2ad01246f0373d7d587b2f8d74d626ff7844b2450dc83884R331-R333)
* Enhanced the info panel widget to include a "Download Map Extension" button and corresponding signal, allowing users to trigger the download from the info panel when needed. (`src/iPhoto/gui/ui/widgets/info_panel.py`) [[1]](diffhunk://#diff-6cfc52bc54151cf982f111e74c5af38311f417534d6ebaa1b57888853babf178R365) [[2]](diffhunk://#diff-6cfc52bc54151cf982f111e74c5af38311f417534d6ebaa1b57888853babf178R517-R524)

**Startup Handling:**

* Modified application startup to apply any pending map extension installations before the main window is shown, ensuring the extension is activated after download and restart. (`src/iPhoto/gui/main.py`)