### PR TITLE
Fix scan and watcher issues for album reconciliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,7 @@ __marimo__/
 /.codex
 /PySide6-OsmAnd-SDK/
 /src/maps/tiles/World_basemap_2.obf
+/src/maps/tiles/*.tar*
 /src/maps/tiles/extension/
 /src/extension/models/
 /demo/face-cluster/runtime/

--- a/docs/refactor/04-implementation-checklist.md
+++ b/docs/refactor/04-implementation-checklist.md
@@ -132,7 +132,8 @@
 - [x] CLI scan 改为调用同一 use case。
 - [x] `app.open_album()`、import 增量扫描、restore rescan 进入 session scan surface。
 - [x] Watcher/live-row 刷新读取改为调用 session query surface。
-- [ ] 删除普通 scan 中的隐式 delete/prune 决策。
+- [x] Watcher-triggered refresh 改为通过 session scan surface 触发扫描。
+- [x] 删除普通 scan 中的隐式 delete/prune 决策。
 
 完成条件：
 
@@ -140,6 +141,7 @@
 - [x] GUI、CLI、watcher 扫描结果一致。
 - [x] scan cancellation 不留下半写坏状态。
 - [x] scan progress 可被 GUI 和 CLI 消费。
+- [x] stale-row prune 通过 lifecycle reconciliation 显式执行。
 
 回归测试：
 
@@ -148,6 +150,7 @@
 - [x] 删除文件不隐式清空用户状态。
 - [x] 扫描后 People 候选状态正确。
 - [x] 扫描后 Live Photo pairing 可恢复。
+- [x] `LibraryScanService.finalize_scan()` 不再隐式删除 stale rows。
 
 ## Phase 4 - GUI Presentation Adapter
 

--- a/docs/refactor/05-current-progress.md
+++ b/docs/refactor/05-current-progress.md
@@ -153,6 +153,29 @@ migration steps.
 - Added `docs/refactor/11-session-cleanup-live-read-migration.md` as the
   process handoff for this pass.
 
+## Completed In Watcher Scan / Prune Migration
+
+- Split scan finalization from stale-row deletion: `LibraryScanService` now
+  performs additive scan fact merge and Live Photo link materialization only.
+- Added `LibraryAssetLifecycleService.reconcile_missing_scan_rows()` as the
+  explicit lifecycle command for scoped stale-row pruning after a completed
+  scan.
+- Routed GUI synchronous/asynchronous rescans, restore rescans, import fallback
+  rescans, CLI `scan`, legacy `app.rescan()`, and `LibraryManager` scan finish
+  through explicit lifecycle reconciliation.
+- Refactored filesystem watcher debounce handling so external directory changes
+  refresh the tree and trigger scans through the active session scan surface
+  instead of remaining a tree-only refresh path.
+- Removed concrete repository access from `index_sync_service.py`; it now
+  receives repository ports from session/lifecycle adapters.
+- Extended architecture checks so future concrete index-store imports in
+  `index_sync_service.py` fail.
+- Added tests for non-pruning scan finalization, lifecycle reconciliation,
+  watcher-triggered session scans, and caller propagation of lifecycle
+  reconciliation.
+- Added `docs/refactor/12-watcher-scan-prune-migration.md` as the process
+  handoff for this pass.
+
 ## Current Phase Status
 
 - Phase 0 is partially complete: vNext docs are in place and architecture
@@ -171,9 +194,11 @@ migration steps.
   `AppFacade.open_album()`, import incremental scans, and restore rescans now
   enter through `LibrarySession` / `LibraryScanService` and
   `ScanLibraryUseCase`; move/delete/restore index updates and Recently Deleted
-  cleanup now enter through `LibraryAssetLifecycleService`, and live scan
-  fallback reads use the session query service. Remaining watcher-triggered
-  incremental scan/refresh orchestration still needs migration.
+  cleanup now enter through `LibraryAssetLifecycleService`, live scan fallback
+  reads use the session query service, watcher-triggered refreshes enter the
+  session scan surface, and stale-row pruning is an explicit lifecycle
+  reconciliation step. Remaining legacy scan-like application services still
+  need review before Phase 3 can be marked fully complete.
 - Phase 4 is partially complete: GUI favorite writes, asset grid reads, export
   reads, dashboard metadata, Location map aggregation, and key People dashboard/
   navigation/manual-face flows now use session surfaces, but `gui.facade.py` and
@@ -199,8 +224,8 @@ migration steps.
 - People still uses `global_index.db` as its asset-row source of truth through
   the bootstrap/session adapter. `src/iPhoto/people/**` and the face-scan worker
   should not import `get_global_repository()` directly.
-- Watcher refresh paths and non-GUI compatibility paths still access the
-  global repository directly or through compatibility adapters.
+- Non-GUI compatibility paths still access the global repository through
+  compatibility adapters.
 - User state still physically lives in `global_index.db`; the new state port is
   an API boundary, not a separate `library_state.db` migration.
 - `global_index.db` compatibility schemas may not have a `metadata` column; the
@@ -258,6 +283,16 @@ Additional People session migration verification:
 Results: all passed with the same existing pytest config and legacy shim
 warnings.
 
+Additional watcher scan / prune migration verification:
+
+- `.venv/bin/python -m pytest tests/application/test_library_scan_service.py tests/application/test_library_asset_lifecycle_service.py tests/test_index_sync_service.py tests/test_app_live_sync.py -q`
+- `.venv/bin/python -m pytest tests/test_app_open_album_lazy.py tests/library/test_rescan_worker_session.py tests/ui/tasks/test_import_worker.py tests/services/test_library_update_service_global_db.py tests/application/test_cli_session_scan.py -q`
+- `.venv/bin/python -m pytest tests/test_library_bind_double_scan.py tests/test_library_manager.py -q`
+- `.venv/bin/python tools/check_architecture.py`
+
+Results: all passed in this environment with the same existing pytest config
+and legacy shim warnings.
+
 Additional session cleanup / live read migration verification:
 
 - `.venv/bin/python tools/check_architecture.py`
@@ -277,9 +312,9 @@ a broad non-GUI/UI run (`1237 passed, 7 skipped`), excluding
 
 ## Next Handoff Steps
 
-1. Move the remaining watcher-triggered incremental scan/refresh orchestration
-   behind session/application commands.
-2. Decide the final source of truth between `cache/index_store.AssetRepository`
+1. Decide the final source of truth between `cache/index_store.AssetRepository`
    and `SQLiteAssetRepository`, then collapse callers to `AssetRepositoryPort`.
+2. Continue reducing `gui.facade.py`, `library.manager.py`, and GUI services to
+   presentation/compatibility surfaces only.
 3. Expand end-to-end temp-library tests for import/move/delete/restore and
    user-state preservation across rescans.

--- a/docs/refactor/12-watcher-scan-prune-migration.md
+++ b/docs/refactor/12-watcher-scan-prune-migration.md
@@ -1,0 +1,73 @@
+# 12 - Watcher Scan / Prune Migration Notes
+
+> Date: 2026-04-30
+
+## Goal
+
+This pass continued the handoff from
+`11-session-cleanup-live-read-migration.md`: watcher-triggered refresh now
+enters the session scan surface, and stale-row pruning is no longer hidden
+inside ordinary scan finalization.
+
+Repository consolidation remains intentionally out of scope. The concrete
+global index store is still owned by bootstrap/session adapters while Phase 2
+decides the final repository source of truth.
+
+## What Changed
+
+- Split scan finalization from stale-row deletion.
+  - `LibraryScanService.finalize_scan()` now performs additive scan-fact merge
+    and Live Photo link materialization only.
+  - `index_sync_service.py` no longer imports `get_global_repository()`; callers
+    pass the active repository port into sync helpers.
+- Added explicit lifecycle reconciliation.
+  - `LibraryAssetLifecycleService.reconcile_missing_scan_rows()` owns scoped
+    stale-row pruning after a completed scan.
+  - GUI sync/async rescans, restore rescans, import fallback rescans, CLI
+    `scan`, legacy `app.rescan()`, and `LibraryManager` scan completion now
+    call lifecycle reconciliation explicitly after scan finalization.
+- Moved watcher-triggered refresh into the session scan path.
+  - `FileSystemWatcherMixin` records changed directories, refreshes the album
+    tree on debounce, and then calls the active session scan service for
+    filters before starting the scan.
+  - Suspended watcher notifications still do not queue scans.
+- Extended architecture guardrails.
+  - `tools/check_layer_boundaries.py` now fails if `index_sync_service.py`
+    imports the concrete index-store module again.
+
+## Behavioral Notes
+
+- Scan merge remains additive and state-preserving. Deleting rows because files
+  disappeared is now a lifecycle decision, not a side effect of
+  `finalize_scan()`.
+- Watcher changes that touch multiple sibling directories are collapsed to a
+  root-level scan because `LibraryManager` still owns a single active scanner.
+- Import incremental chunks still use `scan_specific_files()` and only use full
+  scan reconciliation when the import worker falls back to a full rescan.
+- Compatibility callers without an active session still construct fallback scan
+  and lifecycle services from the available root.
+
+## Verification
+
+Run with the project `.venv`:
+
+- `.venv/bin/python -m pytest tests/application/test_library_scan_service.py tests/application/test_library_asset_lifecycle_service.py tests/test_index_sync_service.py tests/test_app_live_sync.py -q`
+- `.venv/bin/python -m pytest tests/test_app_open_album_lazy.py tests/library/test_rescan_worker_session.py tests/ui/tasks/test_import_worker.py tests/services/test_library_update_service_global_db.py tests/application/test_cli_session_scan.py -q`
+- `.venv/bin/python -m pytest tests/test_library_bind_double_scan.py tests/test_library_manager.py -q`
+- `.venv/bin/python tools/check_architecture.py`
+
+Observed warnings are expected to match the existing `Unknown config option:
+env` pytest warning and legacy shim deprecation warnings where those tests touch
+compatibility code.
+
+Results: all passed in this environment.
+
+## Next Handoff
+
+1. Resume Phase 2 repository consolidation: decide the final source of truth
+   between `cache/index_store.AssetRepository` and `SQLiteAssetRepository`, then
+   collapse callers to `AssetRepositoryPort`.
+2. Continue reducing `gui.facade.py`, `library.manager.py`, and GUI services to
+   presentation/compatibility surfaces only.
+3. Add broader temp-library end-to-end tests for import/move/delete/restore,
+   People state preservation, and user-state preservation across rescans.

--- a/src/iPhoto/app.py
+++ b/src/iPhoto/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
+from .bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from .bootstrap.library_scan_service import LibraryScanService
 from .cache.index_store import get_global_repository
 from .index_sync_service import sync_live_roles_to_db as _sync_live_roles_to_db_impl
@@ -22,7 +23,13 @@ def _sync_live_roles_to_db(
 ) -> None:
     """Backward-compatible wrapper around the index sync helper."""
 
-    _sync_live_roles_to_db_impl(root, groups, library_root=library_root)
+    repository_root = library_root if library_root is not None else root
+    _sync_live_roles_to_db_impl(
+        root,
+        groups,
+        library_root=library_root,
+        repository=get_global_repository(repository_root),
+    )
 
 
 def _scan_service(root: Path, library_root: Path | None = None) -> LibraryScanService:
@@ -30,6 +37,20 @@ def _scan_service(root: Path, library_root: Path | None = None) -> LibraryScanSe
 
     return LibraryScanService(
         library_root if library_root is not None else root,
+        repository_factory=get_global_repository,
+    )
+
+
+def _lifecycle_service(
+    root: Path,
+    library_root: Path | None = None,
+    scan_service: LibraryScanService | None = None,
+) -> LibraryAssetLifecycleService:
+    """Return the session-style lifecycle service used by legacy wrappers."""
+
+    return LibraryAssetLifecycleService(
+        library_root if library_root is not None else root,
+        scan_service=scan_service,
         repository_factory=get_global_repository,
     )
 
@@ -84,6 +105,10 @@ def rescan(
     )
     rows = result.rows
     service.finalize_scan(root, rows)
+    _lifecycle_service(root, library_root, service).reconcile_missing_scan_rows(
+        root,
+        rows,
+    )
     if library_root is None:
         service.sync_manifest_favorites(root)
     return rows

--- a/src/iPhoto/application/ports/repositories.py
+++ b/src/iPhoto/application/ports/repositories.py
@@ -74,6 +74,19 @@ class AssetRepositoryPort(Protocol):
     ) -> list[dict[str, Any]]:
         """Return one paginated asset page."""
 
+    def apply_live_role_updates(
+        self,
+        updates: Iterable[tuple[str, int, str | None]],
+    ) -> None:
+        """Replace Live Photo role state using library-relative updates."""
+
+    def apply_live_role_updates_for_prefix(
+        self,
+        prefix: str,
+        updates: Iterable[tuple[str, int, str | None]],
+    ) -> None:
+        """Replace Live Photo role state only inside a library-relative prefix."""
+
 
 class LibraryStateRepositoryPort(Protocol):
     """Persist durable user choices for one library."""

--- a/src/iPhoto/bootstrap/library_asset_lifecycle_service.py
+++ b/src/iPhoto/bootstrap/library_asset_lifecycle_service.py
@@ -15,6 +15,7 @@ from ..cache.index_store import get_global_repository
 from ..cache.lock import FileLock
 from ..config import ALBUM_MANIFEST_NAMES, RECENTLY_DELETED_DIR_NAME
 from ..errors import IPhotoError
+from ..index_sync_service import prune_index_scope
 from ..io.scanner_adapter import process_media_paths
 from ..media_classifier import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 from ..schemas import validate_album
@@ -216,6 +217,23 @@ class LibraryAssetLifecycleService:
         except (IPhotoError, sqlite3.Error, OSError) as exc:
             LOGGER.debug("Recently Deleted cleanup skipped: %s", exc)
             return 0
+
+    def reconcile_missing_scan_rows(
+        self,
+        root: Path,
+        materialised_rows: Iterable[dict[str, Any]],
+    ) -> int:
+        """Explicitly prune stale scan rows for a completed scan scope."""
+
+        scan_root = Path(root)
+        repository_root = self._repository_root_for_read(scan_root)
+        repository = self._repository(repository_root)
+        return prune_index_scope(
+            scan_root,
+            materialised_rows,
+            library_root=self.library_root,
+            repository=repository,
+        )
 
     def _remove_source_rows(
         self,

--- a/src/iPhoto/bootstrap/library_scan_service.py
+++ b/src/iPhoto/bootstrap/library_scan_service.py
@@ -158,6 +158,7 @@ class LibraryScanService:
             if asset_count == 0 and autoscan:
                 result = self.scan_album(scan_root, persist_chunks=False)
                 self.finalize_scan(scan_root, result.rows)
+                self.reconcile_missing_scan_rows(scan_root, result.rows)
                 rows = result.rows
                 asset_count = len(rows)
                 scanned = True
@@ -199,14 +200,16 @@ class LibraryScanService:
             include=include,
             exclude=exclude,
         )
+        repository = self._repository()
         existing_index = load_incremental_index_cache(
             scan_root,
             library_root=self.library_root,
+            repository=repository,
         )
 
         use_case = ScanLibraryUseCase(
             scanner=self._scanner,
-            asset_repository=self._repository(),
+            asset_repository=repository,
         )
         return use_case.execute(
             ScanLibraryRequest(
@@ -225,21 +228,35 @@ class LibraryScanService:
         )
 
     def finalize_scan(self, root: Path, rows: Iterable[dict[str, Any]]) -> None:
-        """Persist final scan side effects after a successful scan."""
+        """Persist additive scan side effects after a successful scan."""
 
         scan_root = Path(root)
         materialized_rows = [dict(row) for row in rows]
+        repository = self._repository()
         update_index_snapshot(
             scan_root,
             materialized_rows,
             library_root=self.library_root,
+            repository=repository,
         )
-        prune_index_scope(
+        self.ensure_links_for_rows(scan_root, materialized_rows, repository=repository)
+
+    def reconcile_missing_scan_rows(
+        self,
+        root: Path,
+        rows: Iterable[dict[str, Any]],
+    ) -> int:
+        """Prune stale rows for a completed full scan scope."""
+
+        scan_root = Path(root)
+        materialized_rows = [dict(row) for row in rows]
+        repository = self._repository()
+        return prune_index_scope(
             scan_root,
             materialized_rows,
             library_root=self.library_root,
+            repository=repository,
         )
-        self.ensure_links_for_rows(scan_root, materialized_rows)
 
     def scan_specific_files(
         self,
@@ -286,7 +303,12 @@ class LibraryScanService:
             rows = self._album_relative_rows(rows, album_path)
         else:
             rows = list(repository.read_all(filter_hidden=False))
-        return ensure_links(scan_root, rows, library_root=self.library_root)
+        return ensure_links(
+            scan_root,
+            rows,
+            library_root=self.library_root,
+            repository=repository,
+        )
 
     def report_album(self, root: Path) -> AlbumReport:
         """Return the asset and Live Photo counts for *root*."""
@@ -354,15 +376,23 @@ class LibraryScanService:
         self,
         root: Path,
         rows: Iterable[dict[str, Any]],
+        *,
+        repository: AssetRepositoryPort | None = None,
     ) -> "list[LiveGroup]":
         """Rebuild links using already materialized rows for *root*."""
 
         scan_root = Path(root)
         materialized = [dict(row) for row in rows]
+        active_repository = repository or self._repository()
         album_path = self._album_path(scan_root)
         if album_path:
             materialized = self._album_relative_rows(materialized, album_path)
-        return ensure_links(scan_root, materialized, library_root=self.library_root)
+        return ensure_links(
+            scan_root,
+            materialized,
+            library_root=self.library_root,
+            repository=active_repository,
+        )
 
     def sync_manifest_favorites(
         self,

--- a/src/iPhoto/cli.py
+++ b/src/iPhoto/cli.py
@@ -55,6 +55,13 @@ def _require_scan_service(session):
     return scan_service
 
 
+def _require_lifecycle_service(session):
+    lifecycle_service = session.asset_lifecycle
+    if lifecycle_service is None:
+        raise IPhotoError("Library asset lifecycle service is unavailable.")
+    return lifecycle_service
+
+
 @app.command()
 @_handle_errors
 def init(album_dir: Path = typer.Argument(Path.cwd(), exists=False)) -> None:
@@ -76,6 +83,10 @@ def scan(album_dir: Path = typer.Argument(Path.cwd(), exists=True)) -> None:
         scan_service = _require_scan_service(session)
         result = scan_service.scan_album(album_dir, persist_chunks=False)
         scan_service.finalize_scan(album_dir, result.rows)
+        _require_lifecycle_service(session).reconcile_missing_scan_rows(
+            album_dir,
+            result.rows,
+        )
     finally:
         session.shutdown()
     print(f"[green]Indexed {len(result.rows)} assets")

--- a/src/iPhoto/gui/services/asset_import_service.py
+++ b/src/iPhoto/gui/services/asset_import_service.py
@@ -81,11 +81,13 @@ class AssetImportService(QObject):
 
         library_root: Optional[Path] = None
         scan_service = None
+        lifecycle_service = None
         if self._library_manager_getter is not None:
             manager = self._library_manager_getter()
             if manager is not None:
                 library_root = manager.root()
                 scan_service = getattr(manager, "scan_service", None)
+                lifecycle_service = getattr(manager, "asset_lifecycle_service", None)
 
         worker = ImportWorker(
             normalized,
@@ -94,6 +96,7 @@ class AssetImportService(QObject):
             signals,
             library_root=library_root,
             scan_service=scan_service,
+            asset_lifecycle_service=lifecycle_service,
         )
         unique_task_id = f"import:{target_root}:{uuid.uuid4().hex}"
         # The BackgroundTaskManager refuses duplicate task identifiers so we append a

--- a/src/iPhoto/gui/services/library_update_service.py
+++ b/src/iPhoto/gui/services/library_update_service.py
@@ -83,20 +83,36 @@ class LibraryUpdateService(QObject):
 
         library_root = None
         scan_service = None
+        lifecycle_service = None
         lib_manager = self._library_manager_getter()
         if lib_manager:
             library_root = lib_manager.root()
             scan_service = getattr(lib_manager, "scan_service", None)
+            lifecycle_service = getattr(lib_manager, "asset_lifecycle_service", None)
 
         try:
             if scan_service is not None:
                 result = scan_service.scan_album(album.root, persist_chunks=False)
                 scan_service.finalize_scan(album.root, result.rows)
+                self._reconcile_scan_scope(
+                    album.root,
+                    result.rows,
+                    library_root=library_root,
+                    scan_service=scan_service,
+                    lifecycle_service=lifecycle_service,
+                )
                 rows = result.rows
             else:
                 fallback = LibraryScanService(library_root or album.root)
                 result = fallback.scan_album(album.root, persist_chunks=False)
                 fallback.finalize_scan(album.root, result.rows)
+                self._reconcile_scan_scope(
+                    album.root,
+                    result.rows,
+                    library_root=library_root,
+                    scan_service=fallback,
+                    lifecycle_service=lifecycle_service,
+                )
                 if library_root is None:
                     fallback.sync_manifest_favorites(album.root)
                 rows = result.rows
@@ -433,6 +449,17 @@ class LibraryUpdateService(QObject):
             # therefore we flush the global index and ``links.json`` here to
             # mirror the historical facade behaviour before notifying listeners.
             worker.scan_service.finalize_scan(root, materialised_rows)
+            lifecycle_service = None
+            library = self._library_manager()
+            if library is not None:
+                lifecycle_service = getattr(library, "asset_lifecycle_service", None)
+            self._reconcile_scan_scope(
+                root,
+                materialised_rows,
+                library_root=library_root,
+                scan_service=worker.scan_service,
+                lifecycle_service=lifecycle_service,
+            )
         except IPhotoError as exc:
             self.errorRaised.emit(str(exc))
             self.scanFinished.emit(root, False)
@@ -474,6 +501,21 @@ class LibraryUpdateService(QObject):
     def _cleanup_scan_worker(self) -> None:
         self._scanner_worker = None
         self._scan_pending = False
+
+    def _reconcile_scan_scope(
+        self,
+        root: Path,
+        rows: Iterable[dict],
+        *,
+        library_root: Path | None,
+        scan_service: LibraryScanService | None,
+        lifecycle_service: LibraryAssetLifecycleService | None,
+    ) -> int:
+        active_lifecycle = lifecycle_service or LibraryAssetLifecycleService(
+            library_root or root,
+            scan_service=scan_service,
+        )
+        return active_lifecycle.reconcile_missing_scan_rows(root, rows)
 
     def _schedule_scan_retry(self) -> None:
         QTimer.singleShot(0, self._retry_scan_if_album_available)
@@ -569,11 +611,17 @@ class LibraryUpdateService(QObject):
         signals = RescanSignals()
         library = self._library_manager()
         scan_service = getattr(library, "scan_service", None) if library is not None else None
+        lifecycle_service = (
+            getattr(library, "asset_lifecycle_service", None)
+            if library is not None
+            else None
+        )
         worker = RescanWorker(
             album_root,
             signals,
             library_root=library_root,
             scan_service=scan_service,
+            asset_lifecycle_service=lifecycle_service,
         )
         task_id = self._build_restore_rescan_task_id(album_root)
 

--- a/src/iPhoto/gui/ui/tasks/import_worker.py
+++ b/src/iPhoto/gui/ui/tasks/import_worker.py
@@ -8,6 +8,7 @@ import time
 
 from PySide6.QtCore import QObject, QRunnable, Signal
 
+from ....bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from ....bootstrap.library_scan_service import LibraryScanService
 
 # Max updates per second for progress signal
@@ -37,6 +38,7 @@ class ImportWorker(QRunnable):
         *,
         library_root: Path | None = None,
         scan_service: LibraryScanService | None = None,
+        asset_lifecycle_service: LibraryAssetLifecycleService | None = None,
     ) -> None:
         super().__init__()
         self.setAutoDelete(False)
@@ -47,6 +49,7 @@ class ImportWorker(QRunnable):
         self._is_cancelled = False
         self._library_root = library_root
         self._scan_service = scan_service
+        self._asset_lifecycle_service = asset_lifecycle_service
         self._had_incremental_error = False
 
     @property
@@ -62,6 +65,17 @@ class ImportWorker(QRunnable):
         if self._scan_service is None:
             self._scan_service = LibraryScanService(self._library_root or self._destination)
         return self._scan_service
+
+    @property
+    def asset_lifecycle_service(self) -> LibraryAssetLifecycleService:
+        """Return the lifecycle service used for explicit scan reconciliation."""
+
+        if self._asset_lifecycle_service is None:
+            self._asset_lifecycle_service = LibraryAssetLifecycleService(
+                self._library_root or self._destination,
+                scan_service=self.scan_service,
+            )
+        return self._asset_lifecycle_service
 
     def cancel(self) -> None:
         """Request cancellation of the in-flight import operation."""
@@ -150,3 +164,7 @@ class ImportWorker(QRunnable):
 
         result = self.scan_service.scan_album(self._destination, persist_chunks=False)
         self.scan_service.finalize_scan(self._destination, result.rows)
+        self.asset_lifecycle_service.reconcile_missing_scan_rows(
+            self._destination,
+            result.rows,
+        )

--- a/src/iPhoto/index_sync_service.py
+++ b/src/iPhoto/index_sync_service.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 
-from .cache.index_store import get_global_repository
 from .cache.lock import FileLock
 from .core.pairing import pair_live
 from .errors import IndexCorruptedError, ManifestInvalidError
@@ -18,9 +17,15 @@ from .utils.pathutils import ensure_work_dir
 
 LOGGER = get_logger()
 
+if TYPE_CHECKING:  # pragma: no cover
+    from .application.ports import AssetRepositoryPort
+
 
 def load_incremental_index_cache(
-    root: Path, library_root: Optional[Path] = None
+    root: Path,
+    library_root: Optional[Path] = None,
+    *,
+    repository: "AssetRepositoryPort",
 ) -> Dict[str, dict]:
     """Load the existing index into a dictionary for incremental scanning.
 
@@ -32,8 +37,6 @@ def load_incremental_index_cache(
         root: The album root directory.
         library_root: If provided, use this as the database root (global database).
     """
-    db_root = library_root if library_root else root
-    store = get_global_repository(db_root)
     existing_index = {}
     
     # If using global DB, filter by album path
@@ -41,9 +44,9 @@ def load_incremental_index_cache(
     
     try:
         if album_path:
-            rows = store.read_album_assets(album_path, include_subalbums=True)
+            rows = repository.read_album_assets(album_path, include_subalbums=True)
         else:
-            rows = store.read_all()
+            rows = repository.read_all()
         for row in rows:
             rel_key = normalise_rel_key(row.get("rel"))
             if rel_key:
@@ -57,6 +60,8 @@ def update_index_snapshot(
     root: Path,
     materialised_rows: List[dict],
     library_root: Optional[Path] = None,
+    *,
+    repository: "AssetRepositoryPort",
 ) -> None:
     """Apply *materialised_rows* to the global database using additive-only updates.
 
@@ -73,13 +78,10 @@ def update_index_snapshot(
         materialised_rows: List of rows to update/insert.
         library_root: If provided, use this as the database root (global database).
     """
-    db_root = library_root if library_root else root
-    store = get_global_repository(db_root)
-
     corrupted_during_read = False
     try:
         # Just verify we can read the database
-        list(store.read_all())
+        list(repository.read_all())
     except IndexCorruptedError:
         corrupted_during_read = True
 
@@ -94,7 +96,11 @@ def update_index_snapshot(
 
     if corrupted_during_read:
         # On corruption, write all rows to rebuild the database
-        store.write_rows(materialised_snapshot)
+        write_rows = getattr(repository, "write_rows", None)
+        if callable(write_rows):
+            write_rows(materialised_snapshot)
+        else:
+            repository.append_rows(materialised_snapshot)
         return
 
     if not fresh_rows:
@@ -103,13 +109,21 @@ def update_index_snapshot(
     # Additive-only: only append new/updated rows, never delete.
     # Scan merges preserve persisted state fields such as face_status.
     try:
-        store.merge_scan_rows(materialised_snapshot)
+        repository.merge_scan_rows(materialised_snapshot)
     except IndexCorruptedError:
-        store.write_rows(materialised_snapshot)
+        write_rows = getattr(repository, "write_rows", None)
+        if callable(write_rows):
+            write_rows(materialised_snapshot)
+        else:
+            repository.append_rows(materialised_snapshot)
 
 
 def ensure_links(
-    root: Path, rows: List[dict], library_root: Optional[Path] = None
+    root: Path,
+    rows: List[dict],
+    library_root: Optional[Path] = None,
+    *,
+    repository: "AssetRepositoryPort",
 ) -> List[LiveGroup]:
     """Ensure DB live-role state is current and refresh the derived links snapshot.
     
@@ -119,7 +133,12 @@ def ensure_links(
         library_root: If provided, use this as the database root.
     """
     groups, payload = compute_links_payload(rows)
-    sync_live_roles_to_db(root, groups, library_root=library_root)
+    sync_live_roles_to_db(
+        root,
+        groups,
+        library_root=library_root,
+        repository=repository,
+    )
 
     work_dir = ensure_work_dir(root)
     links_path = work_dir / "links.json"
@@ -156,7 +175,11 @@ def write_links(root: Path, payload: Dict[str, object]) -> None:
 
 
 def sync_live_roles_to_db(
-    root: Path, groups: List[LiveGroup], library_root: Optional[Path] = None
+    root: Path,
+    groups: List[LiveGroup],
+    library_root: Optional[Path] = None,
+    *,
+    repository: "AssetRepositoryPort",
 ) -> None:
     """Propagate live photo roles from computed groups to the repository.
     
@@ -186,18 +209,18 @@ def sync_live_roles_to_db(
         # Motion component: Role 1 (Hidden), Partner = Still
         updates.append((motion_rel, 1, still_rel))
 
-    db_root = library_root if library_root else root
-    store = get_global_repository(db_root)
     if album_prefix:
-        store.apply_live_role_updates_for_prefix(album_prefix, updates)
+        repository.apply_live_role_updates_for_prefix(album_prefix, updates)
     else:
-        store.apply_live_role_updates(updates)
+        repository.apply_live_role_updates(updates)
 
 
 def prune_index_scope(
     root: Path,
     materialised_rows: Iterable[dict],
     library_root: Optional[Path] = None,
+    *,
+    repository: "AssetRepositoryPort",
 ) -> int:
     """Delete rows under *root* that were not rediscovered by the completed scan.
 
@@ -206,8 +229,6 @@ def prune_index_scope(
     completed scan root so sibling albums remain untouched.
     """
 
-    db_root = library_root if library_root else root
-    store = get_global_repository(db_root)
     album_path = compute_album_path(root, library_root)
 
     fresh_rels = {
@@ -220,14 +241,14 @@ def prune_index_scope(
     }
 
     if album_path:
-        scoped_rows = store.read_album_assets(
+        scoped_rows = repository.read_album_assets(
             album_path,
             include_subalbums=True,
             sort_by_date=False,
             filter_hidden=False,
         )
     else:
-        scoped_rows = store.read_all(sort_by_date=False, filter_hidden=False)
+        scoped_rows = repository.read_all(sort_by_date=False, filter_hidden=False)
 
     removable: List[str] = []
     for row in scoped_rows:
@@ -240,7 +261,7 @@ def prune_index_scope(
     if not removable:
         return 0
 
-    store.remove_rows(removable)
+    repository.remove_rows(removable)
     return len(removable)
 
 

--- a/src/iPhoto/library/filesystem_watcher.py
+++ b/src/iPhoto/library/filesystem_watcher.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
+
+from ..bootstrap.library_scan_service import LibraryScanService
+from ..config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE
 
 if TYPE_CHECKING:
     pass
@@ -40,7 +44,76 @@ class FileSystemWatcherMixin:
         # ``QFileSystemWatcher`` emits plain strings.  Queue a debounced refresh
         # whenever a change notification arrives so the sidebar reflects
         # external edits without thrashing the filesystem.
+        if path:
+            self._pending_watch_paths.add(Path(path))
         self._debounce.start()
+
+    def _on_watcher_debounce_timeout(self) -> None:
+        """Refresh the tree and scan changed watcher scopes through the session."""
+
+        pending_paths = set(self._pending_watch_paths)
+        self._pending_watch_paths.clear()
+        self._refresh_tree()
+        self._start_watcher_scans(pending_paths)
+
+    def _start_watcher_scans(self, paths: set[Path]) -> None:
+        if self._root is None or not paths:
+            return
+
+        scan_service = getattr(self, "scan_service", None)
+        if scan_service is None:
+            scan_service = LibraryScanService(self._root)
+
+        scan_roots = self._dedupe_watch_scan_roots(paths)
+        if len(scan_roots) > 1:
+            scan_roots = [self._root]
+
+        for scan_root in scan_roots:
+            if not scan_root.exists() or not scan_root.is_dir():
+                continue
+            try:
+                include, exclude = scan_service.scan_filters(scan_root)
+            except Exception:
+                include, exclude = list(DEFAULT_INCLUDE), list(DEFAULT_EXCLUDE)
+            self.start_scanning(scan_root, include, exclude)
+
+    def _dedupe_watch_scan_roots(self, paths: set[Path]) -> list[Path]:
+        """Return minimal existing directory scopes for watcher-triggered scans."""
+
+        if self._root is None:
+            return []
+
+        root_resolved = self._root.resolve()
+        candidates: list[Path] = []
+        for raw_path in sorted(paths, key=lambda item: item.as_posix()):
+            try:
+                path = raw_path.resolve()
+            except OSError:
+                continue
+            if not path.exists():
+                continue
+            if not path.is_dir():
+                path = path.parent
+            try:
+                path.relative_to(root_resolved)
+            except ValueError:
+                continue
+            candidates.append(path)
+
+        deduped: list[Path] = []
+        for candidate in candidates:
+            if any(
+                existing == candidate or existing in candidate.parents
+                for existing in deduped
+            ):
+                continue
+            deduped = [
+                existing
+                for existing in deduped
+                if not (candidate == existing or candidate in existing.parents)
+            ]
+            deduped.append(candidate)
+        return deduped
 
     def _rebuild_watches(self) -> None:
         current = set(self._watcher.directories())

--- a/src/iPhoto/library/filesystem_watcher.py
+++ b/src/iPhoto/library/filesystem_watcher.py
@@ -53,9 +53,14 @@ class FileSystemWatcherMixin:
     def _on_watcher_debounce_timeout(self) -> None:
         """Refresh the tree and scan changed watcher scopes through the session."""
 
+        previous_album_paths = self._known_album_paths()
         pending_paths = set(self._pending_watch_paths)
         self._pending_watch_paths.clear()
         self._refresh_tree()
+        pending_paths = self._expand_new_album_watch_paths(
+            pending_paths,
+            previous_album_paths,
+        )
         self._start_watcher_scans(pending_paths)
 
     def _start_watcher_scans(self, paths: set[Path]) -> None:
@@ -118,6 +123,58 @@ class FileSystemWatcherMixin:
             return str(path.resolve())
         except OSError:
             return str(path)
+
+    def _known_album_paths(self) -> set[Path]:
+        """Return the currently discovered album directories."""
+
+        return {Path(node.path) for node in getattr(self, "_nodes", {}).values()}
+
+    def _expand_new_album_watch_paths(
+        self,
+        paths: set[Path],
+        previous_album_paths: set[Path],
+    ) -> set[Path]:
+        """Scan newly discovered albums instead of their parent watch path."""
+
+        if not paths:
+            return paths
+
+        previous_keys = {
+            self._watch_scan_key(path)
+            for path in previous_album_paths
+        }
+        new_album_paths = [
+            path
+            for path in sorted(self._known_album_paths(), key=lambda item: item.as_posix())
+            if self._watch_scan_key(path) not in previous_keys
+        ]
+        if not new_album_paths:
+            return paths
+
+        expanded = set(paths)
+        for pending_path in paths:
+            additions = [
+                album_path
+                for album_path in new_album_paths
+                if self._path_covers(pending_path, album_path)
+            ]
+            if not additions:
+                continue
+            expanded.discard(pending_path)
+            expanded.update(additions)
+        return expanded
+
+    @staticmethod
+    def _path_covers(root: Path, candidate: Path) -> bool:
+        try:
+            root_resolved = root.resolve()
+            candidate_resolved = candidate.resolve()
+        except OSError:
+            return False
+        return (
+            candidate_resolved == root_resolved
+            or root_resolved in candidate_resolved.parents
+        )
 
     def _dedupe_watch_scan_roots(self, paths: set[Path]) -> list[Path]:
         """Return minimal existing directory scopes for watcher-triggered scans."""

--- a/src/iPhoto/library/filesystem_watcher.py
+++ b/src/iPhoto/library/filesystem_watcher.py
@@ -23,8 +23,10 @@ class FileSystemWatcherMixin:
         # to ensure that an earlier notification does not race with the write we
         # are about to perform.
         self._watch_suspend_depth += 1
-        if self._watch_suspend_depth == 1 and self._debounce.isActive():
-            self._debounce.stop()
+        if self._watch_suspend_depth == 1:
+            if self._debounce.isActive():
+                self._debounce.stop()
+            self._pending_watch_paths.clear()
 
     def resume_watcher(self) -> None:
         """Re-enable change notifications once protected writes have finished."""
@@ -60,15 +62,44 @@ class FileSystemWatcherMixin:
         if self._root is None or not paths:
             return
 
+        scan_roots = self._dedupe_watch_scan_roots(paths)
+        self._queue_watcher_scan_roots(scan_roots)
+
+    def _queue_watcher_scan_roots(self, scan_roots: list[Path]) -> None:
+        """Queue watcher-triggered scan scopes without collapsing album filters."""
+
+        if not scan_roots:
+            return
+
+        queued = {
+            self._watch_scan_key(scan_root)
+            for scan_root in self._watch_scan_queue
+        }
+        active_root = getattr(self, "_live_scan_root", None)
+        for scan_root in scan_roots:
+            key = self._watch_scan_key(scan_root)
+            if key in queued:
+                continue
+            if active_root is not None and self._paths_equal(active_root, scan_root):
+                continue
+            self._watch_scan_queue.append(scan_root)
+            queued.add(key)
+
+        self._start_next_watcher_scan()
+
+    def _start_next_watcher_scan(self) -> None:
+        if self._root is None:
+            self._watch_scan_queue.clear()
+            return
+        if getattr(self, "_current_scanner_worker", None) is not None:
+            return
+
         scan_service = getattr(self, "scan_service", None)
         if scan_service is None:
             scan_service = LibraryScanService(self._root)
 
-        scan_roots = self._dedupe_watch_scan_roots(paths)
-        if len(scan_roots) > 1:
-            scan_roots = [self._root]
-
-        for scan_root in scan_roots:
+        while self._watch_scan_queue:
+            scan_root = self._watch_scan_queue.pop(0)
             if not scan_root.exists() or not scan_root.is_dir():
                 continue
             try:
@@ -76,6 +107,17 @@ class FileSystemWatcherMixin:
             except Exception:
                 include, exclude = list(DEFAULT_INCLUDE), list(DEFAULT_EXCLUDE)
             self.start_scanning(scan_root, include, exclude)
+            return
+
+    def _on_watcher_scan_finished(self, _root: Path, _success: bool) -> None:
+        self._start_next_watcher_scan()
+
+    @staticmethod
+    def _watch_scan_key(path: Path) -> str:
+        try:
+            return str(path.resolve())
+        except OSError:
+            return str(path)
 
     def _dedupe_watch_scan_roots(self, paths: set[Path]) -> list[Path]:
         """Return minimal existing directory scopes for watcher-triggered scans."""
@@ -99,6 +141,9 @@ class FileSystemWatcherMixin:
             except ValueError:
                 continue
             candidates.append(path)
+
+        if len(candidates) > 1:
+            candidates = [candidate for candidate in candidates if candidate != root_resolved]
 
         deduped: list[Path] = []
         for candidate in candidates:

--- a/src/iPhoto/library/manager.py
+++ b/src/iPhoto/library/manager.py
@@ -81,6 +81,7 @@ class LibraryManager(
         self._debounce.setSingleShot(True)
         self._debounce.setInterval(500)
         self._pending_watch_paths: set[Path] = set()
+        self._watch_scan_queue: list[Path] = []
         # ``_watch_suspend_depth`` tracks how many in-flight operations asked us to
         # ignore file-system notifications. We use a counter instead of a boolean
         # to correctly handle nested operations that may overlap (e.g., multiple
@@ -88,6 +89,7 @@ class LibraryManager(
         self._watch_suspend_depth = 0
         self._watcher.directoryChanged.connect(self._on_directory_changed)
         self._debounce.timeout.connect(self._on_watcher_debounce_timeout)
+        self.scanFinished.connect(self._on_watcher_scan_finished)
 
         # Scanner State
         self._current_scanner_worker: Optional[ScannerWorker] = None
@@ -133,6 +135,8 @@ class LibraryManager(
         # Cancel any in-flight scan so we do not block UI interactions while
         # rebinding to a new library root.
         self.stop_scanning()
+        self._pending_watch_paths.clear()
+        self._watch_scan_queue.clear()
         self._face_scan_status_message = None
         self._unbind_people_index_coordinator()
 
@@ -205,6 +209,7 @@ class LibraryManager(
         self._live_scan_buffer.clear()
         self._live_scan_root = None
         self._pending_watch_paths.clear()
+        self._watch_scan_queue.clear()
         self._geotagged_assets_cache = None
         self._geotagged_assets_cache_root = None
         if self._current_face_scanner is not None:

--- a/src/iPhoto/library/manager.py
+++ b/src/iPhoto/library/manager.py
@@ -80,13 +80,14 @@ class LibraryManager(
         self._debounce = QTimer(self)
         self._debounce.setSingleShot(True)
         self._debounce.setInterval(500)
+        self._pending_watch_paths: set[Path] = set()
         # ``_watch_suspend_depth`` tracks how many in-flight operations asked us to
         # ignore file-system notifications. We use a counter instead of a boolean
         # to correctly handle nested operations that may overlap (e.g., multiple
         # concurrent file operations that each need to pause/resume the watcher).
         self._watch_suspend_depth = 0
         self._watcher.directoryChanged.connect(self._on_directory_changed)
-        self._debounce.timeout.connect(self._refresh_tree)
+        self._debounce.timeout.connect(self._on_watcher_debounce_timeout)
 
         # Scanner State
         self._current_scanner_worker: Optional[ScannerWorker] = None
@@ -203,6 +204,7 @@ class LibraryManager(
             self._watcher.removePaths(self._watcher.directories())
         self._live_scan_buffer.clear()
         self._live_scan_root = None
+        self._pending_watch_paths.clear()
         self._geotagged_assets_cache = None
         self._geotagged_assets_cache_root = None
         if self._current_face_scanner is not None:

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
 from PySide6.QtCore import QMutexLocker, QRunnable
 
+from ..bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from ..bootstrap.library_asset_query_service import LibraryAssetQueryService
 from ..bootstrap.library_scan_service import LibraryScanService
 from ..utils.logging import get_logger
@@ -337,8 +338,15 @@ class ScanCoordinatorMixin:
         scan_service = worker.scan_service
         try:
             scan_service.finalize_scan(root, rows)
+            lifecycle_service = getattr(self, "asset_lifecycle_service", None)
+            if lifecycle_service is None:
+                lifecycle_service = LibraryAssetLifecycleService(
+                    self._root or root,
+                    scan_service=scan_service,
+                )
+            lifecycle_service.reconcile_missing_scan_rows(root, rows)
         except Exception as exc:
-            LOGGER.warning("Failed to persist live photo pairings after scan: %s", exc)
+            LOGGER.warning("Failed to persist scan finalization for %s: %s", root, exc)
 
         # Emit immediately so the UI (status bar, map refresh) can react without
         # waiting for the potentially slow live-photo pairing step.

--- a/src/iPhoto/library/workers/rescan_worker.py
+++ b/src/iPhoto/library/workers/rescan_worker.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from PySide6.QtCore import QObject, QRunnable, Signal
 
+from ...bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from ...bootstrap.library_scan_service import LibraryScanService
 from ...errors import IPhotoError
 
@@ -28,6 +29,7 @@ class RescanWorker(QRunnable):
         *,
         library_root: Path | None = None,
         scan_service: LibraryScanService | None = None,
+        asset_lifecycle_service: LibraryAssetLifecycleService | None = None,
     ) -> None:
         super().__init__()
         self.setAutoDelete(False)
@@ -35,6 +37,7 @@ class RescanWorker(QRunnable):
         self._signals = signals
         self._library_root = library_root
         self._scan_service = scan_service
+        self._asset_lifecycle_service = asset_lifecycle_service
 
     @property
     def root(self) -> Path:
@@ -62,6 +65,17 @@ class RescanWorker(QRunnable):
             self._scan_service = LibraryScanService(self._library_root or self._root)
         return self._scan_service
 
+    @property
+    def asset_lifecycle_service(self) -> LibraryAssetLifecycleService:
+        """Return the lifecycle service used for explicit scan reconciliation."""
+
+        if self._asset_lifecycle_service is None:
+            self._asset_lifecycle_service = LibraryAssetLifecycleService(
+                self._library_root or self._root,
+                scan_service=self.scan_service,
+            )
+        return self._asset_lifecycle_service
+
     def run(self) -> None:  # pragma: no cover - executed on worker thread
         """Perform the rescan and emit the outcome back to the GUI thread."""
 
@@ -76,6 +90,10 @@ class RescanWorker(QRunnable):
                 persist_chunks=False,
             )
             self.scan_service.finalize_scan(self._root, result.rows)
+            self.asset_lifecycle_service.reconcile_missing_scan_rows(
+                self._root,
+                result.rows,
+            )
         except IPhotoError as exc:
             # Surface domain-specific failures with the album path attached so the
             # facade can relay meaningful diagnostics to the user.

--- a/tests/application/test_cli_session_scan.py
+++ b/tests/application/test_cli_session_scan.py
@@ -27,9 +27,19 @@ class _FakeScans:
         return AlbumReport(title="Library", asset_count=2, live_pair_count=1)
 
 
+class _FakeLifecycle:
+    def __init__(self) -> None:
+        self.reconciled: list[tuple[Path, list[dict]]] = []
+
+    def reconcile_missing_scan_rows(self, root: Path, rows: list[dict]) -> int:
+        self.reconciled.append((root, rows))
+        return 0
+
+
 class _FakeSession:
     def __init__(self) -> None:
         self.scans = _FakeScans()
+        self.asset_lifecycle = _FakeLifecycle()
         self.shutdown_called = False
 
     def shutdown(self) -> None:
@@ -50,6 +60,7 @@ def test_cli_scan_uses_headless_session(monkeypatch, tmp_path: Path) -> None:
     assert "Indexed 1 assets" in result.output
     assert session.scans.scanned == [(tmp_path, False)]
     assert session.scans.finalized == [(tmp_path, [{"rel": "a.jpg"}])]
+    assert session.asset_lifecycle.reconciled == [(tmp_path, [{"rel": "a.jpg"}])]
     assert session.shutdown_called is True
     assert not hasattr(cli, "app_facade")
     assert not hasattr(cli, "get_global_repository")

--- a/tests/application/test_library_asset_lifecycle_service.py
+++ b/tests/application/test_library_asset_lifecycle_service.py
@@ -270,6 +270,32 @@ def test_cleanup_deleted_index_removes_missing_trash_rows(tmp_path: Path) -> Non
     assert _rows(library_root) == {}
 
 
+def test_reconcile_missing_scan_rows_prunes_scope_after_scan_finalize(
+    tmp_path: Path,
+) -> None:
+    library_root = tmp_path / "Library"
+    album_root = library_root / "AlbumA"
+    album_root.mkdir(parents=True)
+    get_global_repository(library_root).write_rows(
+        [
+            {"rel": "AlbumA/keep.jpg", "id": "keep", "is_favorite": True},
+            {"rel": "AlbumA/stale.jpg", "id": "stale"},
+            {"rel": "AlbumB/other.jpg", "id": "other"},
+        ]
+    )
+    service = LibraryAssetLifecycleService(library_root)
+
+    removed = service.reconcile_missing_scan_rows(
+        album_root,
+        [{"rel": "AlbumA/keep.jpg", "id": "keep"}],
+    )
+
+    rows = _rows(library_root)
+    assert removed == 1
+    assert set(rows) == {"AlbumA/keep.jpg", "AlbumB/other.jpg"}
+    assert bool(rows["AlbumA/keep.jpg"]["is_favorite"]) is True
+
+
 def test_read_index_rows_by_rels_returns_library_rows(tmp_path: Path) -> None:
     library_root = tmp_path / "Library"
     library_root.mkdir(parents=True)

--- a/tests/application/test_library_scan_service.py
+++ b/tests/application/test_library_scan_service.py
@@ -120,6 +120,33 @@ def test_subalbum_scan_prefixes_library_relative_rows(tmp_path: Path) -> None:
     ]
 
 
+def test_finalize_scan_does_not_prune_stale_rows(tmp_path: Path) -> None:
+    library_root = tmp_path / "library"
+    album_root = library_root / "album"
+    album_root.mkdir(parents=True)
+    store = get_global_repository(library_root)
+    store.write_rows(
+        [
+            {"rel": "album/keep.jpg", "id": "keep", "is_favorite": True},
+            {"rel": "album/stale.jpg", "id": "stale"},
+        ]
+    )
+    service = LibraryScanService(library_root)
+
+    service.finalize_scan(album_root, [{"rel": "album/keep.jpg", "id": "keep"}])
+
+    rows = {
+        row["rel"]: row
+        for row in store.read_album_assets(
+            "album",
+            include_subalbums=True,
+            filter_hidden=False,
+        )
+    }
+    assert set(rows) == {"album/keep.jpg", "album/stale.jpg"}
+    assert bool(rows["album/keep.jpg"]["is_favorite"]) is True
+
+
 def test_finalize_scan_preserves_subalbum_live_pairs_across_repeated_rescans(
     tmp_path: Path,
 ) -> None:
@@ -223,6 +250,36 @@ def test_prepare_album_open_autoscan_uses_shared_scan_and_finalize(tmp_path: Pat
     assert result.scanned is True
     assert result.rows == [{"rel": "a.jpg", "id": "asset-a"}]
     assert [row["rel"] for row in store.read_all(filter_hidden=False)] == ["a.jpg"]
+
+
+def test_prepare_album_open_autoscan_prunes_stale_hidden_rows(
+    tmp_path: Path,
+) -> None:
+    library_root = tmp_path / "library"
+    album_root = library_root / "album"
+    album_root.mkdir(parents=True)
+    store = get_global_repository(library_root)
+    store.write_rows(
+        [
+            {
+                "rel": "album/deleted.mov",
+                "id": "deleted-motion",
+                "live_role": 1,
+                "live_partner_rel": "album/deleted.heic",
+            },
+        ]
+    )
+    service = LibraryScanService(library_root, scanner=_Scanner([]))
+
+    result = service.prepare_album_open(
+        album_root,
+        autoscan=True,
+        hydrate_index=False,
+    )
+
+    assert result.scanned is True
+    assert result.rows == []
+    assert list(store.read_all(filter_hidden=False)) == []
 
 
 def test_sync_manifest_favorites_raises_recoverable_errors_by_default(

--- a/tests/library/test_rescan_worker_session.py
+++ b/tests/library/test_rescan_worker_session.py
@@ -29,11 +29,21 @@ class FakeScanService:
         self.finalized.append((root, rows))
 
 
+class FakeLifecycleService:
+    def __init__(self) -> None:
+        self.reconciled: list[tuple[Path, list[dict]]] = []
+
+    def reconcile_missing_scan_rows(self, root: Path, rows: list[dict]) -> int:
+        self.reconciled.append((root, rows))
+        return 0
+
+
 def test_rescan_worker_uses_session_scan_service(tmp_path: Path) -> None:
     album_root = tmp_path / "album"
     album_root.mkdir()
     scan_service = FakeScanService()
     signals = RescanSignals()
+    lifecycle_service = FakeLifecycleService()
     progress: list[tuple[Path, int, int]] = []
     finished: list[tuple[Path, bool]] = []
     signals.progressUpdated.connect(
@@ -41,10 +51,16 @@ def test_rescan_worker_uses_session_scan_service(tmp_path: Path) -> None:
     )
     signals.finished.connect(lambda root, success: finished.append((root, success)))
 
-    worker = RescanWorker(album_root, signals, scan_service=scan_service)
+    worker = RescanWorker(
+        album_root,
+        signals,
+        scan_service=scan_service,
+        asset_lifecycle_service=lifecycle_service,
+    )
     worker.run()
 
     assert scan_service.scanned == [(album_root, False)]
     assert scan_service.finalized == [(album_root, [{"rel": "a.jpg"}])]
+    assert lifecycle_service.reconciled == [(album_root, [{"rel": "a.jpg"}])]
     assert progress == [(album_root, 1, 2)]
     assert finished == [(album_root, True)]

--- a/tests/services/test_library_update_service_global_db.py
+++ b/tests/services/test_library_update_service_global_db.py
@@ -12,9 +12,10 @@ class DummyAlbum:
 
 
 class DummyLibrary:
-    def __init__(self, root: Path, scan_service=None) -> None:
+    def __init__(self, root: Path, scan_service=None, lifecycle_service=None) -> None:
         self._root = Path(root)
         self.scan_service = scan_service
+        self.asset_lifecycle_service = lifecycle_service
 
     def root(self) -> Path:
         return self._root
@@ -31,6 +32,15 @@ class FakeScanService:
 
     def finalize_scan(self, root: Path, rows: list[dict]) -> None:
         self.finalized.append((root, rows))
+
+
+class FakeLifecycleService:
+    def __init__(self) -> None:
+        self.reconciled: list[tuple[Path, list[dict]]] = []
+
+    def reconcile_missing_scan_rows(self, root: Path, rows: list[dict]) -> int:
+        self.reconciled.append((root, rows))
+        return 0
 
 
 class FakeFallbackScanService(FakeScanService):
@@ -60,11 +70,16 @@ def test_rescan_album_uses_session_scan_service(tmp_path: Path) -> None:
     lib_root.mkdir()
     album_root.mkdir()
     scan_service = FakeScanService()
+    lifecycle_service = FakeLifecycleService()
 
     service = lus.LibraryUpdateService(
         task_manager=DummyTaskManager(),
         current_album_getter=lambda: None,
-        library_manager_getter=lambda: DummyLibrary(lib_root, scan_service=scan_service),
+        library_manager_getter=lambda: DummyLibrary(
+            lib_root,
+            scan_service=scan_service,
+            lifecycle_service=lifecycle_service,
+        ),
     )
 
     rows = service.rescan_album(DummyAlbum(album_root))
@@ -72,6 +87,7 @@ def test_rescan_album_uses_session_scan_service(tmp_path: Path) -> None:
     assert rows == [{"rel": "a.jpg"}]
     assert scan_service.scanned == [(album_root, False)]
     assert scan_service.finalized == [(album_root, [{"rel": "a.jpg"}])]
+    assert lifecycle_service.reconciled == [(album_root, [{"rel": "a.jpg"}])]
 
 
 def test_rescan_album_fallback_syncs_manifest_favorites(
@@ -150,10 +166,15 @@ def test_rescan_album_async_passes_library_root(monkeypatch, tmp_path: Path) -> 
 
     task_manager = DummyTaskManager()
     scan_service = FakeScanService()
+    lifecycle_service = FakeLifecycleService()
     service = lus.LibraryUpdateService(
         task_manager=task_manager,
         current_album_getter=lambda: None,
-        library_manager_getter=lambda: DummyLibrary(lib_root, scan_service=scan_service),
+        library_manager_getter=lambda: DummyLibrary(
+            lib_root,
+            scan_service=scan_service,
+            lifecycle_service=lifecycle_service,
+        ),
     )
 
     service.rescan_album_async(DummyAlbum(album_root))
@@ -173,12 +194,21 @@ def test_restore_rescan_worker_receives_session_scan_service(
     album_root = lib_root / "Album"
     album_root.mkdir(parents=True)
     scan_service = FakeScanService()
+    lifecycle_service = FakeLifecycleService()
 
     class StubRescanWorker:
-        def __init__(self, root, signals, library_root=None, scan_service=None) -> None:
+        def __init__(
+            self,
+            root,
+            signals,
+            library_root=None,
+            scan_service=None,
+            asset_lifecycle_service=None,
+        ) -> None:
             self.root = Path(root)
             self.library_root = library_root
             self.scan_service = scan_service
+            self._asset_lifecycle_service = asset_lifecycle_service
 
     monkeypatch.setattr(lus, "RescanWorker", StubRescanWorker)
 
@@ -186,7 +216,11 @@ def test_restore_rescan_worker_receives_session_scan_service(
     service = lus.LibraryUpdateService(
         task_manager=task_manager,
         current_album_getter=lambda: None,
-        library_manager_getter=lambda: DummyLibrary(lib_root, scan_service=scan_service),
+        library_manager_getter=lambda: DummyLibrary(
+            lib_root,
+            scan_service=scan_service,
+            lifecycle_service=lifecycle_service,
+        ),
     )
 
     service._refresh_restored_album(album_root, lib_root)
@@ -196,3 +230,4 @@ def test_restore_rescan_worker_receives_session_scan_service(
     assert isinstance(worker, StubRescanWorker)
     assert worker.library_root == lib_root
     assert worker.scan_service is scan_service
+    assert worker._asset_lifecycle_service is lifecycle_service

--- a/tests/test_app_open_album_lazy.py
+++ b/tests/test_app_open_album_lazy.py
@@ -38,6 +38,15 @@ class FakeScanService:
         return ["pair"]
 
 
+class FakeLifecycleService:
+    def __init__(self) -> None:
+        self.reconciled: list[tuple[Path, list[dict]]] = []
+
+    def reconcile_missing_scan_rows(self, root: Path, rows: list[dict]) -> int:
+        self.reconciled.append((root, rows))
+        return 0
+
+
 def test_open_album_forwards_lazy_open_to_session_scan_service(monkeypatch, tmp_path):
     album_dir = tmp_path / "album"
     album_dir.mkdir()
@@ -78,9 +87,15 @@ def test_rescan_wrapper_uses_session_scan_and_finalize(monkeypatch, tmp_path):
     album_dir = tmp_path / "album"
     album_dir.mkdir()
     service = FakeScanService()
+    lifecycle = FakeLifecycleService()
     progress: list[tuple[int, int]] = []
 
     monkeypatch.setattr(app, "_scan_service", lambda root, library_root=None: service)
+    monkeypatch.setattr(
+        app,
+        "_lifecycle_service",
+        lambda root, library_root=None, scan_service=None: lifecycle,
+    )
 
     rows = app.rescan(
         album_dir,
@@ -90,6 +105,7 @@ def test_rescan_wrapper_uses_session_scan_and_finalize(monkeypatch, tmp_path):
     assert rows == [{"rel": "a.jpg"}]
     assert service.scanned == [(album_dir, False)]
     assert service.finalized == [(album_dir, [{"rel": "a.jpg"}])]
+    assert lifecycle.reconciled == [(album_dir, [{"rel": "a.jpg"}])]
     assert service.synced == [album_dir]
     assert progress == [(1, 1)]
 

--- a/tests/test_index_sync_service.py
+++ b/tests/test_index_sync_service.py
@@ -36,6 +36,7 @@ def test_prune_index_scope_removes_only_rows_within_scan_prefix(tmp_path: Path) 
         album_a,
         [{"rel": "album-a/keep.jpg", "id": "keep"}],
         library_root=library_root,
+        repository=store,
     )
 
     assert removed == 2
@@ -80,7 +81,7 @@ def test_ensure_links_keeps_db_live_roles_when_derived_snapshot_write_fails(
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("disk full")),
     )
 
-    ensure_links(album_root, rows)
+    ensure_links(album_root, rows, repository=store)
 
     data = {row["rel"]: row for row in store.read_all(filter_hidden=False)}
     assert data["photo.heic"]["live_partner_rel"] == "motion.mov"

--- a/tests/test_library_bind_double_scan.py
+++ b/tests/test_library_bind_double_scan.py
@@ -116,6 +116,48 @@ def test_watcher_debounce_scans_changed_scope_through_session_service(
     start_scanning.assert_called_once_with(album, ["*.jpg"], [])
 
 
+def test_root_watcher_event_for_new_album_uses_new_album_filters(
+    tmp_path,
+    qapp,
+):
+    root = tmp_path / "Library"
+    root.mkdir()
+
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    album = root / "NewAlbum"
+    album.mkdir()
+    (album / ".iphoto.album.json").write_text(
+        json.dumps(
+            {
+                "schema": "iPhoto/album@1",
+                "title": "NewAlbum",
+                "filters": {"include": ["*.heic"], "exclude": ["*.mov"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeScanService:
+        def __init__(self) -> None:
+            self.filter_roots = []
+
+        def scan_filters(self, path):
+            self.filter_roots.append(Path(path))
+            return ["*.heic"], ["*.mov"]
+
+    scan_service = FakeScanService()
+    manager.bind_scan_service(scan_service)
+
+    with patch.object(manager, "start_scanning") as start_scanning:
+        manager._on_directory_changed(str(root))
+        manager._on_watcher_debounce_timeout()
+
+    assert scan_service.filter_roots == [album]
+    start_scanning.assert_called_once_with(album, ["*.heic"], ["*.mov"])
+
+
 def test_watcher_scans_multiple_changed_scopes_with_each_album_filter(
     tmp_path,
     qapp,

--- a/tests/test_library_bind_double_scan.py
+++ b/tests/test_library_bind_double_scan.py
@@ -2,7 +2,7 @@
 import os
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from PySide6.QtTest import QSignalSpy
@@ -114,6 +114,75 @@ def test_watcher_debounce_scans_changed_scope_through_session_service(
 
     assert scan_service.filter_roots == [album]
     start_scanning.assert_called_once_with(album, ["*.jpg"], [])
+
+
+def test_watcher_scans_multiple_changed_scopes_with_each_album_filter(
+    tmp_path,
+    qapp,
+):
+    root = tmp_path / "Library"
+    album_a = root / "AlbumA"
+    album_b = root / "AlbumB"
+    album_a.mkdir(parents=True)
+    album_b.mkdir(parents=True)
+    for album in (album_a, album_b):
+        (album / ".iphoto.album.json").write_text(
+            json.dumps({"schema": "iPhoto/album@1", "title": album.name, "filters": {}}),
+            encoding="utf-8",
+        )
+
+    class FakeScanService:
+        def __init__(self) -> None:
+            self.filter_roots = []
+
+        def scan_filters(self, path):
+            path = Path(path)
+            self.filter_roots.append(path)
+            return [f"*.{path.name.lower()}"], [f"skip-{path.name.lower()}"]
+
+    manager = LibraryManager()
+    manager.bind_path(root)
+    scan_service = FakeScanService()
+    manager.bind_scan_service(scan_service)
+
+    with patch.object(manager, "start_scanning") as start_scanning:
+        manager._on_directory_changed(str(root))
+        manager._on_directory_changed(str(album_b))
+        manager._on_directory_changed(str(album_a))
+        manager._on_watcher_debounce_timeout()
+
+        assert scan_service.filter_roots == [album_a]
+        start_scanning.assert_called_once_with(
+            album_a,
+            ["*.albuma"],
+            ["skip-albuma"],
+        )
+
+        manager._on_watcher_scan_finished(album_a, True)
+
+    assert scan_service.filter_roots == [album_a, album_b]
+    assert start_scanning.call_args_list == [
+        call(album_a, ["*.albuma"], ["skip-albuma"]),
+        call(album_b, ["*.albumb"], ["skip-albumb"]),
+    ]
+
+
+def test_watcher_pause_drops_previously_queued_paths(tmp_path, qapp):
+    root = tmp_path / "Library"
+    root.mkdir()
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    with patch.object(manager, "start_scanning") as start_scanning:
+        manager._on_directory_changed(str(root))
+        assert manager._pending_watch_paths == {root}
+
+        manager.pause_watcher()
+        manager.resume_watcher()
+        manager._on_watcher_debounce_timeout()
+
+    assert manager._pending_watch_paths == set()
+    start_scanning.assert_not_called()
 
 
 def test_watcher_pause_suppresses_session_scan(tmp_path, qapp):

--- a/tests/test_library_bind_double_scan.py
+++ b/tests/test_library_bind_double_scan.py
@@ -1,5 +1,6 @@
 
 import os
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -80,3 +81,51 @@ def test_bind_path_emits_tree_updated_for_empty_library(tmp_path, qapp):
     spy = QSignalSpy(manager.treeUpdated)
     manager.bind_path(root)
     assert spy.count() >= 1, "treeUpdated must be emitted when binding an empty library"
+
+
+def test_watcher_debounce_scans_changed_scope_through_session_service(
+    tmp_path,
+    qapp,
+):
+    root = tmp_path / "Library"
+    album = root / "Album"
+    album.mkdir(parents=True)
+    (album / ".iphoto.album.json").write_text(
+        json.dumps({"schema": "iPhoto/album@1", "title": "Album", "filters": {}}),
+        encoding="utf-8",
+    )
+
+    class FakeScanService:
+        def __init__(self) -> None:
+            self.filter_roots = []
+
+        def scan_filters(self, path):
+            self.filter_roots.append(Path(path))
+            return ["*.jpg"], []
+
+    manager = LibraryManager()
+    manager.bind_path(root)
+    scan_service = FakeScanService()
+    manager.bind_scan_service(scan_service)
+
+    with patch.object(manager, "start_scanning") as start_scanning:
+        manager._on_directory_changed(str(album))
+        manager._on_watcher_debounce_timeout()
+
+    assert scan_service.filter_roots == [album]
+    start_scanning.assert_called_once_with(album, ["*.jpg"], [])
+
+
+def test_watcher_pause_suppresses_session_scan(tmp_path, qapp):
+    root = tmp_path / "Library"
+    root.mkdir()
+    manager = LibraryManager()
+    manager.bind_path(root)
+
+    with patch.object(manager, "start_scanning") as start_scanning:
+        manager.pause_watcher()
+        manager._on_directory_changed(str(root))
+        manager.resume_watcher()
+        manager._on_watcher_debounce_timeout()
+
+    start_scanning.assert_not_called()

--- a/tests/test_library_manager.py
+++ b/tests/test_library_manager.py
@@ -191,13 +191,13 @@ def test_scan_finished_skips_prune_when_worker_failed(tmp_path: Path, qapp: QApp
     manager._current_scanner_worker = _Worker()
 
     with (
-        patch("iPhoto.app._prune_index_scope") as prune_mock,
-        patch("iPhoto.app.pair") as pair_mock,
+        patch("iPhoto.library.scan_coordinator.LibraryAssetLifecycleService") as lifecycle_mock,
+        patch.object(manager._scan_thread_pool, "start") as start_mock,
     ):
         manager._on_scan_finished(root, [])
         qapp.processEvents()
 
-    prune_mock.assert_not_called()
-    pair_mock.assert_not_called()
+    lifecycle_mock.assert_not_called()
+    start_mock.assert_not_called()
     assert spy.count() == 1
     assert spy.at(0)[1] is False

--- a/tests/ui/tasks/test_import_worker.py
+++ b/tests/ui/tasks/test_import_worker.py
@@ -51,6 +51,15 @@ class FakeScanService:
         self.finalized.append((root, rows))
 
 
+class FakeLifecycleService:
+    def __init__(self) -> None:
+        self.reconciled: list[tuple[Path, list[dict]]] = []
+
+    def reconcile_missing_scan_rows(self, root: Path, rows: list[dict]) -> int:
+        self.reconciled.append((root, rows))
+        return 0
+
+
 @pytest.fixture()
 def qapp() -> QApplication:
     """Ensure a QApplication exists for QObject-based signals."""
@@ -77,18 +86,27 @@ def test_import_worker_prefers_pair_over_rescan(qapp: QApplication, tmp_path: Pa
     )
 
     scan_service = FakeScanService()
+    lifecycle_service = FakeLifecycleService()
 
     def copier(src: Path, dst: Path) -> Path:
         target = dst / src.name
         target.write_bytes(src.read_bytes())
         return target
 
-    worker = ImportWorker([source], destination, copier, signals, scan_service=scan_service)
+    worker = ImportWorker(
+        [source],
+        destination,
+        copier,
+        signals,
+        scan_service=scan_service,
+        asset_lifecycle_service=lifecycle_service,
+    )
     worker.run()
 
     assert scan_service.specific == [(destination, [destination / source.name])]
     assert scan_service.paired == [destination]
     assert scan_service.scanned == []
+    assert lifecycle_service.reconciled == []
 
     assert finished
     root, imported, success = finished[-1]
@@ -115,17 +133,26 @@ def test_import_worker_falls_back_to_full_rescan_after_incremental_failure(
     )
 
     scan_service = FakeScanService(fail_incremental=True)
+    lifecycle_service = FakeLifecycleService()
 
     def copier(src: Path, dst: Path) -> Path:
         target = dst / src.name
         target.write_bytes(src.read_bytes())
         return target
 
-    worker = ImportWorker([source], destination, copier, signals, scan_service=scan_service)
+    worker = ImportWorker(
+        [source],
+        destination,
+        copier,
+        signals,
+        scan_service=scan_service,
+        asset_lifecycle_service=lifecycle_service,
+    )
     worker.run()
 
     assert errors == ["Incremental scan failed: chunk failed"]
     assert scan_service.paired == []
     assert scan_service.scanned == [(destination, False)]
     assert scan_service.finalized == [(destination, [{"rel": "photo.jpg"}])]
+    assert lifecycle_service.reconciled == [(destination, [{"rel": "photo.jpg"}])]
     assert finished[-1] == (destination, [destination / source.name], True)

--- a/tools/check_layer_boundaries.py
+++ b/tools/check_layer_boundaries.py
@@ -34,6 +34,10 @@ PEOPLE_INDEX_STORE_FORBIDDEN_FILES = {
     "library/workers/face_scan_worker.py",
 }
 
+INDEX_SYNC_FORBIDDEN_FILES = {
+    "index_sync_service.py",
+}
+
 
 def _is_type_checking_guard(node: ast.If) -> bool:
     test = node.test
@@ -178,6 +182,14 @@ def check(src_root: Path) -> list[str]:
             ):
                 violations.append(
                     f"{py_file}:{lineno}: People runtime imports concrete index store {module}"
+                )
+
+            if rel in INDEX_SYNC_FORBIDDEN_FILES and (
+                module == "iPhoto.cache"
+                or _is_or_under(module, "iPhoto.cache.index_store")
+            ):
+                violations.append(
+                    f"{py_file}:{lineno}: index sync imports concrete index store {module}"
                 )
 
             if (


### PR DESCRIPTION
This pull request completes the migration of watcher-triggered scans and stale-row pruning to explicit, session-based orchestration, making scan side effects more predictable and improving architectural separation. Scan finalization is now strictly additive, with stale-row deletion handled by a dedicated lifecycle reconciliation step. The changes also ensure all major scan entrypoints (CLI, GUI, watcher, imports, restores) follow a unified session and lifecycle flow, and extend architecture guardrails to prevent regressions.

**Scan orchestration and lifecycle separation:**
- Split scan finalization from stale-row deletion: `LibraryScanService.finalize_scan()` now only merges scan results and materializes Live Photo links, while stale-row pruning is handled explicitly by `LibraryAssetLifecycleService.reconcile_missing_scan_rows()` after scans. [[1]](diffhunk://#diff-cfb9bf5653cdbdcef3cba63580d64e24f3f9b13bf138b86a8a9a87d0fd02ffc2L228-L242) [[2]](diffhunk://#diff-4ce4e7ee4935ae34c18daa266411617b32f3c287c1b88c939760339b9dc46c9dR153) [[3]](diffhunk://#diff-4ce4e7ee4935ae34c18daa266411617b32f3c287c1b88c939760339b9dc46c9dL135-R144) [[4]](diffhunk://#diff-0f7f93f97f2d3f3ff8ac7547a5485e151ba637004c1fac6f5c09c594ff05e127R1-R73) [[5]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR156-R178)
- All scan entrypoints (CLI, GUI, watcher, restore, import) now call explicit lifecycle reconciliation after scan finalization, ensuring consistent state and making deletion/pruning an explicit, auditable step. [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaR108-R111) [[2]](diffhunk://#diff-9affa4c3e5559fd78f6529d1d8a2c12aec46fb2d3e928d220e927846f1bae7eaR86-R89) [[3]](diffhunk://#diff-cfb9bf5653cdbdcef3cba63580d64e24f3f9b13bf138b86a8a9a87d0fd02ffc2R161) [[4]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cL174-R201)

**Watcher and repository refactoring:**
- Watcher-triggered refreshes now route through the session scan surface, ensuring directory changes trigger proper session-based scans and lifecycle handling. [[1]](diffhunk://#diff-4ce4e7ee4935ae34c18daa266411617b32f3c287c1b88c939760339b9dc46c9dL135-R144) [[2]](diffhunk://#diff-0f7f93f97f2d3f3ff8ac7547a5485e151ba637004c1fac6f5c09c594ff05e127R1-R73) [[3]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR156-R178)
- Removed direct concrete repository access from `index_sync_service.py`; repository ports are now passed from session/lifecycle adapters, and architecture checks prevent future regressions. [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaL25-R32) [[2]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR156-R178) [[3]](diffhunk://#diff-0f7f93f97f2d3f3ff8ac7547a5485e151ba637004c1fac6f5c09c594ff05e127R1-R73)

**API and protocol updates:**
- Extended repository protocols to support targeted Live Photo role updates, improving modularity and testability.
- Added new service constructors and helpers to facilitate session/lifecycle orchestration from legacy and compatibility callers. [[1]](diffhunk://#diff-100948ae30f42b75bcf4d7571913c7d5ca3e43d822ac5d6713b175817bb17ffaR44-R57) [[2]](diffhunk://#diff-9affa4c3e5559fd78f6529d1d8a2c12aec46fb2d3e928d220e927846f1bae7eaR58-R64)

**Verification and documentation:**
- Added and updated documentation on watcher scan/prune migration, including new verification steps and test coverage. All relevant tests pass with existing configs. [[1]](diffhunk://#diff-0f7f93f97f2d3f3ff8ac7547a5485e151ba637004c1fac6f5c09c594ff05e127R1-R73) [[2]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR286-R295)
- Updated implementation checklists and migration progress docs to reflect completed work and next steps. [[1]](diffhunk://#diff-4ce4e7ee4935ae34c18daa266411617b32f3c287c1b88c939760339b9dc46c9dL135-R144) [[2]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR156-R178) [[3]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cL174-R201) [[4]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cL202-R228) [[5]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cL280-R318)

These changes collectively ensure that scan orchestration is explicit, auditable, and consistent across all entrypoints, while continuing to move the codebase toward cleaner separation of concerns and improved maintainability.