### PR TITLE
Refactor GUI navigation and enhance documentation integration

### DIFF
--- a/docs/refactor/04-implementation-checklist.md
+++ b/docs/refactor/04-implementation-checklist.md
@@ -190,6 +190,13 @@
 - [ ] GUI services 只保留 presentation coordination。
 - [ ] Background task manager 只保留 Qt transport。
 
+- 本轮补充（第19步）：
+  - [x] `LibraryUpdateService` 不再导入 `iPhoto.app`、`cache.index_store` 或 `library.workers.*`；worker ownership 迁入 GUI 任务运行器，durable scan finalize 迁到 runtime/library surface。
+  - [x] GUI scan update flows 通过 runtime scan finalize hook 处理 snapshot 持久化、Recently Deleted 保留字段、stale-row reconciliation 与 Live Photo pairing follow-up。
+  - [x] Recently Deleted 的 prepare/cleanup throttle 不再由 `NavigationCoordinator` 负责，而是经由 Location/Trash GUI transport adapter。
+  - [x] Location 的地理资产加载不再从 `GalleryViewModel` 直接读取，后台加载与 request token 管理走 Location/Trash adapter。
+  - [ ] People fallback 仍残留 coordinator/viewmodel touchpoints，作为下一块 GUI residual。
+
 完成条件：
 
 - [x] `gui.facade.py` 不直接调用 `iPhoto.app` 业务函数。
@@ -299,21 +306,3 @@
 - [ ] 没有新增兼容层业务债务。
 - [ ] 没有丢失用户状态的迁移风险。
 - [ ] 文档、测试和架构检查同步更新。
-
-## 11. 第19轮更新：GUI Update + Location/Trash
-
-本轮用于收口 GUI Update 与 Location/Trash 的残留编排职责。
-
-### Phase 4 状态调整
-
-- [x] `LibraryUpdateService` 不再导入 `iPhoto.app`、`cache.index_store` 或 `library.workers.*`；worker ownership 迁入 GUI 任务运行器，durable scan finalize 迁到 runtime/library surface。
-- [x] GUI scan update flows 通过 runtime scan finalize hook 处理 snapshot 持久化、Recently Deleted 保留字段、stale-row reconciliation 与 Live Photo pairing follow-up。
-- [x] Recently Deleted 的 prepare/cleanup throttle 不再由 `NavigationCoordinator` 负责，而是经由 Location/Trash GUI transport adapter。
-- [x] Location 的地理资产加载不再从 `GalleryViewModel` 直接读取，后台加载与 request token 管理走 Location/Trash adapter。
-- [ ] People fallback 仍残留 coordinator/viewmodel touchpoints，作为下一块 GUI residual。
-
-### Phase 5 状态调整
-
-- Maps runtime porting 本轮仍未完成。
-- 本轮仅清理 GUI 侧 Location 入口，为后续 Maps runtime 提取收窄边界。
-- 不应仅凭本轮将 `MapRuntimePort` 标记为完成。

--- a/docs/refactor/04-implementation-checklist.md
+++ b/docs/refactor/04-implementation-checklist.md
@@ -187,15 +187,13 @@
 - [x] Gallery collection/windowed reads 迁移到 session query surface。
 - [x] Move/delete/restore planning 迁移到 session asset operation surface。
 - [x] album cover / featured / import-mark-featured durable 规则迁移到 session album metadata surface。
+- [x] `LibraryUpdateService` 不再导入 `iPhoto.app`、`cache.index_store` 或 `library.workers.*`；worker ownership 迁入 GUI 任务运行器，durable scan finalize 迁到 runtime/library surface。
+- [x] GUI scan update flows 通过 runtime scan finalize hook 处理 snapshot 持久化、Recently Deleted 保留字段、stale-row reconciliation 与 Live Photo pairing follow-up。
+- [x] Recently Deleted 的 prepare/cleanup throttle 不再由 `NavigationCoordinator` 负责，而是经由 Location/Trash GUI transport adapter。
+- [x] Location 的地理资产加载不再从 `GalleryViewModel` 直接读取，后台加载与 request token 管理走 Location/Trash adapter。
 - [ ] GUI services 只保留 presentation coordination。
 - [ ] Background task manager 只保留 Qt transport。
-
-- 本轮补充（第19步）：
-  - [x] `LibraryUpdateService` 不再导入 `iPhoto.app`、`cache.index_store` 或 `library.workers.*`；worker ownership 迁入 GUI 任务运行器，durable scan finalize 迁到 runtime/library surface。
-  - [x] GUI scan update flows 通过 runtime scan finalize hook 处理 snapshot 持久化、Recently Deleted 保留字段、stale-row reconciliation 与 Live Photo pairing follow-up。
-  - [x] Recently Deleted 的 prepare/cleanup throttle 不再由 `NavigationCoordinator` 负责，而是经由 Location/Trash GUI transport adapter。
-  - [x] Location 的地理资产加载不再从 `GalleryViewModel` 直接读取，后台加载与 request token 管理走 Location/Trash adapter。
-  - [ ] People fallback 仍残留 coordinator/viewmodel touchpoints，作为下一块 GUI residual。
+- [ ] People fallback 仍残留 coordinator/viewmodel touchpoints，作为下一块 GUI residual。
 
 完成条件：
 
@@ -232,6 +230,8 @@
 - [ ] 地图可用性查询通过 session。
 - [x] 地理资产聚合通过 application query。
 - [ ] native runtime fallback 有测试。
+
+本轮仅清理 GUI 侧 Location 入口，Maps runtime 仍是部分完成，不应仅凭本轮将 `MapRuntimePort` 标记为完成。
 
 ### Thumbnail
 

--- a/docs/refactor/04-implementation-checklist.md
+++ b/docs/refactor/04-implementation-checklist.md
@@ -1,8 +1,16 @@
-# 04 - Implementation Checklist
+# 04 - 重构实施清单
 
-> 执行清单用于跟踪 vNext 重构。勾选前必须满足对应完成条件和回归测试。
+> **版本:** 1.0 | **日期:** 2026-05-01  
+> **状态:** 进行中  
+> **范围:** vNext 重构执行清单与回归要求
 
-## 全局规则
+---
+
+## 1. 文档定位
+
+执行清单用于跟踪 vNext 重构。勾选前必须满足对应完成条件和回归测试。
+
+## 2. 全局规则
 
 - [ ] 不新增业务逻辑到 `src/iPhoto/app.py`。
 - [ ] 不新增业务逻辑到 `src/iPhoto/appctx.py`。
@@ -13,7 +21,7 @@
 - [ ] 不绕过 use case 直接从 GUI 写 persistence。
 - [ ] 每个阶段结束运行 `python3 tools/check_architecture.py`。
 
-## Phase 0 - 文档与 Guardrail
+## 3. Phase 0 - 文档与 Guardrail
 
 主要文件：
 
@@ -46,7 +54,7 @@
 - [x] `python3 tools/check_architecture.py`
 - [x] `pytest tests/architecture -q`，如果 architecture tests 已存在。
 
-## Phase 1 - RuntimeContext / LibrarySession
+## 4. Phase 1 - RuntimeContext / LibrarySession
 
 主要文件：
 
@@ -79,7 +87,7 @@
 - [ ] GUI startup smoke test，如已有。
 - [ ] 手动打开一个已有 library，确认资产能加载。
 
-## Phase 2 - Repository 与用户状态拆分
+## 5. Phase 2 - Repository 与用户状态拆分
 
 主要文件：
 
@@ -115,7 +123,7 @@
 - [x] trash/restore 在 rescan 后保持。
 - [x] Live Photo role 在 pairing 后可查询。
 
-## Phase 3 - 扫描管线统一
+## 6. Phase 3 - 扫描管线统一
 
 主要文件：
 
@@ -157,7 +165,7 @@
 - [x] 扫描后 Live Photo pairing 可恢复。
 - [x] `LibraryScanService.finalize_scan()` 不再隐式删除 stale rows。
 
-## Phase 4 - GUI Presentation Adapter
+## 7. Phase 4 - GUI Presentation Adapter
 
 主要文件：
 
@@ -200,7 +208,7 @@
 - [x] Favorite/hidden 状态刷新正确。
 - [x] album cover / featured manifest 同步与 favorite state mirror 正确。
 
-## Phase 5 - Bounded Context Ports
+## 8. Phase 5 - Bounded Context Ports
 
 ### People
 
@@ -245,7 +253,7 @@
 - [x] Thumbnail 生成不阻塞 UI。
 - [ ] Edit sidecar 保存后重启仍可恢复。
 
-## Phase 6 - 测试、性能、CI
+## 9. Phase 6 - 测试、性能、CI
 
 主要文件：
 
@@ -282,7 +290,7 @@
 - [x] `pytest tests/architecture -q`
 - [ ] 性能测试按项目约定运行。
 
-## Definition of Done
+## 10. Definition of Done
 
 - [ ] 代码边界符合 `01-target-architecture-vnext.md`。
 - [ ] 行为需求符合 `02-detailed-requirements.md`。
@@ -291,18 +299,21 @@
 - [ ] 没有新增兼容层业务债务。
 - [ ] 没有丢失用户状态的迁移风险。
 - [ ] 文档、测试和架构检查同步更新。
-## Round 19 Update: GUI Update + Location/Trash
 
-Phase 4 status adjustments:
+## 11. 第19轮更新：GUI Update + Location/Trash
 
-- [x] `LibraryUpdateService` no longer imports `iPhoto.app`, `cache.index_store`, or `library.workers.*`; worker ownership moved behind a GUI task runner and durable scan finalization moved to runtime/library surfaces.
-- [x] GUI scan update flows now use a runtime scan finalize hook for snapshot persistence, Recently Deleted preserved fields, stale-row reconciliation, and Live Photo pairing follow-up.
-- [x] Recently Deleted preparation and cleanup throttling no longer live in `NavigationCoordinator`; they now flow through a dedicated Location/Trash GUI transport adapter that calls existing library/runtime surfaces.
-- [x] Location geotagged-asset loading no longer reads directly from `GalleryViewModel`; background transport and request-token handling now flow through the dedicated Location/Trash adapter.
-- [ ] People fallback still has residual coordinator/viewmodel touchpoints and remains the next GUI residual slice.
+本轮用于收口 GUI Update 与 Location/Trash 的残留编排职责。
 
-Phase 5 status adjustments:
+### Phase 4 状态调整
 
-- Maps runtime porting is still not complete in this round.
-- This slice only cleaned the GUI-side Location entry point so later Maps runtime extraction has a narrower boundary to target.
-- Do not mark `MapRuntimePort` complete from this round alone.
+- [x] `LibraryUpdateService` 不再导入 `iPhoto.app`、`cache.index_store` 或 `library.workers.*`；worker ownership 迁入 GUI 任务运行器，durable scan finalize 迁到 runtime/library surface。
+- [x] GUI scan update flows 通过 runtime scan finalize hook 处理 snapshot 持久化、Recently Deleted 保留字段、stale-row reconciliation 与 Live Photo pairing follow-up。
+- [x] Recently Deleted 的 prepare/cleanup throttle 不再由 `NavigationCoordinator` 负责，而是经由 Location/Trash GUI transport adapter。
+- [x] Location 的地理资产加载不再从 `GalleryViewModel` 直接读取，后台加载与 request token 管理走 Location/Trash adapter。
+- [ ] People fallback 仍残留 coordinator/viewmodel touchpoints，作为下一块 GUI residual。
+
+### Phase 5 状态调整
+
+- Maps runtime porting 本轮仍未完成。
+- 本轮仅清理 GUI 侧 Location 入口，为后续 Maps runtime 提取收窄边界。
+- 不应仅凭本轮将 `MapRuntimePort` 标记为完成。

--- a/docs/refactor/04-implementation-checklist.md
+++ b/docs/refactor/04-implementation-checklist.md
@@ -291,3 +291,18 @@
 - [ ] 没有新增兼容层业务债务。
 - [ ] 没有丢失用户状态的迁移风险。
 - [ ] 文档、测试和架构检查同步更新。
+## Round 19 Update: GUI Update + Location/Trash
+
+Phase 4 status adjustments:
+
+- [x] `LibraryUpdateService` no longer imports `iPhoto.app`, `cache.index_store`, or `library.workers.*`; worker ownership moved behind a GUI task runner and durable scan finalization moved to runtime/library surfaces.
+- [x] GUI scan update flows now use a runtime scan finalize hook for snapshot persistence, Recently Deleted preserved fields, stale-row reconciliation, and Live Photo pairing follow-up.
+- [x] Recently Deleted preparation and cleanup throttling no longer live in `NavigationCoordinator`; they now flow through a dedicated Location/Trash GUI transport adapter that calls existing library/runtime surfaces.
+- [x] Location geotagged-asset loading no longer reads directly from `GalleryViewModel`; background transport and request-token handling now flow through the dedicated Location/Trash adapter.
+- [ ] People fallback still has residual coordinator/viewmodel touchpoints and remains the next GUI residual slice.
+
+Phase 5 status adjustments:
+
+- Maps runtime porting is still not complete in this round.
+- This slice only cleaned the GUI-side Location entry point so later Maps runtime extraction has a narrower boundary to target.
+- Do not mark `MapRuntimePort` complete from this round alone.

--- a/docs/refactor/05-current-progress.md
+++ b/docs/refactor/05-current-progress.md
@@ -91,9 +91,14 @@ adapter 职责。
   gallery query reads、media-load-failure 修复、album metadata durable
   mutation 都已迁到 session service；但 `gui/services/*` 和
   `BackgroundTaskManager` 仍未完全瘦身成纯 presentation transport。
+  本轮已将 `LibraryUpdateService` 定位为 presentation adapter，
+  `NavigationCoordinator` 与 `GalleryViewModel` 的 Location/Trash 流程
+  通过新的 GUI transport adapter 收口，并继续沿用 `LibraryManager`
+  + bootstrap runtime surfaces 作为事实边界。
 - Phase 5：部分完成。
   People、Thumbnail、Assign Location 边界已有明显收口；Maps runtime
-  availability/fallback 与 Edit sidecar port 仍待深入迁移。
+  availability/fallback 与 Edit sidecar port 仍待深入迁移。本轮仅通过
+  清理 GUI 侧 Location 入口为后续 Maps runtime 提取收窄边界。
 - Phase 6：部分完成。
   architecture tests、targeted application/infrastructure tests 已存在；
   temp-library end-to-end 与性能 baseline 仍未完成。
@@ -114,6 +119,7 @@ adapter 职责。
 - `global_index.db` 兼容 schema 可能缺失 `metadata` 列；state adapter 保持
   best-effort 行为。
 - Maps 与 Edit sidecar 仍缺少完整的 session/runtime boundary 收口。
+- People fallback 仍有 coordinator/viewmodel 残留。
 
 ## 6. 最新验证
 
@@ -129,45 +135,20 @@ adapter 职责。
 - `tools/check_architecture.py` 通过。
 - 仍有既有的 pytest `Unknown config option: env` warning。
 - 仍有既有的 legacy model shim / pairing deprecation warnings。
+- 本轮新增验证意图：`LibraryUpdateService` worker import guardrail，
+  以及 `LibraryUpdateService` / `NavigationCoordinator` / `GalleryViewModel`
+  / `AppFacade` 的 GUI regressions。
 
 之前各个切片的针对性验证命令和结果，继续以 `06` 到 `16` 交接文档为准；
 本文件只保留当前整体验证结论和最新增量验证。
 
 ## 7. 下一步交接
 
-1. 继续瘦身 `gui/services/*` 与 `BackgroundTaskManager`，优先收口仍在
-   coordinator/viewmodel 里的 location/trash-cleanup/People fallback 之类
-   非 Qt durable orchestration。
+1. 继续瘦身 `gui/services/*` 与 `BackgroundTaskManager`，优先收口
+   coordinator/viewmodel 里的 People fallback 与 location/trash-cleanup
+   之类非 Qt durable orchestration。
 2. 补 `temp library` 端到端回归：import / move / delete / restore，以及
    rescan 后用户状态保护。
 3. 推进 Phase 5 的 Maps / Edit：地图可用性查询、native fallback、`.ipo`
-   sidecar 读写与 save/reset/export use case。
-
-## 8. 第19轮复盘：GUI Update + Location/Trash
-
-本轮完成 `LibraryUpdate` 与 `Location/Trash` 的 GUI residual 编排清理。
-
-### Phase 4 状态说明
-
-- `LibraryUpdateService` 现在是 presentation-facing adapter；scan worker ownership 迁入 GUI task runner，durable scan completion 行为迁到当前 runtime/library surface。
-- `NavigationCoordinator` 不再负责 Recently Deleted 清理节流或后台线程调度；`GalleryViewModel` 不再直接准备 deleted roots 或从 `LibraryManager` 读取 geotagged assets，这些流程改走 Location/Trash GUI transport adapter。
-- 当前仓库仍以 `LibraryManager` + bootstrap/mixin runtime surfaces 作为事实边界，本轮未强制引入新的 `LibrarySession` / `RuntimeContext` 术语层。
-
-### Phase 5 状态说明
-
-- Maps runtime extraction 仍是部分完成；本轮仅通过清理 GUI 侧 Location 编排收窄边界。
-
-### 已知例外
-
-- People fallback 仍有 coordinator/viewmodel 残留。
-- Edit sidecar、完整 Maps fallback 清理、temp-library 端到端工作继续保持 out of scope。
-
-### 本轮验证意图
-
-- 架构 guardrail 增强：`gui/services/library_update_service.py` 不得 import `library.workers.*`
-- 针对 `LibraryUpdateService`、`NavigationCoordinator`、`GalleryViewModel`、`AppFacade` 的 GUI regressions 已更新
-
-### 下一步交接
-
-- 优先继续处理剩余 People residuals，除非 Maps runtime 提取更紧急。
-- 恢复 Maps 工作时，继续以 Location/Trash transport adapter 作为临时 GUI seam，而不是 Phase 5 的最终 runtime boundary。
+   sidecar 读写与 save/reset/export use case；恢复 Maps 工作时继续沿用
+   Location/Trash transport adapter 作为临时 GUI seam。

--- a/docs/refactor/05-current-progress.md
+++ b/docs/refactor/05-current-progress.md
@@ -1,8 +1,12 @@
 # 05 - 当前进度
 
-> Last updated: 2026-05-01
+> **版本:** 1.0 | **日期:** 2026-05-01  
+> **状态:** 进行中  
+> **范围:** vNext 重构进度与交接记录
 
-## 摘要
+---
+
+## 1. 摘要
 
 本文件记录当前 vNext 重构的真实落点。项目还没有完成全部六个阶段，
 但运行时主路径已经建立起可执行的 session boundary、repository/state
@@ -14,7 +18,7 @@ featured/favorite mirror 和 import 后 `mark_featured` 的 durable 规则，
 `gui/services/album_metadata_service.py` 现在只保留 Qt/watcher/presentation
 adapter 职责。
 
-## 本轮完成：Album Metadata Session 化
+## 2. 本轮完成：Album Metadata Session 化
 
 - 新增 `AlbumRepositoryPort` 与 `AlbumManifestRepository`。
   - album manifest 的 load/save/exists 现在通过 application/infrastructure
@@ -34,7 +38,7 @@ adapter 职责。
   - `gui/services/album_metadata_service.py` 不得再 runtime import
     `iPhoto.models.album`、`library_session`、`jsonio` 等旧实现细节。
 
-## 历史已完成切片摘要
+## 3. 历史已完成切片摘要
 
 以下切片已经完成，详细过程性交接分别见 `06` 到 `16`：
 
@@ -62,7 +66,7 @@ adapter 职责。
   `LibraryAssetOperationService`，GUI service 只负责 prompt、worker、
   signal 和用户提示。
 
-## 当前阶段状态
+## 4. 当前阶段状态
 
 - Phase 0：部分完成。
   vNext 文档与 guardrail 已落地，当前 guardrail 已覆盖 application/concrete
@@ -94,7 +98,7 @@ adapter 职责。
   architecture tests、targeted application/infrastructure tests 已存在；
   temp-library end-to-end 与性能 baseline 仍未完成。
 
-## 已知迁移例外
+## 5. 已知迁移例外
 
 - `app.py`、`appctx.py`、`gui.facade.py`、`library.manager.py` 仍是兼容入口，
   但不应继续承载新的 durable business logic。
@@ -111,7 +115,7 @@ adapter 职责。
   best-effort 行为。
 - Maps 与 Edit sidecar 仍缺少完整的 session/runtime boundary 收口。
 
-## 最新验证
+## 6. 最新验证
 
 本轮在项目 `.venv` 下执行：
 
@@ -129,7 +133,7 @@ adapter 职责。
 之前各个切片的针对性验证命令和结果，继续以 `06` 到 `16` 交接文档为准；
 本文件只保留当前整体验证结论和最新增量验证。
 
-## 下一步交接
+## 7. 下一步交接
 
 1. 继续瘦身 `gui/services/*` 与 `BackgroundTaskManager`，优先收口仍在
    coordinator/viewmodel 里的 location/trash-cleanup/People fallback 之类
@@ -138,28 +142,32 @@ adapter 职责。
    rescan 后用户状态保护。
 3. 推进 Phase 5 的 Maps / Edit：地图可用性查询、native fallback、`.ipo`
    sidecar 读写与 save/reset/export use case。
-## Round 19 Summary
 
-This round completed the remaining GUI residual orchestration cleanup for `LibraryUpdate` plus `Location/Trash`.
+## 8. 第19轮复盘：GUI Update + Location/Trash
 
-Current phase notes:
+本轮完成 `LibraryUpdate` 与 `Location/Trash` 的 GUI residual 编排清理。
 
-- Phase 4: `LibraryUpdateService` is now a presentation-facing adapter. It still exposes the same facade-facing API, but scan worker ownership moved behind a dedicated GUI task runner and durable scan completion behavior moved onto the current runtime/library surface.
-- Phase 4: `NavigationCoordinator` no longer owns Recently Deleted cleanup throttling or background thread launch. `GalleryViewModel` no longer prepares deleted roots or reads geotagged assets directly from `LibraryManager`; those flows now go through a narrow GUI Location/Trash transport adapter.
-- Phase 4: the current repository still uses `LibraryManager` plus bootstrap/mixin runtime surfaces as the real boundary. This round did not force in a new full `LibrarySession` / `RuntimeContext` terminology layer where the codebase does not already have one.
-- Phase 5: Maps runtime extraction is still partial. This round only created a cleaner entry point by removing GUI-side Location orchestration from the coordinator/viewmodel path.
+### Phase 4 状态说明
 
-Known exceptions:
+- `LibraryUpdateService` 现在是 presentation-facing adapter；scan worker ownership 迁入 GUI task runner，durable scan completion 行为迁到当前 runtime/library surface。
+- `NavigationCoordinator` 不再负责 Recently Deleted 清理节流或后台线程调度；`GalleryViewModel` 不再直接准备 deleted roots 或从 `LibraryManager` 读取 geotagged assets，这些流程改走 Location/Trash GUI transport adapter。
+- 当前仓库仍以 `LibraryManager` + bootstrap/mixin runtime surfaces 作为事实边界，本轮未强制引入新的 `LibrarySession` / `RuntimeContext` 术语层。
 
-- People fallback behavior is still not fully migrated out of coordinator/viewmodel edges.
-- Edit sidecar, full Maps fallback cleanup, and temp-library end-to-end work remain intentionally out of scope for this slice.
+### Phase 5 状态说明
 
-Latest verification intent:
+- Maps runtime extraction 仍是部分完成；本轮仅通过清理 GUI 侧 Location 编排收窄边界。
 
-- architecture guardrail extended so `gui/services/library_update_service.py` cannot import `library.workers.*`
-- targeted GUI regressions updated around `LibraryUpdateService`, `NavigationCoordinator`, `GalleryViewModel`, and `AppFacade`
+### 已知例外
 
-Next handoff:
+- People fallback 仍有 coordinator/viewmodel 残留。
+- Edit sidecar、完整 Maps fallback 清理、temp-library 端到端工作继续保持 out of scope。
 
-- Continue with the remaining People residuals first, unless Maps runtime port extraction becomes more urgent.
-- When resuming Maps work, treat the new Location/Trash transport adapter as the temporary GUI seam rather than a final Phase 5 runtime boundary.
+### 本轮验证意图
+
+- 架构 guardrail 增强：`gui/services/library_update_service.py` 不得 import `library.workers.*`
+- 针对 `LibraryUpdateService`、`NavigationCoordinator`、`GalleryViewModel`、`AppFacade` 的 GUI regressions 已更新
+
+### 下一步交接
+
+- 优先继续处理剩余 People residuals，除非 Maps runtime 提取更紧急。
+- 恢复 Maps 工作时，继续以 Location/Trash transport adapter 作为临时 GUI seam，而不是 Phase 5 的最终 runtime boundary。

--- a/docs/refactor/05-current-progress.md
+++ b/docs/refactor/05-current-progress.md
@@ -18,6 +18,10 @@ featured/favorite mirror 和 import 后 `mark_featured` 的 durable 规则，
 `gui/services/album_metadata_service.py` 现在只保留 Qt/watcher/presentation
 adapter 职责。
 
+本轮同时补齐 `LibraryUpdate` 与 `Location/Trash` 的 GUI residual 编排收口：
+scan worker ownership 迁入 GUI 任务运行器，durable scan finalize 迁到
+runtime/library surface，Location/Trash 流程改由 GUI transport adapter 收口。
+
 ## 2. 本轮完成：Album Metadata Session 化
 
 - 新增 `AlbumRepositoryPort` 与 `AlbumManifestRepository`。
@@ -91,14 +95,21 @@ adapter 职责。
   gallery query reads、media-load-failure 修复、album metadata durable
   mutation 都已迁到 session service；但 `gui/services/*` 和
   `BackgroundTaskManager` 仍未完全瘦身成纯 presentation transport。
-  本轮已将 `LibraryUpdateService` 定位为 presentation adapter，
-  `NavigationCoordinator` 与 `GalleryViewModel` 的 Location/Trash 流程
-  通过新的 GUI transport adapter 收口，并继续沿用 `LibraryManager`
-  + bootstrap runtime surfaces 作为事实边界。
+  本轮补齐 `LibraryUpdate` + `Location/Trash` GUI residual：
+  `LibraryUpdateService` 的 scan worker ownership 迁入 GUI 任务运行器，
+  durable scan finalize 迁到 runtime/library surface；GUI scan update flows
+  通过 runtime scan finalize hook 处理 snapshot 持久化、Recently Deleted
+  保留字段、stale-row reconciliation 与 Live Photo pairing follow-up；
+  `NavigationCoordinator` 不再负责 Recently Deleted cleanup throttle 或后台
+  线程调度，`GalleryViewModel` 不再直接准备 deleted roots 或读取
+  geotagged assets，统一改走 Location/Trash transport adapter；
+  仍沿用 `LibraryManager` + bootstrap runtime surfaces 作为事实边界，
+  未强制引入新的 `LibrarySession` / `RuntimeContext` 术语层。
 - Phase 5：部分完成。
   People、Thumbnail、Assign Location 边界已有明显收口；Maps runtime
   availability/fallback 与 Edit sidecar port 仍待深入迁移。本轮仅通过
-  清理 GUI 侧 Location 入口为后续 Maps runtime 提取收窄边界。
+  清理 GUI 侧 Location 入口为后续 Maps runtime 提取收窄边界，不应仅凭
+  本轮将 `MapRuntimePort` 视为完成。
 - Phase 6：部分完成。
   architecture tests、targeted application/infrastructure tests 已存在；
   temp-library end-to-end 与性能 baseline 仍未完成。
@@ -120,6 +131,7 @@ adapter 职责。
   best-effort 行为。
 - Maps 与 Edit sidecar 仍缺少完整的 session/runtime boundary 收口。
 - People fallback 仍有 coordinator/viewmodel 残留。
+- temp-library 端到端仍保持 out of scope。
 
 ## 6. 最新验证
 
@@ -145,10 +157,11 @@ adapter 职责。
 ## 7. 下一步交接
 
 1. 继续瘦身 `gui/services/*` 与 `BackgroundTaskManager`，优先收口
-   coordinator/viewmodel 里的 People fallback 与 location/trash-cleanup
-   之类非 Qt durable orchestration。
+   coordinator/viewmodel 里的 People fallback 等 residual；
+   除非 Maps runtime 提取更紧急。
 2. 补 `temp library` 端到端回归：import / move / delete / restore，以及
    rescan 后用户状态保护。
 3. 推进 Phase 5 的 Maps / Edit：地图可用性查询、native fallback、`.ipo`
    sidecar 读写与 save/reset/export use case；恢复 Maps 工作时继续沿用
-   Location/Trash transport adapter 作为临时 GUI seam。
+   Location/Trash transport adapter 作为临时 GUI seam，不作为最终 Phase 5
+   boundary。

--- a/docs/refactor/05-current-progress.md
+++ b/docs/refactor/05-current-progress.md
@@ -138,3 +138,28 @@ adapter 职责。
    rescan 后用户状态保护。
 3. 推进 Phase 5 的 Maps / Edit：地图可用性查询、native fallback、`.ipo`
    sidecar 读写与 save/reset/export use case。
+## Round 19 Summary
+
+This round completed the remaining GUI residual orchestration cleanup for `LibraryUpdate` plus `Location/Trash`.
+
+Current phase notes:
+
+- Phase 4: `LibraryUpdateService` is now a presentation-facing adapter. It still exposes the same facade-facing API, but scan worker ownership moved behind a dedicated GUI task runner and durable scan completion behavior moved onto the current runtime/library surface.
+- Phase 4: `NavigationCoordinator` no longer owns Recently Deleted cleanup throttling or background thread launch. `GalleryViewModel` no longer prepares deleted roots or reads geotagged assets directly from `LibraryManager`; those flows now go through a narrow GUI Location/Trash transport adapter.
+- Phase 4: the current repository still uses `LibraryManager` plus bootstrap/mixin runtime surfaces as the real boundary. This round did not force in a new full `LibrarySession` / `RuntimeContext` terminology layer where the codebase does not already have one.
+- Phase 5: Maps runtime extraction is still partial. This round only created a cleaner entry point by removing GUI-side Location orchestration from the coordinator/viewmodel path.
+
+Known exceptions:
+
+- People fallback behavior is still not fully migrated out of coordinator/viewmodel edges.
+- Edit sidecar, full Maps fallback cleanup, and temp-library end-to-end work remain intentionally out of scope for this slice.
+
+Latest verification intent:
+
+- architecture guardrail extended so `gui/services/library_update_service.py` cannot import `library.workers.*`
+- targeted GUI regressions updated around `LibraryUpdateService`, `NavigationCoordinator`, `GalleryViewModel`, and `AppFacade`
+
+Next handoff:
+
+- Continue with the remaining People residuals first, unless Maps runtime port extraction becomes more urgent.
+- When resuming Maps work, treat the new Location/Trash transport adapter as the temporary GUI seam rather than a final Phase 5 runtime boundary.

--- a/docs/refactor/19-gui-update-navigation-session-migration.md
+++ b/docs/refactor/19-gui-update-navigation-session-migration.md
@@ -1,81 +1,83 @@
-# 19 GUI Update + Navigation Session Migration
+# 19 - GUI Update + Navigation Session Migration
 
-## Goal
+> **版本:** 1.0 | **日期:** 2026-05-01  
+> **状态:** 已完成  
+> **范围:** Phase 4 GUI residual orchestration cleanup（LibraryUpdate + Location/Trash）
 
-Continue the GUI residual-orchestration cleanup without cutting across Maps or Edit in a broad way.
+---
 
-This slice targets two remaining seams:
+## 1. 背景与目标
 
-- `LibraryUpdateService` still owning scan/pair/finalize/restore-refresh orchestration details.
-- Location / Recently Deleted flows still reaching through GUI code into library/runtime behavior instead of consuming a narrow adapter surface.
+继续清理 GUI 残留编排，不对 Maps / Edit 做大范围切入。本轮关注两个剩余缝隙：
 
-The goal of this round is to leave GUI code with presentation coordination, Qt transport, and routing responsibilities only, while reusing the repository's current runtime/library boundary (`LibraryManager` plus bootstrap services and mixins) instead of forcing a parallel session abstraction.
+- `LibraryUpdateService` 仍持有 scan / pair / finalize / restore-refresh 编排细节。
+- Location / Recently Deleted 仍从 GUI 直接触达库/运行时行为。
 
-## What Changed
+目标是让 GUI 只保留 presentation coordination、Qt transport 与路由职责，继续复用当前 runtime/library 边界（`LibraryManager` + bootstrap services/mixins），不强推新的 session 抽象。
 
-### LibraryUpdate
+## 2. 变更摘要
 
-- Added higher-level runtime scan entry points on `LibraryScanService`:
-  - synchronous rescan
-  - scan finalize hook
-  - restore-refresh rescan entry
-- The runtime finalize hook now centralizes:
-  - Recently Deleted preserved-field merge
-  - snapshot persistence
-  - link rebuild
-  - stale-row reconciliation
-  - optional Live Photo pairing follow-up
-- `RescanWorker` now refreshes restored albums through the runtime scan surface instead of directly composing lifecycle persistence rules.
-- `LibraryUpdateService` no longer imports `ScannerWorker` / `RescanWorker` directly.
-- Worker ownership moved into a dedicated GUI task runner so `LibraryUpdateService` remains a presentation adapter that:
-  - starts or cancels tasks
-  - relays progress and chunk signals
-  - emits `indexUpdated`, `linksUpdated`, and `assetReloadRequested`
-  - keeps facade-facing behavior stable
+### 2.1 LibraryUpdate
 
-### Location / Trash
+- 在 `LibraryScanService` 上补充更高层 scan 入口：同步 rescan、scan finalize hook、restore-refresh rescan 入口。
+- finalize hook 统一处理：Recently Deleted 保留字段、snapshot persistence、link rebuild、stale-row reconciliation、可选 Live Photo pairing follow-up。
+- `RescanWorker` 改为通过 runtime scan surface 刷新恢复相册。
+- `LibraryUpdateService` 不再直接 import `ScannerWorker` / `RescanWorker`。
+- worker ownership 移入专用 GUI task runner；`LibraryUpdateService` 保持 presentation adapter，负责：
+  - 启动/取消任务
+  - 转发 progress/chunk 信号
+  - 发出 `indexUpdated`、`linksUpdated`、`assetReloadRequested`
+  - 维持 facade-facing API 兼容
 
-- Added a narrow GUI `LocationTrashNavigationService` for:
-  - Recently Deleted directory preparation
-  - trash cleanup throttling and background dispatch
-  - background geotagged-asset loading
-  - request-serial management for Location reloads
-- `NavigationCoordinator` dropped its trash cleanup thread logic and remains a thin routing binder.
-- `GalleryViewModel` no longer calls `ensure_deleted_directory()` or `get_geotagged_assets()` directly.
-- `GalleryViewModel` now consumes adapter results and keeps only UI state:
-  - static selection
-  - route changes
-  - cluster gallery state
-  - cached location snapshot state
+### 2.2 Location / Trash
 
-### Guardrails
+- 新增 `LocationTrashNavigationService`，负责：
+  - Recently Deleted 目录准备
+  - trash cleanup 节流与后台调度
+  - geotagged assets 后台加载
+  - Location reload 的 request-serial 管理
+- `NavigationCoordinator` 去除 trash cleanup 线程逻辑，保持路由绑定。
+- `GalleryViewModel` 不再直接调用 `ensure_deleted_directory()` 或 `get_geotagged_assets()`。
+- `GalleryViewModel` 只保留 UI 状态：静态选择、路由切换、cluster gallery、location snapshot cache。
 
-- Extended architecture checking so `gui/services/library_update_service.py` cannot import `library.workers.*`.
-- Updated targeted GUI regressions to assert the new boundary shape rather than old worker-construction details.
+### 2.3 Guardrails
 
-## Behavioral Notes
+- 架构检查扩展：`gui/services/library_update_service.py` 禁止 import `library.workers.*`。
+- 相关 GUI regressions 调整为验证新的 boundary 形态。
 
-- `AppFacade` public API shape stays the same; the refactor only changes internal forwarding.
-- The current branch still uses `LibraryManager` and bootstrap runtime services as the effective boundary. This round does not claim a new full `LibrarySession` / `RuntimeContext` rollout where the code does not already use one.
-- Maps runtime extraction is still incomplete. The new Location/Trash adapter is a cleanup seam for future work, not the final Phase 5 port.
-- People residual fallback behavior remains for a later slice.
+## 3. 行为说明
 
-## Verification
+- `AppFacade` 公共 API 形态保持不变，变化仅在内部转发路径。
+- 当前边界仍以 `LibraryManager` + bootstrap runtime services 为主，本轮不强制新的 `LibrarySession` / `RuntimeContext` 术语层。
+- Maps runtime extraction 仍未完成；Location/Trash adapter 是后续 Maps 工作的临时 GUI seam。
+- People residual fallback 仍留待后续切片。
 
-Targeted regressions updated for:
+## 4. 审查结论
 
-- `LibraryUpdateService` runtime forwarding and task-runner delegation
-- `GalleryViewModel` Recently Deleted and Location flows through the new adapter
-- `NavigationCoordinator` remaining free of direct trash cleanup calls
-- `AppFacade` preserving its public async-rescan forwarding shape
-- architecture boundary checks for `LibraryUpdateService` worker imports
+核对现有实现后，变更描述与代码一致：
 
-Environment note:
+- `LibraryUpdateService` 通过 `LibraryUpdateTaskRunner` 持有 worker 生命周期，服务本体无直接 `library.workers` import；对应 guardrail 已在 `tools/check_layer_boundaries.py` 与 `tests/architecture/test_layer_boundaries.py` 覆盖。
+- `LibraryScanService.finalize_scan_result()` 已包含 Recently Deleted 保留字段合并、snapshot/links 持久化、stale-row reconciliation 与可选 Live Photo pairing。
+- `LocationTrashNavigationService` 负责 trash cleanup 节流与 geotagged assets 后台加载，`GalleryViewModel` 使用 adapter 获取数据。
 
-- Final command-based verification was partially blocked by the local Codex escalation limit during this round, so any remaining test execution should be rerun once command access is available again.
+结论：第 19 步文档描述与当前代码一致，无需更正。
 
-## Next Handoff
+## 5. 验证
 
-- Continue with the remaining People fallback/coordinator residuals as the next Phase 4 GUI cleanup slice.
-- When returning to Maps work, build on the new `LocationTrashNavigationService` seam instead of reintroducing direct `LibraryManager` reads into coordinator/viewmodel code.
-- Keep Edit sidecar, full Maps fallback cleanup, and temp-library end-to-end validation out of this slice unless a later round explicitly re-scopes them.
+目标回归覆盖：
+
+- `LibraryUpdateService` runtime forwarding 与 task-runner delegation
+- `GalleryViewModel` Recently Deleted / Location 流程通过新的 adapter
+- `NavigationCoordinator` 保持无 direct trash cleanup 调用
+- `AppFacade` 维持 async rescan forwarding 形态
+- `LibraryUpdateService` worker import 的架构边界检查
+
+环境说明：
+
+- 本轮命令式验证曾因本地 Codex 权限限制部分阻断；如需完整结果请在具备命令权限时重跑。
+
+## 6. 下一步交接
+
+- 继续清理 People fallback/coordinator residuals（Phase 4）。
+- Maps 侧回归时，以 `LocationTrashNavigationService` 作为临时 GUI seam，避免直接回引 `LibraryManager`。
+- Edit sidecar、完整 Maps fallback、temp-library E2E 仍保持 out of scope。

--- a/docs/refactor/19-gui-update-navigation-session-migration.md
+++ b/docs/refactor/19-gui-update-navigation-session-migration.md
@@ -54,27 +54,51 @@
 
 ## 4. 审查结论
 
-核对现有实现后，变更描述与代码一致：
+核对现有实现后，本步迁移的主方向与代码一致，但原始结论写得过满，需要以下修正：
 
-- `LibraryUpdateService` 通过 `LibraryUpdateTaskRunner` 持有 worker 生命周期，服务本体无直接 `library.workers` import；对应 guardrail 已在 `tools/check_layer_boundaries.py` 与 `tests/architecture/test_layer_boundaries.py` 覆盖。
-- `LibraryScanService.finalize_scan_result()` 已包含 Recently Deleted 保留字段合并、snapshot/links 持久化、stale-row reconciliation 与可选 Live Photo pairing。
-- `LocationTrashNavigationService` 负责 trash cleanup 节流与 geotagged assets 后台加载，`GalleryViewModel` 使用 adapter 获取数据。
+- `LibraryUpdateService` 确实通过 `LibraryUpdateTaskRunner` 持有 worker 生命周期；服务本体无直接 `library.workers` import，而具体 worker import 位于 task runner 中。这一边界由 `tools/check_layer_boundaries.py` 与 `tests/architecture/test_layer_boundaries.py` 约束。
+- `LibraryScanService.finalize_scan_result()` 已承担 scan finalize 责任，包括 Recently Deleted 保留字段合并、snapshot/links 持久化、stale-row reconciliation 与可选 Live Photo pairing。
+- `LocationTrashNavigationService` 已承接 Recently Deleted 准备、trash cleanup 节流与 geotagged assets 后台加载；`GalleryViewModel` 通过 adapter 触发这些流程，不再直接调用 `ensure_deleted_directory()` 或 `get_geotagged_assets()`。
+- 但 `AppFacade.open_album()` -> `LibraryUpdateService.prepare_album_open()` 是本轮迁移后的关键兼容入口，这一点需要在文档中明确记录。该路径依赖 `_scan_dependencies()` 的返回契约，曾出现过一次返回值解包回归，导致 album-open 主流程抛出异常；问题已修复，但说明本步并非“无需更正”的完全收口状态。
 
-结论：第 19 步文档描述与当前代码一致，无需更正。
+结论：第 19 步迁移目标已基本落地，但文档应保留关键入口契约、验证锚点与已修复回归，而不应使用“完全一致、无需更正”的强结论。
 
 ## 5. 验证
 
-目标回归覆盖：
+建议将本步验证固定为以下可复现锚点，而不是只保留目标描述：
 
-- `LibraryUpdateService` runtime forwarding 与 task-runner delegation
-- `GalleryViewModel` Recently Deleted / Location 流程通过新的 adapter
-- `NavigationCoordinator` 保持无 direct trash cleanup 调用
-- `AppFacade` 维持 async rescan forwarding 形态
-- `LibraryUpdateService` worker import 的架构边界检查
+- `tests/services/test_library_update_service_global_db.py`
+  - 覆盖 `LibraryUpdateService.prepare_album_open()` 对 session scan service 的转发。
+  - 覆盖空 scope 时 `should_rescan_async` 的行为。
+  - 覆盖 `rescan_album()` / `rescan_album_async()` 的 runtime forwarding 形态。
+- `tests/test_app_facade_session_open.py`
+  - 覆盖 `AppFacade.open_album()` 通过 `prepare_album_open()` 进入 session scan surface。
+  - 覆盖 library bound / unbound 时 `sync_manifest_favorites` 的分支。
+  - 覆盖 `rescan_current_async()` 的 facade-facing forwarding 兼容形态。
+- `tests/gui/viewmodels/test_gallery_viewmodel.py`
+  - 覆盖 Recently Deleted 通过 `LocationTrashNavigationService.prepare_recently_deleted()` 打开。
+  - 覆盖 Location 视图通过 `request_location_assets()` 异步加载，且不再直接调用 `library.get_geotagged_assets()`。
+- `tests/test_navigation_coordinator_refresh.py`
+  - 覆盖 `NavigationCoordinator` 不直接触发 trash cleanup。
+- `tests/architecture/test_layer_boundaries.py`
+  - 覆盖 `gui/services/library_update_service.py` 禁止直接 import `iPhoto.library.workers.*`。
 
-环境说明：
+本轮已执行的重点回归：
 
-- 本轮命令式验证曾因本地 Codex 权限限制部分阻断；如需完整结果请在具备命令权限时重跑。
+- `pytest -q tests/services/test_library_update_service_global_db.py tests/test_app_facade_session_open.py`
+  - 结果：`14 passed`
+  - 用于确认 `prepare_album_open()` / `AppFacade.open_album()` 路径与 async rescan forwarding 已恢复一致。
+
+说明：
+
+- 上述结果足以支撑本步文档结论，但不等于全量 GUI E2E 已完成。
+- 若后续继续修改 `LibraryUpdateService`、`AppFacade.open_album()` 或 `_scan_dependencies()` 契约，应优先重跑上述用例。
+
+## 5.1 已修复回归
+
+- `prepare_album_open()` 曾按旧契约将 `_scan_dependencies()` 解包为 3 个返回值，而 `_scan_dependencies()` 当前仅返回 `(library_root, scan_service)`。
+- 该不一致会在 `AppFacade.open_album()` 主路径上触发 `ValueError`，影响 bound 与 standalone 两类 album-open 流程。
+- 现已修复为按 2 值解包；这类入口契约回归说明本步仍需以 focused regression tests 作为发布前检查项。
 
 ## 6. 下一步交接
 

--- a/docs/refactor/19-gui-update-navigation-session-migration.md
+++ b/docs/refactor/19-gui-update-navigation-session-migration.md
@@ -1,0 +1,81 @@
+# 19 GUI Update + Navigation Session Migration
+
+## Goal
+
+Continue the GUI residual-orchestration cleanup without cutting across Maps or Edit in a broad way.
+
+This slice targets two remaining seams:
+
+- `LibraryUpdateService` still owning scan/pair/finalize/restore-refresh orchestration details.
+- Location / Recently Deleted flows still reaching through GUI code into library/runtime behavior instead of consuming a narrow adapter surface.
+
+The goal of this round is to leave GUI code with presentation coordination, Qt transport, and routing responsibilities only, while reusing the repository's current runtime/library boundary (`LibraryManager` plus bootstrap services and mixins) instead of forcing a parallel session abstraction.
+
+## What Changed
+
+### LibraryUpdate
+
+- Added higher-level runtime scan entry points on `LibraryScanService`:
+  - synchronous rescan
+  - scan finalize hook
+  - restore-refresh rescan entry
+- The runtime finalize hook now centralizes:
+  - Recently Deleted preserved-field merge
+  - snapshot persistence
+  - link rebuild
+  - stale-row reconciliation
+  - optional Live Photo pairing follow-up
+- `RescanWorker` now refreshes restored albums through the runtime scan surface instead of directly composing lifecycle persistence rules.
+- `LibraryUpdateService` no longer imports `ScannerWorker` / `RescanWorker` directly.
+- Worker ownership moved into a dedicated GUI task runner so `LibraryUpdateService` remains a presentation adapter that:
+  - starts or cancels tasks
+  - relays progress and chunk signals
+  - emits `indexUpdated`, `linksUpdated`, and `assetReloadRequested`
+  - keeps facade-facing behavior stable
+
+### Location / Trash
+
+- Added a narrow GUI `LocationTrashNavigationService` for:
+  - Recently Deleted directory preparation
+  - trash cleanup throttling and background dispatch
+  - background geotagged-asset loading
+  - request-serial management for Location reloads
+- `NavigationCoordinator` dropped its trash cleanup thread logic and remains a thin routing binder.
+- `GalleryViewModel` no longer calls `ensure_deleted_directory()` or `get_geotagged_assets()` directly.
+- `GalleryViewModel` now consumes adapter results and keeps only UI state:
+  - static selection
+  - route changes
+  - cluster gallery state
+  - cached location snapshot state
+
+### Guardrails
+
+- Extended architecture checking so `gui/services/library_update_service.py` cannot import `library.workers.*`.
+- Updated targeted GUI regressions to assert the new boundary shape rather than old worker-construction details.
+
+## Behavioral Notes
+
+- `AppFacade` public API shape stays the same; the refactor only changes internal forwarding.
+- The current branch still uses `LibraryManager` and bootstrap runtime services as the effective boundary. This round does not claim a new full `LibrarySession` / `RuntimeContext` rollout where the code does not already use one.
+- Maps runtime extraction is still incomplete. The new Location/Trash adapter is a cleanup seam for future work, not the final Phase 5 port.
+- People residual fallback behavior remains for a later slice.
+
+## Verification
+
+Targeted regressions updated for:
+
+- `LibraryUpdateService` runtime forwarding and task-runner delegation
+- `GalleryViewModel` Recently Deleted and Location flows through the new adapter
+- `NavigationCoordinator` remaining free of direct trash cleanup calls
+- `AppFacade` preserving its public async-rescan forwarding shape
+- architecture boundary checks for `LibraryUpdateService` worker imports
+
+Environment note:
+
+- Final command-based verification was partially blocked by the local Codex escalation limit during this round, so any remaining test execution should be rerun once command access is available again.
+
+## Next Handoff
+
+- Continue with the remaining People fallback/coordinator residuals as the next Phase 4 GUI cleanup slice.
+- When returning to Maps work, build on the new `LocationTrashNavigationService` seam instead of reintroducing direct `LibraryManager` reads into coordinator/viewmodel code.
+- Keep Edit sidecar, full Maps fallback cleanup, and temp-library end-to-end validation out of this slice unless a later round explicitly re-scopes them.

--- a/src/iPhoto/bootstrap/library_scan_service.py
+++ b/src/iPhoto/bootstrap/library_scan_service.py
@@ -15,7 +15,12 @@ from ..application.use_cases.scan_library import (
     ScanLibraryUseCase,
 )
 from ..cache.index_store import get_global_repository
-from ..config import ALBUM_MANIFEST_NAMES, DEFAULT_EXCLUDE, DEFAULT_INCLUDE
+from ..config import (
+    ALBUM_MANIFEST_NAMES,
+    DEFAULT_EXCLUDE,
+    DEFAULT_INCLUDE,
+    RECENTLY_DELETED_DIR_NAME,
+)
 from ..errors import (
     AlbumNotFoundError,
     IndexCorruptedError,
@@ -227,6 +232,32 @@ class LibraryScanService:
             )
         )
 
+    def rescan_album(
+        self,
+        root: Path,
+        *,
+        include: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+        is_cancelled: Callable[[], bool] | None = None,
+        sync_manifest_favorites: bool = False,
+        pair_live: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Synchronously rebuild one scan scope and persist follow-up state."""
+
+        result = self.scan_album(
+            root,
+            include=include,
+            exclude=exclude,
+            progress_callback=progress_callback,
+            is_cancelled=is_cancelled,
+            persist_chunks=False,
+        )
+        rows = self.finalize_scan_result(root, result.rows, pair_live=pair_live)
+        if sync_manifest_favorites:
+            self.sync_manifest_favorites(Path(root))
+        return rows
+
     def finalize_scan(self, root: Path, rows: Iterable[dict[str, Any]]) -> None:
         """Persist additive scan side effects after a successful scan."""
 
@@ -240,6 +271,59 @@ class LibraryScanService:
             repository=repository,
         )
         self.ensure_links_for_rows(scan_root, materialized_rows, repository=repository)
+
+    def finalize_scan_result(
+        self,
+        root: Path,
+        rows: Iterable[dict[str, Any]],
+        *,
+        pair_live: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Persist scan completion side effects for one scope.
+
+        This is the higher-level runtime hook used by GUI adapters after a scan
+        completes. It preserves Recently Deleted restore metadata, persists the
+        snapshot and derived links, prunes stale rows, and optionally refreshes
+        Live Photo pairing state.
+        """
+
+        from .library_asset_lifecycle_service import LibraryAssetLifecycleService
+
+        scan_root = Path(root)
+        lifecycle_service = LibraryAssetLifecycleService(
+            self.library_root,
+            scan_service=self,
+        )
+        materialized_rows = [dict(row) for row in rows]
+
+        if scan_root.name == RECENTLY_DELETED_DIR_NAME:
+            materialized_rows = lifecycle_service.preserve_trash_metadata(
+                scan_root,
+                materialized_rows,
+            )
+
+        self.finalize_scan(scan_root, materialized_rows)
+        lifecycle_service.reconcile_missing_scan_rows(scan_root, materialized_rows)
+        if pair_live:
+            self.pair_album(scan_root)
+        return materialized_rows
+
+    def refresh_restored_album(
+        self,
+        root: Path,
+        *,
+        progress_callback: Callable[[int, int], None] | None = None,
+        is_cancelled: Callable[[], bool] | None = None,
+        pair_live: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Refresh one restored album so gallery state and links stay current."""
+
+        return self.rescan_album(
+            root,
+            progress_callback=progress_callback,
+            is_cancelled=is_cancelled,
+            pair_live=pair_live,
+        )
 
     def reconcile_missing_scan_rows(
         self,

--- a/src/iPhoto/gui/coordinators/location_selection_session.py
+++ b/src/iPhoto/gui/coordinators/location_selection_session.py
@@ -57,6 +57,18 @@ class LocationSelectionSession:
         self._request_serial += 1
         return self._request_serial
 
+    def begin_load_with_serial(self, root: Path, serial: int) -> int:
+        normalized_root = Path(root)
+        if self._root != normalized_root:
+            self._asset_index = {}
+            self._full_assets = []
+            self._list_dirty = False
+            self._has_snapshot = False
+        self._root = normalized_root
+        self._invalidated = True
+        self._request_serial = int(serial)
+        return self._request_serial
+
     def accept_loaded(self, serial: int, root: Path, assets: list) -> bool:
         normalized_root = Path(root)
         if serial != self._request_serial or self._root != normalized_root:

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -44,11 +44,14 @@ from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeControl
 from iPhoto.gui.ui.media import MediaAdjustmentCommitter, MediaSelectionSession
 from iPhoto.gui.ui.models.roles import Roles
 from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
+from iPhoto.gui.services.location_trash_navigation_service import (
+    LocationTrashNavigationService,
+)
+from iPhoto.gui.services.pinned_items_service import PinnedItemsService
 from iPhoto.gui.ui.widgets.asset_delegate import AssetGridDelegate
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailViewModel
 from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAdapter
 from iPhoto.gui.viewmodels.gallery_viewmodel import GalleryViewModel
-from iPhoto.gui.services.pinned_items_service import PinnedItemsService
 from iPhoto.bootstrap.library_people_service import create_people_service
 from iPhoto.people.service import PeopleService
 from maps.map_sources import supports_map_extension_download
@@ -138,12 +141,17 @@ class MainCoordinator(QObject):
 
         # 1. View Router
         self._view_router = ViewRouter(window.ui)
+        self._location_trash_navigation_service = LocationTrashNavigationService(
+            library_manager_getter=lambda: context.library,
+            parent=self,
+        )
 
         self._gallery_vm = GalleryViewModel(
             store=self._gallery_store,
             context=context,
             facade=context.facade,
             asset_service=self._asset_service,
+            location_trash_service=self._location_trash_navigation_service,
         )
 
         # 2. Navigation Coordinator

--- a/src/iPhoto/gui/coordinators/navigation_coordinator.py
+++ b/src/iPhoto/gui/coordinators/navigation_coordinator.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import logging
-import threading
-import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -29,8 +27,6 @@ class NavigationCoordinator(QObject):
     """Thin binder around gallery navigation and location flows."""
 
     bindLibraryRequested = Signal()
-
-    _TRASH_CLEANUP_THROTTLE_SEC = 300.0
     _logger = logging.getLogger(__name__)
 
     def __init__(
@@ -52,9 +48,6 @@ class NavigationCoordinator(QObject):
 
         self._playback_coordinator: Optional[PlaybackCoordinator] = None
 
-        self._trash_cleanup_running = False
-        self._trash_cleanup_lock = threading.Lock()
-        self._last_trash_cleanup_at: Optional[float] = None
         self._suppress_tree_refresh = False
         self._tree_refresh_suppression_reason: Optional[Literal["edit", "operation"]] = None
 
@@ -187,7 +180,6 @@ class NavigationCoordinator(QObject):
 
     def open_recently_deleted(self) -> None:
         self._reset_playback()
-        self._schedule_trash_cleanup()
         self._gallery_vm.open_recently_deleted()
 
     def open_location_view(self) -> None:
@@ -285,28 +277,6 @@ class NavigationCoordinator(QObject):
     def _reset_playback(self) -> None:
         if self._playback_coordinator is not None:
             self._playback_coordinator.reset_for_gallery()
-
-    def _schedule_trash_cleanup(self) -> None:
-        def _cleanup() -> None:
-            try:
-                self._context.library.cleanup_deleted_index()
-            finally:
-                with self._trash_cleanup_lock:
-                    self._trash_cleanup_running = False
-
-        with self._trash_cleanup_lock:
-            should_start = not self._trash_cleanup_running and self._should_run_trash_cleanup()
-            if should_start:
-                self._trash_cleanup_running = True
-                self._last_trash_cleanup_at = time.monotonic()
-
-        if should_start:
-            threading.Thread(target=_cleanup, daemon=True, name="trash-cleanup").start()
-
-    def _should_run_trash_cleanup(self) -> bool:
-        if self._last_trash_cleanup_at is None:
-            return True
-        return (time.monotonic() - self._last_trash_cleanup_at) >= self._TRASH_CLEANUP_THROTTLE_SEC
 
     def suppress_tree_refresh_for_edit(self) -> None:
         self._suppress_tree_refresh = True

--- a/src/iPhoto/gui/services/__init__.py
+++ b/src/iPhoto/gui/services/__init__.py
@@ -4,6 +4,7 @@ from .album_metadata_service import AlbumMetadataService
 from .asset_import_service import AssetImportService
 from .asset_move_service import AssetMoveService
 from .deletion_service import DeletionService
+from .location_trash_navigation_service import LocationTrashNavigationService
 from .library_update_service import LibraryUpdateService, MoveOperationResult
 from .pinned_items_service import PinnedItemsService, PinnedSidebarItem
 from .restoration_service import RestorationService
@@ -13,6 +14,7 @@ __all__ = [
     "AssetImportService",
     "AssetMoveService",
     "DeletionService",
+    "LocationTrashNavigationService",
     "LibraryUpdateService",
     "MoveOperationResult",
     "PinnedItemsService",

--- a/src/iPhoto/gui/services/library_update_service.py
+++ b/src/iPhoto/gui/services/library_update_service.py
@@ -5,19 +5,17 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, TYPE_CHECKING
 
 from PySide6.QtCore import QObject, QTimer, Signal, Slot
 
 from ...bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from ...bootstrap.library_scan_service import LibraryScanService
-from ...config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE, RECENTLY_DELETED_DIR_NAME
+from ...config import DEFAULT_EXCLUDE, DEFAULT_INCLUDE
 from ...errors import IPhotoError
 from ...utils.pathutils import resolve_work_dir
 from ..background_task_manager import BackgroundTaskManager
-# Updated imports to new location
-from ...library.workers.rescan_worker import RescanSignals, RescanWorker
-from ...library.workers.scanner_worker import ScannerSignals, ScannerWorker
+from .library_update_tasks import LibraryUpdateTaskRunner, ScanTaskCompletion
 
 if TYPE_CHECKING:
     from ...library.manager import LibraryManager
@@ -74,11 +72,9 @@ class LibraryUpdateService(QObject):
         parent: Optional[QObject] = None,
     ) -> None:
         super().__init__(parent)
-        self._task_manager = task_manager
+        self._task_runner = LibraryUpdateTaskRunner(task_manager=task_manager)
         self._current_album_getter = current_album_getter
         self._library_manager_getter = library_manager_getter
-        self._scanner_worker: Optional[ScannerWorker] = None
-        self._scan_pending = False
         self._stale_album_roots: Dict[str, Path] = {}
         self._album_root_cache: Dict[str, Optional[Path]] = {}
         self._model_loading_due_to_scan = False
@@ -123,26 +119,17 @@ class LibraryUpdateService(QObject):
     def rescan_album(self, album: "Album") -> List[dict]:
         """Synchronously rebuild the album index and emit cache updates."""
 
-        library_root, scan_service, lifecycle_service = self._scan_dependencies(
-            album.root
-        )
+        library_root, scan_service = self._scan_dependencies(album.root)
         active_scan_service = scan_service or LibraryScanService(
             library_root or album.root
         )
 
         try:
-            result = active_scan_service.scan_album(album.root, persist_chunks=False)
-            active_scan_service.finalize_scan(album.root, result.rows)
-            self._reconcile_scan_scope(
+            rows = active_scan_service.rescan_album(
                 album.root,
-                result.rows,
-                library_root=library_root,
-                scan_service=active_scan_service,
-                lifecycle_service=lifecycle_service,
+                sync_manifest_favorites=scan_service is None and library_root is None,
+                pair_live=True,
             )
-            if scan_service is None and library_root is None:
-                active_scan_service.sync_manifest_favorites(album.root)
-            rows = result.rows
         except IPhotoError as exc:
             self.errorRaised.emit(str(exc))
             return []
@@ -160,63 +147,29 @@ class LibraryUpdateService(QObject):
             lib_manager.start_scanning(album.root, include, exclude)
             return
 
-        library_root, scan_service, _lifecycle_service = self._scan_dependencies(
-            album.root
-        )
-
-        if self._scanner_worker is not None:
-            self._scanner_worker.cancel()
-            self._scan_pending = True
-            return
-
-        signals = ScannerSignals()
-        signals.progressUpdated.connect(self._relay_scan_progress)
-        signals.chunkReady.connect(self._relay_scan_chunk_ready)
-
-        worker = ScannerWorker(
-            album.root,
-            include,
-            exclude,
-            signals,
+        library_root, scan_service = self._scan_dependencies(album.root)
+        self._task_runner.start_scan(
+            root=album.root,
+            include=include,
+            exclude=exclude,
             library_root=library_root,
             scan_service=scan_service,
-        )
-        self._scanner_worker = worker
-        self._scan_pending = False
-
-        self._task_manager.submit_task(
-            task_id=f"scan:{album.root}",
-            worker=worker,
-            progress=signals.progressUpdated,
-            finished=signals.finished,
-            error=signals.error,
-            pause_watcher=False,
-            on_finished=lambda root, rows, captured_library_root=library_root: self._on_scan_finished(
-                worker,
-                root,
-                rows,
-                library_root=captured_library_root,
-            ),
-            on_error=lambda root, message: self._on_scan_error(worker, root, message),
-            result_payload=lambda root, rows: rows,
+            on_progress=self._relay_scan_progress,
+            on_chunk=self._relay_scan_chunk_ready,
+            on_cancelled=self._on_scan_cancelled,
+            on_completed=self._on_scan_completed,
+            on_error=self._on_scan_error,
         )
 
     def cancel_active_scan(self) -> None:
         """Request cancellation of the active scan without scheduling retries."""
 
-        if self._scanner_worker is None:
-            return
-
-        self._scanner_worker.cancel()
-        # Cancelling a scan should not schedule immediate retry attempts.
-        self._scan_pending = False
+        self._task_runner.cancel_active_scan()
 
     def pair_live(self, album: "Album") -> List[dict]:
         """Rebuild Live Photo pairings for *album* and refresh related views."""
 
-        library_root, scan_service, _lifecycle_service = self._scan_dependencies(
-            album.root
-        )
+        library_root, scan_service = self._scan_dependencies(album.root)
 
         try:
             active_scan_service = scan_service or LibraryScanService(
@@ -453,109 +406,49 @@ class LibraryUpdateService(QObject):
 
         self.scanChunkReady.emit(root, chunk)
 
-    def _on_scan_finished(
+    def _on_scan_cancelled(self, root: Path, restart_requested: bool) -> None:
+        self.scanFinished.emit(root, True)
+        if restart_requested:
+            self._schedule_scan_retry()
+
+    def _on_scan_completed(
         self,
-        worker: ScannerWorker,
-        root: Path,
-        rows: Sequence[dict],
-        *,
-        library_root: Path | None = None,
+        completion: ScanTaskCompletion,
     ) -> None:
-        if self._scanner_worker is not worker:
-            return
-
-        if worker.cancelled:
-            self.scanFinished.emit(root, True)
-            should_restart = self._scan_pending
-            self._cleanup_scan_worker()
-            if should_restart:
-                self._schedule_scan_retry()
-            return
-
-        if worker.failed:
-            self.scanFinished.emit(root, False)
-            should_restart = self._scan_pending
-            self._cleanup_scan_worker()
-            if should_restart:
-                self._schedule_scan_retry()
-            return
-
-        if library_root is None:
-            library_root = getattr(worker, "library_root", None)
-
-        materialised_rows = list(rows)
-
-        if root.name == RECENTLY_DELETED_DIR_NAME:
-            library = self._library_manager()
-            lifecycle_service = (
-                getattr(library, "asset_lifecycle_service", None)
-                if library is not None
-                else None
-            ) or LibraryAssetLifecycleService(library_root)
-            materialised_rows = lifecycle_service.preserve_trash_metadata(
-                root,
-                materialised_rows,
-            )
-
         try:
-            # Persist the freshly computed index snapshot immediately so future
-            # reloads observe the new metadata rather than the stale cache that
-            # existed before the rescan.  The worker keeps the result in memory,
-            # therefore we flush the global index and ``links.json`` here to
-            # mirror the historical facade behaviour before notifying listeners.
-            worker.scan_service.finalize_scan(root, materialised_rows)
-            lifecycle_service = None
-            library = self._library_manager()
-            if library is not None:
-                lifecycle_service = getattr(library, "asset_lifecycle_service", None)
-            self._reconcile_scan_scope(
-                root,
-                materialised_rows,
-                library_root=library_root,
-                scan_service=worker.scan_service,
-                lifecycle_service=lifecycle_service,
+            completion.scan_service.finalize_scan_result(
+                completion.root,
+                completion.rows,
+                pair_live=True,
             )
         except IPhotoError as exc:
             self.errorRaised.emit(str(exc))
-            self.scanFinished.emit(root, False)
+            self.scanFinished.emit(completion.root, False)
         else:
-            self.indexUpdated.emit(root)
-            self.linksUpdated.emit(root)
+            self.indexUpdated.emit(completion.root)
+            self.linksUpdated.emit(completion.root)
             # Ensure the view reloads if this scan was triggered for the current album
             # (e.g. initial auto-scan on startup).
             # Only emit assetReloadRequested if the model is not already loading due to this scan
             if not self._model_loading_due_to_scan:
-                self.assetReloadRequested.emit(root, False, False)
+                self.assetReloadRequested.emit(completion.root, False, False)
             self._model_loading_due_to_scan = False
-            self.scanFinished.emit(root, True)
+            self.scanFinished.emit(completion.root, True)
 
-        should_restart = self._scan_pending
-        self._cleanup_scan_worker()
-
-        if should_restart:
+        if completion.restart_requested:
             self._schedule_scan_retry()
 
     def _on_scan_error(
         self,
-        worker: ScannerWorker,
         root: Path,
         message: str,
+        restart_requested: bool,
     ) -> None:
-        if self._scanner_worker is not worker:
-            return
-
         self.errorRaised.emit(message)
         self.scanFinished.emit(root, False)
 
-        should_restart = self._scan_pending
-        self._cleanup_scan_worker()
-
-        if should_restart:
+        if restart_requested:
             self._schedule_scan_retry()
-
-    def _cleanup_scan_worker(self) -> None:
-        self._scanner_worker = None
-        self._scan_pending = False
 
     def _scan_dependencies(
         self,
@@ -563,40 +456,22 @@ class LibraryUpdateService(QObject):
     ) -> tuple[
         Path | None,
         LibraryScanService | None,
-        LibraryAssetLifecycleService | None,
     ]:
         library_root: Path | None = None
         scan_service: LibraryScanService | None = None
-        lifecycle_service: LibraryAssetLifecycleService | None = None
         library = self._library_manager()
         if library is not None:
             library_root = library.root()
             scan_service = getattr(library, "scan_service", None)
-            lifecycle_service = getattr(library, "asset_lifecycle_service", None)
         if library_root is None:
             root = Path(root)
-        return library_root, scan_service, lifecycle_service
+        return library_root, scan_service
 
     def _scan_filters(self, album: "Album") -> tuple[Iterable[str], Iterable[str]]:
         filters = album.manifest.get("filters", {}) if isinstance(album.manifest, dict) else {}
         include: Iterable[str] = filters.get("include", DEFAULT_INCLUDE)
         exclude: Iterable[str] = filters.get("exclude", DEFAULT_EXCLUDE)
         return include, exclude
-
-    def _reconcile_scan_scope(
-        self,
-        root: Path,
-        rows: Iterable[dict],
-        *,
-        library_root: Path | None,
-        scan_service: LibraryScanService | None,
-        lifecycle_service: LibraryAssetLifecycleService | None,
-    ) -> int:
-        active_lifecycle = lifecycle_service or LibraryAssetLifecycleService(
-            library_root or root,
-            scan_service=scan_service,
-        )
-        return active_lifecycle.reconcile_missing_scan_rows(root, rows)
 
     def _schedule_scan_retry(self) -> None:
         QTimer.singleShot(0, self._retry_scan_if_album_available)
@@ -702,21 +577,8 @@ class LibraryUpdateService(QObject):
         if not album_root.exists():
             return
 
-        signals = RescanSignals()
         library = self._library_manager()
         scan_service = getattr(library, "scan_service", None) if library is not None else None
-        lifecycle_service = (
-            getattr(library, "asset_lifecycle_service", None)
-            if library is not None
-            else None
-        )
-        worker = RescanWorker(
-            album_root,
-            signals,
-            library_root=library_root,
-            scan_service=scan_service,
-            asset_lifecycle_service=lifecycle_service,
-        )
         task_id = self._build_restore_rescan_task_id(album_root)
 
         def _on_finished(path: Path, succeeded: bool) -> None:
@@ -745,15 +607,13 @@ class LibraryUpdateService(QObject):
         def _on_error(path: Path, message: str) -> None:
             self.errorRaised.emit(f"Failed to refresh '{path.name}': {message}")
 
-        self._task_manager.submit_task(
+        self._task_runner.start_restore_refresh(
+            root=album_root,
             task_id=task_id,
-            worker=worker,
-            finished=signals.finished,
-            error=signals.error,
-            pause_watcher=False,
+            library_root=library_root,
+            scan_service=scan_service,
             on_finished=_on_finished,
             on_error=_on_error,
-            result_payload=lambda path, succeeded: (path, succeeded),
         )
 
     def _build_restore_rescan_task_id(self, album_root: Path) -> str:

--- a/src/iPhoto/gui/services/library_update_service.py
+++ b/src/iPhoto/gui/services/library_update_service.py
@@ -93,7 +93,7 @@ class LibraryUpdateService(QObject):
         """Prepare one album open through the active session scan surface."""
 
         scan_root = Path(root)
-        library_root, scan_service, _lifecycle_service = self._scan_dependencies(scan_root)
+        library_root, scan_service = self._scan_dependencies(scan_root)
         active_scan_service = scan_service or LibraryScanService(library_root or scan_root)
         preparation = active_scan_service.prepare_album_open(
             scan_root,

--- a/src/iPhoto/gui/services/library_update_tasks.py
+++ b/src/iPhoto/gui/services/library_update_tasks.py
@@ -1,0 +1,184 @@
+"""Qt task transport for library update scans and restore refreshes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...bootstrap.library_scan_service import LibraryScanService
+from ..background_task_manager import BackgroundTaskManager
+from ...library.workers.rescan_worker import RescanSignals, RescanWorker
+from ...library.workers.scanner_worker import ScannerSignals, ScannerWorker
+
+
+@dataclass(frozen=True)
+class ScanTaskCompletion:
+    """Normalized scan completion payload for GUI presentation adapters."""
+
+    root: Path
+    rows: list[dict]
+    scan_service: LibraryScanService
+    library_root: Path | None
+    restart_requested: bool = False
+
+
+class LibraryUpdateTaskRunner:
+    """Own worker lifecycle and task-manager wiring for library updates."""
+
+    def __init__(self, *, task_manager: BackgroundTaskManager) -> None:
+        self._task_manager = task_manager
+        self._scanner_worker: ScannerWorker | None = None
+        self._scan_pending = False
+
+    def start_scan(
+        self,
+        *,
+        root: Path,
+        include: Iterable[str],
+        exclude: Iterable[str],
+        library_root: Path | None,
+        scan_service: LibraryScanService | None,
+        on_progress: Callable[[Path, int, int], None],
+        on_chunk: Callable[[Path, list[dict]], None],
+        on_cancelled: Callable[[Path, bool], None],
+        on_completed: Callable[[ScanTaskCompletion], None],
+        on_error: Callable[[Path, str, bool], None],
+    ) -> None:
+        """Submit an asynchronous scan task or request a restart."""
+
+        if self._scanner_worker is not None:
+            self._scanner_worker.cancel()
+            self._scan_pending = True
+            return
+
+        signals = ScannerSignals()
+        signals.progressUpdated.connect(on_progress)
+        signals.chunkReady.connect(on_chunk)
+
+        worker = ScannerWorker(
+            root,
+            include,
+            exclude,
+            signals,
+            library_root=library_root,
+            scan_service=scan_service,
+        )
+        self._scanner_worker = worker
+        self._scan_pending = False
+
+        self._task_manager.submit_task(
+            task_id=f"scan:{root}",
+            worker=worker,
+            progress=signals.progressUpdated,
+            finished=signals.finished,
+            error=signals.error,
+            pause_watcher=False,
+            on_finished=lambda emitted_root, rows, captured_library_root=library_root: self._handle_scan_finished(
+                worker,
+                emitted_root,
+                rows,
+                library_root=captured_library_root,
+                on_cancelled=on_cancelled,
+                on_completed=on_completed,
+            ),
+            on_error=lambda emitted_root, message: self._handle_scan_error(
+                worker,
+                emitted_root,
+                message,
+                on_error=on_error,
+            ),
+            result_payload=lambda _root, rows: rows,
+        )
+
+    def cancel_active_scan(self) -> None:
+        """Cancel the active scan without scheduling a retry."""
+
+        if self._scanner_worker is None:
+            return
+        self._scanner_worker.cancel()
+        self._scan_pending = False
+
+    def start_restore_refresh(
+        self,
+        *,
+        root: Path,
+        task_id: str,
+        library_root: Path | None,
+        scan_service: LibraryScanService | None,
+        on_finished: Callable[[Path, bool], None],
+        on_error: Callable[[Path, str], None],
+    ) -> None:
+        """Submit a restored-album refresh task."""
+
+        signals = RescanSignals()
+        worker = RescanWorker(
+            root,
+            signals,
+            library_root=library_root,
+            scan_service=scan_service,
+        )
+        self._task_manager.submit_task(
+            task_id=task_id,
+            worker=worker,
+            progress=signals.progressUpdated,
+            finished=signals.finished,
+            error=signals.error,
+            pause_watcher=False,
+            on_finished=on_finished,
+            on_error=on_error,
+            result_payload=lambda path, ok: (path, ok),
+        )
+
+    def _handle_scan_finished(
+        self,
+        worker: ScannerWorker,
+        root: Path,
+        rows: list[dict],
+        *,
+        library_root: Path | None,
+        on_cancelled: Callable[[Path, bool], None],
+        on_completed: Callable[[ScanTaskCompletion], None],
+    ) -> None:
+        if self._scanner_worker is not worker:
+            return
+
+        restart_requested = self._scan_pending
+        if worker.cancelled:
+            self._cleanup_scan_worker()
+            on_cancelled(root, restart_requested)
+            return
+
+        if worker.failed:
+            self._cleanup_scan_worker()
+            return
+
+        completion = ScanTaskCompletion(
+            root=Path(root),
+            rows=[dict(row) for row in rows],
+            scan_service=worker.scan_service,
+            library_root=library_root,
+            restart_requested=restart_requested,
+        )
+        self._cleanup_scan_worker()
+        on_completed(completion)
+
+    def _handle_scan_error(
+        self,
+        worker: ScannerWorker,
+        root: Path,
+        message: str,
+        *,
+        on_error: Callable[[Path, str, bool], None],
+    ) -> None:
+        if self._scanner_worker is not worker:
+            return
+
+        restart_requested = self._scan_pending
+        self._cleanup_scan_worker()
+        on_error(root, message, restart_requested)
+
+    def _cleanup_scan_worker(self) -> None:
+        self._scanner_worker = None
+        self._scan_pending = False
+

--- a/src/iPhoto/gui/services/location_trash_navigation_service.py
+++ b/src/iPhoto/gui/services/location_trash_navigation_service.py
@@ -1,0 +1,197 @@
+"""GUI transport adapter for Location and Recently Deleted navigation flows."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
+
+if TYPE_CHECKING:
+    from ...library.manager import LibraryManager
+
+
+class _LocationAssetsSignals(QObject):
+    finished = Signal(int, Path, list)
+    error = Signal(int, Path, str)
+
+
+class _LocationAssetsWorker(QRunnable):
+    def __init__(
+        self,
+        *,
+        serial: int,
+        root: Path,
+        load_assets: Callable[[], list],
+        signals: _LocationAssetsSignals,
+    ) -> None:
+        super().__init__()
+        self.setAutoDelete(True)
+        self._serial = int(serial)
+        self._root = Path(root)
+        self._load_assets = load_assets
+        self._signals = signals
+
+    def run(self) -> None:  # pragma: no cover - background Qt task
+        try:
+            assets = list(self._load_assets())
+        except Exception as exc:  # noqa: BLE001 - best-effort UI transport
+            self._signals.error.emit(self._serial, self._root, str(exc))
+            return
+        self._signals.finished.emit(self._serial, self._root, assets)
+
+
+class _TrashCleanupSignals(QObject):
+    finished = Signal()
+
+
+class _TrashCleanupWorker(QRunnable):
+    def __init__(
+        self,
+        *,
+        cleanup: Callable[[], int],
+        signals: _TrashCleanupSignals,
+    ) -> None:
+        super().__init__()
+        self.setAutoDelete(True)
+        self._cleanup = cleanup
+        self._signals = signals
+
+    def run(self) -> None:  # pragma: no cover - background Qt task
+        try:
+            self._cleanup()
+        finally:
+            self._signals.finished.emit()
+
+
+class LocationTrashNavigationService(QObject):
+    """Own background transport and request state for Location/Trash flows."""
+
+    locationAssetsLoaded = Signal(int, Path, list)
+    errorRaised = Signal(str)
+
+    _TRASH_CLEANUP_THROTTLE_SEC = 300.0
+
+    def __init__(
+        self,
+        *,
+        library_manager_getter: Callable[[], "LibraryManager | None"],
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._library_manager_getter = library_manager_getter
+        self._thread_pool = QThreadPool.globalInstance()
+        self._location_request_serial = 0
+        self._location_signals: dict[int, _LocationAssetsSignals] = {}
+        self._trash_cleanup_running = False
+        self._trash_cleanup_lock = threading.Lock()
+        self._last_trash_cleanup_at: float | None = None
+        self._trash_cleanup_signals: _TrashCleanupSignals | None = None
+
+    def prepare_recently_deleted(self) -> Path | None:
+        """Return the deleted-items root and trigger best-effort cleanup."""
+
+        library = self._library_manager()
+        if library is None:
+            return None
+        try:
+            deleted_root = library.ensure_deleted_directory()
+        except Exception as exc:  # noqa: BLE001 - surface to GUI
+            self.errorRaised.emit(str(exc))
+            return None
+        self._schedule_trash_cleanup(library)
+        return deleted_root
+
+    def request_location_assets(self) -> tuple[int, Path] | None:
+        """Load geotagged assets in the background and return the request token."""
+
+        library = self._library_manager()
+        if library is None:
+            return None
+        root = library.root()
+        if root is None:
+            return None
+
+        self._location_request_serial += 1
+        serial = self._location_request_serial
+        signals = _LocationAssetsSignals()
+        signals.finished.connect(self._handle_location_assets_finished)
+        signals.error.connect(self._handle_location_assets_error)
+        self._location_signals[serial] = signals
+        self._thread_pool.start(
+            _LocationAssetsWorker(
+                serial=serial,
+                root=root,
+                load_assets=lambda: list(library.get_geotagged_assets()),
+                signals=signals,
+            )
+        )
+        return serial, root
+
+    def _handle_location_assets_finished(
+        self,
+        serial: int,
+        root: Path,
+        assets: list,
+    ) -> None:
+        signals = self._location_signals.pop(int(serial), None)
+        if signals is not None:
+            signals.deleteLater()
+        if int(serial) != self._location_request_serial:
+            return
+        self.locationAssetsLoaded.emit(int(serial), Path(root), list(assets))
+
+    def _handle_location_assets_error(
+        self,
+        serial: int,
+        _root: Path,
+        message: str,
+    ) -> None:
+        signals = self._location_signals.pop(int(serial), None)
+        if signals is not None:
+            signals.deleteLater()
+        if int(serial) != self._location_request_serial:
+            return
+        self.errorRaised.emit(message)
+
+    def _schedule_trash_cleanup(self, library: "LibraryManager") -> None:
+        with self._trash_cleanup_lock:
+            should_start = (
+                not self._trash_cleanup_running and self._should_run_trash_cleanup()
+            )
+            if not should_start:
+                return
+            self._trash_cleanup_running = True
+            self._last_trash_cleanup_at = time.monotonic()
+
+        signals = _TrashCleanupSignals()
+        signals.finished.connect(self._handle_trash_cleanup_finished)
+        self._trash_cleanup_signals = signals
+        self._thread_pool.start(
+            _TrashCleanupWorker(
+                cleanup=library.cleanup_deleted_index,
+                signals=signals,
+            )
+        )
+
+    def _handle_trash_cleanup_finished(self) -> None:
+        with self._trash_cleanup_lock:
+            self._trash_cleanup_running = False
+        signals = self._trash_cleanup_signals
+        self._trash_cleanup_signals = None
+        if signals is not None:
+            signals.deleteLater()
+
+    def _should_run_trash_cleanup(self) -> bool:
+        if self._last_trash_cleanup_at is None:
+            return True
+        return (
+            time.monotonic() - self._last_trash_cleanup_at
+        ) >= self._TRASH_CLEANUP_THROTTLE_SEC
+
+    def _library_manager(self) -> "LibraryManager | None":
+        return self._library_manager_getter()
+

--- a/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/gallery_viewmodel.py
@@ -14,6 +14,9 @@ from iPhoto.domain.models.query import AssetQuery
 from iPhoto.gui.ui.menus.core import MenuContext
 from iPhoto.gui.coordinators.location_selection_session import LocationSelectionSession
 from iPhoto.gui.facade import AppFacade
+from iPhoto.gui.services.location_trash_navigation_service import (
+    LocationTrashNavigationService,
+)
 from iPhoto.library.geo_aggregator import geotagged_asset_from_row
 from iPhoto.people.service import PeopleService
 
@@ -33,6 +36,7 @@ class GalleryViewModel(BaseViewModel):
         facade: AppFacade,
         asset_service: AssetService,
         location_session: LocationSelectionSession | None = None,
+        location_trash_service: LocationTrashNavigationService | None = None,
     ) -> None:
         super().__init__()
         self._store = store
@@ -40,6 +44,9 @@ class GalleryViewModel(BaseViewModel):
         self._facade = facade
         self._asset_service = asset_service
         self._location_session = location_session or LocationSelectionSession()
+        self._location_trash_service = location_trash_service or LocationTrashNavigationService(
+            library_manager_getter=lambda: self._context.library,
+        )
         self._cluster_gallery_origin: Literal["location", "people", None] = None
         self._people_cluster_kind: Literal["person", "group", None] = None
         self._people_cluster_id: str | None = None
@@ -59,6 +66,13 @@ class GalleryViewModel(BaseViewModel):
         self.cluster_gallery_mode_changed = Signal()
         self.sidebar_path_requested = Signal()
         self.message_requested = Signal()
+
+        self._location_trash_service.locationAssetsLoaded.connect(
+            self._handle_location_assets_loaded
+        )
+        self._location_trash_service.errorRaised.connect(
+            lambda message: self.message_requested.emit(message, 3000)
+        )
 
     @property
     def location_session(self) -> LocationSelectionSession:
@@ -122,7 +136,9 @@ class GalleryViewModel(BaseViewModel):
         if root is None:
             self.bind_library_requested.emit()
             return
-        deleted_root = self._context.library.ensure_deleted_directory()
+        deleted_root = self._location_trash_service.prepare_recently_deleted()
+        if deleted_root is None:
+            return
         self._facade.open_album(deleted_root)
         self._clear_location_context()
         self._clear_cluster_gallery_context()
@@ -205,10 +221,7 @@ class GalleryViewModel(BaseViewModel):
             self.map_assets_changed.emit(self._location_session.full_assets(), root)
             return
 
-        request_serial = self._location_session.begin_load(root)
-        assets = list(self._context.library.get_geotagged_assets())
-        self._location_session.accept_loaded(request_serial, root, assets)
-        self.map_assets_changed.emit(self._location_session.full_assets(), root)
+        self._request_location_assets(root)
 
     def open_location_asset(self, rel: str) -> None:
         root = self._context.library.root()
@@ -398,7 +411,25 @@ class GalleryViewModel(BaseViewModel):
                 self._location_session.invalidate()
             return
 
-        self._location_session.replace_assets(list(self._context.library.get_geotagged_assets()))
+        self._request_location_assets(root)
+
+    def _request_location_assets(self, root: Path) -> None:
+        request = self._location_trash_service.request_location_assets()
+        if request is None:
+            return
+        serial, request_root = request
+        if request_root != root:
+            root = request_root
+        self._location_session.begin_load_with_serial(root, serial)
+
+    def _handle_location_assets_loaded(
+        self,
+        serial: int,
+        root: Path,
+        assets: list,
+    ) -> None:
+        if not self._location_session.accept_loaded(serial, root, list(assets)):
+            return
         if self._location_session.mode == "map":
             self.map_assets_changed.emit(self._location_session.full_assets(), root)
 

--- a/src/iPhoto/library/scan_coordinator.py
+++ b/src/iPhoto/library/scan_coordinator.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
 from PySide6.QtCore import QMutexLocker, QRunnable
 
-from ..bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from ..bootstrap.library_asset_query_service import LibraryAssetQueryService
 from ..bootstrap.library_scan_service import LibraryScanService
 from ..utils.logging import get_logger
@@ -337,14 +336,7 @@ class ScanCoordinatorMixin:
         # links.json reflect the latest scan results.
         scan_service = worker.scan_service
         try:
-            scan_service.finalize_scan(root, rows)
-            lifecycle_service = getattr(self, "asset_lifecycle_service", None)
-            if lifecycle_service is None:
-                lifecycle_service = LibraryAssetLifecycleService(
-                    self._root or root,
-                    scan_service=scan_service,
-                )
-            lifecycle_service.reconcile_missing_scan_rows(root, rows)
+            scan_service.finalize_scan_result(root, rows, pair_live=False)
         except Exception as exc:
             LOGGER.warning("Failed to persist scan finalization for %s: %s", root, exc)
 

--- a/src/iPhoto/library/workers/rescan_worker.py
+++ b/src/iPhoto/library/workers/rescan_worker.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from PySide6.QtCore import QObject, QRunnable, Signal
 
-from ...bootstrap.library_asset_lifecycle_service import LibraryAssetLifecycleService
 from ...bootstrap.library_scan_service import LibraryScanService
 from ...errors import IPhotoError
 
@@ -29,7 +28,6 @@ class RescanWorker(QRunnable):
         *,
         library_root: Path | None = None,
         scan_service: LibraryScanService | None = None,
-        asset_lifecycle_service: LibraryAssetLifecycleService | None = None,
     ) -> None:
         super().__init__()
         self.setAutoDelete(False)
@@ -37,7 +35,6 @@ class RescanWorker(QRunnable):
         self._signals = signals
         self._library_root = library_root
         self._scan_service = scan_service
-        self._asset_lifecycle_service = asset_lifecycle_service
 
     @property
     def root(self) -> Path:
@@ -65,17 +62,6 @@ class RescanWorker(QRunnable):
             self._scan_service = LibraryScanService(self._library_root or self._root)
         return self._scan_service
 
-    @property
-    def asset_lifecycle_service(self) -> LibraryAssetLifecycleService:
-        """Return the lifecycle service used for explicit scan reconciliation."""
-
-        if self._asset_lifecycle_service is None:
-            self._asset_lifecycle_service = LibraryAssetLifecycleService(
-                self._library_root or self._root,
-                scan_service=self.scan_service,
-            )
-        return self._asset_lifecycle_service
-
     def run(self) -> None:  # pragma: no cover - executed on worker thread
         """Perform the rescan and emit the outcome back to the GUI thread."""
 
@@ -84,15 +70,10 @@ class RescanWorker(QRunnable):
             def progress_callback(processed: int, total: int) -> None:
                 self._signals.progressUpdated.emit(self._root, processed, total)
 
-            result = self.scan_service.scan_album(
+            self.scan_service.refresh_restored_album(
                 self._root,
                 progress_callback=progress_callback,
-                persist_chunks=False,
-            )
-            self.scan_service.finalize_scan(self._root, result.rows)
-            self.asset_lifecycle_service.reconcile_missing_scan_rows(
-                self._root,
-                result.rows,
+                pair_live=True,
             )
         except IPhotoError as exc:
             # Surface domain-specific failures with the album path attached so the

--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -99,3 +99,21 @@ def test_gui_runtime_backend_import_is_blocked(tmp_path: Path) -> None:
         "GUI runtime imports compatibility backend iPhoto.app" in violation
         for violation in violations
     )
+
+
+def test_gui_library_update_service_worker_import_is_blocked(tmp_path: Path) -> None:
+    source = tmp_path / "iPhoto"
+    module = source / "gui" / "services" / "library_update_service.py"
+    module.parent.mkdir(parents=True)
+    module.write_text(
+        "from iPhoto.library.workers.scanner_worker import ScannerWorker\n",
+        encoding="utf-8",
+    )
+
+    violations = check_layer_boundaries.check(source)
+
+    assert any(
+        "GUI library update service imports worker implementation detail "
+        "iPhoto.library.workers.scanner_worker" in violation
+        for violation in violations
+    )

--- a/tests/gui/viewmodels/test_gallery_viewmodel.py
+++ b/tests/gui/viewmodels/test_gallery_viewmodel.py
@@ -16,19 +16,63 @@ from iPhoto.gui.viewmodels.gallery_viewmodel import GalleryViewModel
 from iPhoto.domain.models.query import AssetQuery
 
 
-def _make_vm(*, library_root: Path | None = None):
+class _FakeSignal:
+    def __init__(self) -> None:
+        self._handlers: list = []
+
+    def connect(self, handler) -> None:
+        self._handlers.append(handler)
+
+    def emit(self, *args) -> None:
+        for handler in list(self._handlers):
+            handler(*args)
+
+
+class FakeLocationTrashService:
+    def __init__(self, library_root: Path | None = None) -> None:
+        self._library_root = library_root
+        self.deleted_root = (
+            library_root / RECENTLY_DELETED_DIR_NAME if library_root is not None else None
+        )
+        self.locationAssetsLoaded = _FakeSignal()
+        self.errorRaised = _FakeSignal()
+        self.prepared_calls = 0
+        self.location_requests = 0
+
+    def prepare_recently_deleted(self) -> Path | None:
+        self.prepared_calls += 1
+        return self.deleted_root
+
+    def request_location_assets(self) -> tuple[int, Path] | None:
+        if self._library_root is None:
+            return None
+        self.location_requests += 1
+        return self.location_requests, self._library_root
+
+
+def _make_vm(
+    *,
+    library_root: Path | None = None,
+    location_trash_service: FakeLocationTrashService | None = None,
+    return_service: bool = False,
+):
     store = MagicMock()
     context = MagicMock()
     context.library.root.return_value = library_root
     facade = MagicMock()
     asset_service = MagicMock()
+    nav_service = location_trash_service or FakeLocationTrashService(library_root)
     vm = GalleryViewModel(
         store=store,
         context=context,
         facade=facade,
         asset_service=asset_service,
+        location_trash_service=nav_service,
     )
-    return vm, store, context, facade, asset_service
+    result = (vm, store, context, facade, asset_service, nav_service)
+    if return_service:
+        return result
+    return result[:-1]
 
 
 def _face_repository(library_root: Path) -> FaceRepository:
@@ -128,8 +172,13 @@ def test_open_all_photos_loads_root_query(tmp_path: Path) -> None:
 def test_open_recently_deleted_uses_deleted_root(tmp_path: Path) -> None:
     library_root = tmp_path / "Library"
     deleted_root = library_root / RECENTLY_DELETED_DIR_NAME
-    vm, store, context, _facade, _asset_service = _make_vm(library_root=library_root)
-    context.library.ensure_deleted_directory.return_value = deleted_root
+    location_service = FakeLocationTrashService(library_root)
+    location_service.deleted_root = deleted_root
+    vm, store, context, _facade, _asset_service, nav_service = _make_vm(
+        library_root=library_root,
+        location_trash_service=location_service,
+        return_service=True,
+    )
 
     vm.open_recently_deleted()
 
@@ -138,6 +187,8 @@ def test_open_recently_deleted_uses_deleted_root(tmp_path: Path) -> None:
     query = store.load_selection.call_args.kwargs["query"]
     assert active_root == deleted_root
     assert query.album_path == RECENTLY_DELETED_DIR_NAME
+    assert nav_service.prepared_calls == 1
+    context.library.ensure_deleted_directory.assert_not_called()
 
 
 def test_open_filtered_collection_sets_media_types(tmp_path: Path) -> None:
@@ -147,6 +198,19 @@ def test_open_filtered_collection_sets_media_types(tmp_path: Path) -> None:
 
     query = store.load_selection.call_args.kwargs["query"]
     assert query.media_types == [MediaType.VIDEO]
+
+
+def test_open_location_map_requests_assets_through_navigation_service(tmp_path: Path) -> None:
+    vm, _store, context, _facade, _asset_service, nav_service = _make_vm(
+        library_root=tmp_path,
+        return_service=True,
+    )
+
+    vm.open_location_map()
+
+    assert nav_service.location_requests == 1
+    assert vm.location_session.request_serial == 1
+    context.library.get_geotagged_assets.assert_not_called()
 
 
 def test_open_location_asset_opens_singleton_cluster_gallery(tmp_path: Path) -> None:
@@ -276,18 +340,22 @@ def test_location_scan_chunk_updates_snapshot_without_refreshing_cluster_gallery
 
 
 def test_location_scan_finished_rebuilds_snapshot_and_refreshes_map(tmp_path: Path) -> None:
-    vm, _store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    vm, _store, _context, _facade, _asset_service, nav_service = _make_vm(
+        library_root=tmp_path,
+        return_service=True,
+    )
     existing = SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")
     refreshed = SimpleNamespace(library_relative="Album/final.jpg", absolute_path=tmp_path / "Album" / "final.jpg")
     serial = vm.location_session.begin_load(tmp_path)
     assert vm.location_session.accept_loaded(serial, tmp_path, [existing])
     vm.location_session.set_mode("map")
-    context.library.get_geotagged_assets.return_value = [refreshed]
 
     payloads = []
     vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
 
     vm.handle_location_scan_finished(tmp_path / "Album", True)
+    assert nav_service.location_requests == 1
+    nav_service.locationAssetsLoaded.emit(1, tmp_path, [refreshed])
 
     snapshot = vm.location_session.full_assets()
     assert snapshot == [refreshed]
@@ -295,11 +363,10 @@ def test_location_scan_finished_rebuilds_snapshot_and_refreshes_map(tmp_path: Pa
 
 
 def test_location_scan_updates_ignore_unrelated_scan_roots(tmp_path: Path) -> None:
-    vm, _store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    vm, _store, _context, _facade, _asset_service = _make_vm(library_root=tmp_path)
     serial = vm.location_session.begin_load(tmp_path)
     assert vm.location_session.accept_loaded(serial, tmp_path, [])
     vm.location_session.set_mode("map")
-    context.library.get_geotagged_assets.return_value = [SimpleNamespace(library_relative="x.jpg")]
 
     payloads = []
     vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
@@ -339,19 +406,23 @@ def test_location_scan_chunk_invalidates_cached_snapshot_while_location_is_inact
 
 
 def test_open_location_map_reloads_after_inactive_snapshot_was_invalidated_by_scan(tmp_path: Path) -> None:
-    vm, _store, context, _facade, _asset_service = _make_vm(library_root=tmp_path)
+    vm, _store, _context, _facade, _asset_service, nav_service = _make_vm(
+        library_root=tmp_path,
+        return_service=True,
+    )
     stale = SimpleNamespace(library_relative="a.jpg", absolute_path=tmp_path / "a.jpg")
     refreshed = SimpleNamespace(library_relative="Album/new.jpg", absolute_path=tmp_path / "Album" / "new.jpg")
     serial = vm.location_session.begin_load(tmp_path)
     assert vm.location_session.accept_loaded(serial, tmp_path, [stale])
     vm.location_session.set_mode("inactive")
-    context.library.get_geotagged_assets.return_value = [refreshed]
 
     payloads = []
     vm.map_assets_changed.connect(lambda loaded_assets, root: payloads.append((loaded_assets, root)))
 
     vm.handle_location_scan_finished(tmp_path / "Album", True)
     vm.open_location_map()
+    assert nav_service.location_requests == 1
+    nav_service.locationAssetsLoaded.emit(1, tmp_path, [refreshed])
 
     assert vm.location_session.invalidated is False
     assert vm.location_session.full_assets() == [refreshed]
@@ -463,8 +534,12 @@ def test_pinned_group_context_menu_state_exposes_group_gallery_semantics(tmp_pat
 def test_recently_deleted_context_menu_state_marks_deleted_surface(tmp_path: Path) -> None:
     library_root = tmp_path / "Library"
     deleted_root = library_root / RECENTLY_DELETED_DIR_NAME
-    vm, _store, context, _facade, _asset_service = _make_vm(library_root=library_root)
-    context.library.ensure_deleted_directory.return_value = deleted_root
+    location_service = FakeLocationTrashService(library_root)
+    location_service.deleted_root = deleted_root
+    vm, _store, _context, _facade, _asset_service = _make_vm(
+        library_root=library_root,
+        location_trash_service=location_service,
+    )
 
     vm.open_recently_deleted()
 

--- a/tests/services/test_library_update_service_global_db.py
+++ b/tests/services/test_library_update_service_global_db.py
@@ -40,19 +40,20 @@ class DummyLibrary:
 class FakeScanService:
     def __init__(self) -> None:
         self.prepared: list[dict] = []
-        self.scanned: list[tuple[Path, bool]] = []
-        self.finalized: list[tuple[Path, list[dict]]] = []
+        self.rescanned: list[dict] = []
+        self.paired: list[Path] = []
 
     def prepare_album_open(self, root: Path, **kwargs):
         self.prepared.append({"root": Path(root), **kwargs})
         return SimpleNamespace(asset_count=1, scanned=False)
 
-    def scan_album(self, root: Path, *, persist_chunks: bool):
-        self.scanned.append((root, persist_chunks))
-        return SimpleNamespace(rows=[{"rel": "a.jpg"}])
+    def rescan_album(self, root: Path, **kwargs):
+        self.rescanned.append({"root": Path(root), **kwargs})
+        return [{"rel": "a.jpg"}]
 
-    def finalize_scan(self, root: Path, rows: list[dict]) -> None:
-        self.finalized.append((root, rows))
+    def pair_album(self, root: Path):
+        self.paired.append(Path(root))
+        return [SimpleNamespace(root=Path(root))]
 
 
 class FakeLifecycleService:
@@ -78,8 +79,11 @@ class FakeFallbackScanService(FakeScanService):
         self.synced: list[Path] = []
         self.instances.append(self)
 
-    def sync_manifest_favorites(self, root: Path) -> None:
-        self.synced.append(Path(root))
+    def rescan_album(self, root: Path, **kwargs):
+        self.rescanned.append({"root": Path(root), **kwargs})
+        if kwargs.get("sync_manifest_favorites"):
+            self.synced.append(Path(root))
+        return [{"rel": "a.jpg"}]
 
 
 class FakeOpenScanService(FakeScanService):
@@ -124,9 +128,14 @@ def test_rescan_album_uses_session_scan_service(tmp_path: Path) -> None:
     rows = service.rescan_album(DummyAlbum(album_root))
 
     assert rows == [{"rel": "a.jpg"}]
-    assert scan_service.scanned == [(album_root, False)]
-    assert scan_service.finalized == [(album_root, [{"rel": "a.jpg"}])]
-    assert lifecycle_service.reconciled == [(album_root, [{"rel": "a.jpg"}])]
+    assert scan_service.rescanned == [
+        {
+            "root": album_root,
+            "sync_manifest_favorites": False,
+            "pair_live": True,
+        }
+    ]
+    assert lifecycle_service.reconciled == []
 
 
 def test_rescan_album_fallback_syncs_manifest_favorites(
@@ -150,8 +159,13 @@ def test_rescan_album_fallback_syncs_manifest_favorites(
     assert len(FakeFallbackScanService.instances) == 1
     fallback = FakeFallbackScanService.instances[0]
     assert fallback.root == album_root
-    assert fallback.scanned == [(album_root, False)]
-    assert fallback.finalized == [(album_root, [{"rel": "a.jpg"}])]
+    assert fallback.rescanned == [
+        {
+            "root": album_root,
+            "sync_manifest_favorites": True,
+            "pair_live": True,
+        }
+    ]
     assert fallback.synced == [album_root]
 
 
@@ -249,47 +263,12 @@ def test_rescan_album_async_fallback_passes_library_root(monkeypatch, tmp_path: 
     lib_root.mkdir()
     album_root.mkdir()
 
-    class StubSignal:
-        def connect(self, *_args, **_kwargs):
-            return None
-
-    class StubScannerSignals:
+    class FakeTaskRunner:
         def __init__(self) -> None:
-            self.progressUpdated = StubSignal()
-            self.chunkReady = StubSignal()
-            self.finished = StubSignal()
-            self.error = StubSignal()
-            self.batchFailed = StubSignal()
+            self.calls: list[dict] = []
 
-    class StubScannerWorker:
-        def __init__(
-            self,
-            root,
-            include,
-            exclude,
-            signals,
-            library_root=None,
-            scan_service=None,
-        ) -> None:
-            self.root = Path(root)
-            self.library_root = library_root
-            self.scan_service = scan_service
-            self._is_cancelled = False
-            self._had_error = False
-
-        @property
-        def cancelled(self) -> bool:
-            return self._is_cancelled
-
-        @property
-        def failed(self) -> bool:
-            return self._had_error
-
-        def cancel(self) -> None:
-            self._is_cancelled = True
-
-    monkeypatch.setattr(lus, "ScannerSignals", StubScannerSignals)
-    monkeypatch.setattr(lus, "ScannerWorker", StubScannerWorker)
+        def start_scan(self, **kwargs) -> None:
+            self.calls.append(kwargs)
 
     task_manager = DummyTaskManager()
     service = lus.LibraryUpdateService(
@@ -297,18 +276,21 @@ def test_rescan_album_async_fallback_passes_library_root(monkeypatch, tmp_path: 
         current_album_getter=lambda: None,
         library_manager_getter=lambda: None,
     )
+    runner = FakeTaskRunner()
+    service._task_runner = runner
 
     service.rescan_album_async(DummyAlbum(album_root))
 
-    assert task_manager.submitted, "scan task should be submitted"
-    worker = task_manager.submitted[0]["worker"]
-    assert isinstance(worker, StubScannerWorker)
-    assert worker.library_root is None
-    assert worker.scan_service is None
+    assert runner.calls
+    call = runner.calls[0]
+    assert call["root"] == album_root
+    assert list(call["include"]) == list(DEFAULT_INCLUDE)
+    assert list(call["exclude"]) == list(DEFAULT_EXCLUDE)
+    assert call["library_root"] is None
+    assert call["scan_service"] is None
 
 
 def test_restore_rescan_worker_receives_session_scan_service(
-    monkeypatch,
     tmp_path: Path,
 ) -> None:
     lib_root = tmp_path / "library"
@@ -317,21 +299,12 @@ def test_restore_rescan_worker_receives_session_scan_service(
     scan_service = FakeScanService()
     lifecycle_service = FakeLifecycleService()
 
-    class StubRescanWorker:
-        def __init__(
-            self,
-            root,
-            signals,
-            library_root=None,
-            scan_service=None,
-            asset_lifecycle_service=None,
-        ) -> None:
-            self.root = Path(root)
-            self.library_root = library_root
-            self.scan_service = scan_service
-            self._asset_lifecycle_service = asset_lifecycle_service
+    class FakeTaskRunner:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
 
-    monkeypatch.setattr(lus, "RescanWorker", StubRescanWorker)
+        def start_restore_refresh(self, **kwargs) -> None:
+            self.calls.append(kwargs)
 
     task_manager = DummyTaskManager()
     service = lus.LibraryUpdateService(
@@ -343,15 +316,16 @@ def test_restore_rescan_worker_receives_session_scan_service(
             lifecycle_service=lifecycle_service,
         ),
     )
+    runner = FakeTaskRunner()
+    service._task_runner = runner
 
     service._refresh_restored_album(album_root, lib_root)
 
-    assert task_manager.submitted
-    worker = task_manager.submitted[0]["worker"]
-    assert isinstance(worker, StubRescanWorker)
-    assert worker.library_root == lib_root
-    assert worker.scan_service is scan_service
-    assert worker._asset_lifecycle_service is lifecycle_service
+    assert runner.calls
+    call = runner.calls[0]
+    assert call["root"] == album_root
+    assert call["library_root"] == lib_root
+    assert call["scan_service"] is scan_service
 
 
 def test_handle_media_load_failure_uses_lifecycle_service(tmp_path: Path) -> None:
@@ -424,3 +398,43 @@ def test_handle_media_load_failure_uses_current_album_root_when_library_root_is_
     replacement = ReplacementLifecycleService.instances[0]
     assert replacement.library_root == album_root
     assert replacement.media_failures == [asset_path]
+
+
+def test_scan_completion_uses_runtime_finalize_hook(tmp_path: Path) -> None:
+    album_root = tmp_path / "Album"
+    album_root.mkdir()
+
+    class FinalizeScanService:
+        def __init__(self) -> None:
+            self.completed: list[tuple[Path, list[dict], bool]] = []
+
+        def finalize_scan_result(self, root: Path, rows: list[dict], *, pair_live: bool):
+            self.completed.append((Path(root), list(rows), pair_live))
+            return list(rows)
+
+    service = lus.LibraryUpdateService(
+        task_manager=DummyTaskManager(),
+        current_album_getter=lambda: None,
+        library_manager_getter=lambda: None,
+    )
+    scan_service = FinalizeScanService()
+    completion = lus.ScanTaskCompletion(
+        root=album_root,
+        rows=[{"rel": "a.jpg"}],
+        scan_service=scan_service,
+        library_root=None,
+    )
+
+    index_updates: list[Path] = []
+    link_updates: list[Path] = []
+    finished: list[tuple[Path, bool]] = []
+    service.indexUpdated.connect(index_updates.append)
+    service.linksUpdated.connect(link_updates.append)
+    service.scanFinished.connect(lambda root, ok: finished.append((root, ok)))
+
+    service._on_scan_completed(completion)
+
+    assert scan_service.completed == [(album_root, [{"rel": "a.jpg"}], True)]
+    assert index_updates == [album_root]
+    assert link_updates == [album_root]
+    assert finished == [(album_root, True)]

--- a/tests/test_app_facade_session_open.py
+++ b/tests/test_app_facade_session_open.py
@@ -103,3 +103,26 @@ def test_facade_open_album_syncs_manifest_favorites_when_library_root_is_unbound
             "sync_manifest_favorites": True,
         }
     ]
+
+
+def test_facade_rescan_current_async_keeps_public_forwarding_shape(
+    tmp_path: Path,
+) -> None:
+    album_root = tmp_path / "album"
+    album_root.mkdir(parents=True)
+    facade = AppFacade()
+    facade._current_album = SimpleNamespace(root=album_root)
+
+    class _FakeUpdateService:
+        def __init__(self) -> None:
+            self.requested: list[Path] = []
+
+        def rescan_album_async(self, album) -> None:
+            self.requested.append(album.root)
+
+    update_service = _FakeUpdateService()
+    facade._inject_scan_dependencies_for_tests(library_update_service=update_service)
+
+    facade.rescan_current_async()
+
+    assert update_service.requested == [album_root]

--- a/tests/test_navigation_coordinator_cluster_gallery.py
+++ b/tests/test_navigation_coordinator_cluster_gallery.py
@@ -55,6 +55,7 @@ def test_open_location_view_delegates_to_gallery_vm() -> None:
     coord.open_location_view()
 
     coord._gallery_vm.open_location_map.assert_called_once_with()
+    coord._context.library.get_geotagged_assets.assert_not_called()
 
 
 def test_open_people_view_delegates_to_gallery_vm() -> None:

--- a/tests/test_navigation_coordinator_refresh.py
+++ b/tests/test_navigation_coordinator_refresh.py
@@ -76,3 +76,4 @@ def test_open_recently_deleted_delegates_to_gallery_vm() -> None:
     coord.open_recently_deleted()
 
     coord._gallery_vm.open_recently_deleted.assert_called_once_with()
+    coord._context.library.cleanup_deleted_index.assert_not_called()

--- a/tools/check_layer_boundaries.py
+++ b/tools/check_layer_boundaries.py
@@ -72,6 +72,14 @@ GUI_ALBUM_METADATA_SERVICE_FORBIDDEN_IMPORTS = {
     "iPhoto.utils.jsonio",
 }
 
+GUI_LIBRARY_UPDATE_SERVICE_FORBIDDEN_FILES = {
+    "gui/services/library_update_service.py",
+}
+
+GUI_LIBRARY_UPDATE_SERVICE_FORBIDDEN_IMPORTS = {
+    "iPhoto.library.workers",
+}
+
 GUI_RUNTIME_BACKEND_FORBIDDEN = {
     "iPhoto.app",
 }
@@ -301,6 +309,14 @@ def check(src_root: Path) -> list[str]:
             ):
                 violations.append(
                     f"{py_file}:{lineno}: GUI album metadata service imports retired implementation detail {module}"
+                )
+
+            if rel in GUI_LIBRARY_UPDATE_SERVICE_FORBIDDEN_FILES and any(
+                _is_or_under(module, forbidden)
+                for forbidden in GUI_LIBRARY_UPDATE_SERVICE_FORBIDDEN_IMPORTS
+            ):
+                violations.append(
+                    f"{py_file}:{lineno}: GUI library update service imports worker implementation detail {module}"
                 )
 
             if rel not in LEGACY_DOMAIN_USE_CASE_ALLOWED_IMPORTERS and (


### PR DESCRIPTION
This pull request focuses on documentation and codebase refactoring to further decouple GUI orchestration from runtime/business logic, especially regarding library update and location/trash management. The main goals are to ensure the GUI layer remains responsible only for presentation and routing, while all durable state changes and background operations are handled by dedicated adapters and services. Additional architectural guardrails and validation steps are introduced to enforce these boundaries.

Key changes include:

**Documentation structure and clarity improvements:**

* Major updates and restructuring to `docs/refactor/04-implementation-checklist.md` and `docs/refactor/05-current-progress.md`, including clearer phase breakdowns, improved summaries, explicit versioning/status headers, and detailed tracking of GUI residual orchestration cleanup progress. [[1]](diffhunk://#diff-4ce4e7ee4935ae34c18daa266411617b32f3c287c1b88c939760339b9dc46c9dL1-R13) [[2]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cL3-R9) [[3]](diffhunk://#diff-906c20cb8faf2a03806148042db1f5f7b38ea49b3ca8409fb268099d2a073d54R1-R83)

**GUI orchestration decoupling:**

* Introduction of `LocationTrashNavigationService` to handle Recently Deleted preparation, trash cleanup throttling, and geotagged asset loading, moving these responsibilities out of `NavigationCoordinator` and `GalleryViewModel`. [[1]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR47-L51) [[2]](diffhunk://#diff-b4c26a1cdc2d1dd12081287d7d330c296e672e819274468622b83eb5210365ecR144-R154) [[3]](diffhunk://#diff-717ca3b12c440172c01bae4751f92a47a799dee531e372e29d2dbab1c62449ddR60-R71) [[4]](diffhunk://#diff-4556391ec9d260bba38f005160914e4947a8ae4a7706e5399e8ecfc4fcd1f6f4L6-L7)
* `LibraryUpdateService` now delegates scan worker lifecycle management to a dedicated GUI task runner and no longer directly imports or manages worker logic, focusing solely on presentation-layer coordination. [[1]](diffhunk://#diff-906c20cb8faf2a03806148042db1f5f7b38ea49b3ca8409fb268099d2a073d54R1-R83) [[2]](diffhunk://#diff-4ce4e7ee4935ae34c18daa266411617b32f3c287c1b88c939760339b9dc46c9dR190-R196)

**Library scan service enhancements:**

* `LibraryScanService` gains new high-level methods: `rescan_album`, `finalize_scan_result`, and `refresh_restored_album`, which encapsulate persistence, metadata preservation, and follow-up operations after scans, supporting the new orchestration model. [[1]](diffhunk://#diff-cfb9bf5653cdbdcef3cba63580d64e24f3f9b13bf138b86a8a9a87d0fd02ffc2R235-R260) [[2]](diffhunk://#diff-cfb9bf5653cdbdcef3cba63580d64e24f3f9b13bf138b86a8a9a87d0fd02ffc2R275-R327)

**Architecture guardrails and validation:**

* Expanded architecture checks to prevent forbidden imports (e.g., `gui/services/library_update_service.py` importing `library.workers.*`) and updated regression/validation documentation to cover new boundaries. [[1]](diffhunk://#diff-906c20cb8faf2a03806148042db1f5f7b38ea49b3ca8409fb268099d2a073d54R1-R83) [[2]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR150-R167)

**Phase tracking and next steps:**

* Updated documentation to reflect current progress, known exceptions, and next steps, with explicit notes regarding remaining GUI residuals (e.g., People fallback, Maps runtime, Edit sidecar) and the temporary nature of certain adapters. [[1]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR98-R117) [[2]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR133-R136) [[3]](diffhunk://#diff-567724c12977e533b51fbfb81ab9def8f7e6b369b28f3a6463c22c9e02b4471cR150-R167)

These changes collectively enforce a cleaner separation of concerns, improve maintainability, and clarify project status and next steps for future contributors.