### PR TITLE
Update download links and installation instructions for v6.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 
 ## 📥 Download & Install
 
-[![Download for Windows](https://img.shields.io/badge/⬇️%20Download-Windows%20(.exe)-blue?style=for-the-badge&logo=windows)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/v6.10-x86-setup.exe)
-[![Download for Linux (.deb)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.deb)-orange?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/iphotron_6.1.0_amd64.deb)
-[![Download for Linux (.AppImage)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.AppImage)-brightgreen?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/iPhotron-6.1.0-x86_64.AppImage)
-[![Download for Linux (.flatpak)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.flatpak)-purple?style=for-the-badge&logo=flatpak&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/com.github.OliverZhaohaibin.iPhotron-6.1.0-x86_64.flatpak)
+[![Download for Windows](https://img.shields.io/badge/⬇️%20Download-Windows%20(.exe)-blue?style=for-the-badge&logo=windows)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/v6.50-x86-setup.exe)
+[![Download for Linux (.deb)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.deb)-orange?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/iphotron_6.5.0_amd64.deb)
+[![Download for Linux (.AppImage)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.AppImage)-brightgreen?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/iPhotron-6.5.0-x86_64.AppImage)
+[![Download for Linux (.flatpak)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.flatpak)-purple?style=for-the-badge&logo=flatpak&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/com.github.OliverZhaohaibin.iPhotron-6.5.0-x86_64.flatpak)
 
 **💡 Quick Install:** Click the buttons above to download the latest installer directly.
 
@@ -31,20 +31,20 @@
 - **Linux (.deb):** Install with the following command:
 
 ```bash
-sudo apt install ./iphotron_6.1.0_amd64.deb
+sudo apt install ./iphotron_6.5.0_amd64.deb
 ```
 
 - **Linux (.AppImage):** Make the file executable and run it:
 
 ```bash
-chmod +x iPhotron-6.1.0-x86_64.AppImage
-./iPhotron-6.1.0-x86_64.AppImage
+chmod +x iPhotron-6.5.0-x86_64.AppImage
+./iPhotron-6.5.0-x86_64.AppImage
 ```
 
 - **Linux (.flatpak):** Install the bundle with Flatpak:
 
 ```bash
-flatpak install --user ./com.github.OliverZhaohaibin.iPhotron-6.1.0-x86_64.flatpak
+flatpak install --user ./com.github.OliverZhaohaibin.iPhotron-6.5.0-x86_64.flatpak
 ```
 
 **For developers** — install from source:
@@ -179,7 +179,7 @@ pinned. Face scanning uses the optional `ai-demo` dependencies; the core photo
 manager remains usable without installing the AI runtime, and People state is
 kept behind the library session so names, covers, hidden flags, groups, and
 manual faces survive rescans.
-![People and groups interface](<docs/picture/People & Group.png>)
+![People and groups interface](docs/picture/People%20%26%20Group.png)
 
 ### 🖼 Immersive Detail View
 An elegant viewer with a filmstrip navigator, floating playback bar for videos,

--- a/docs/readme/README_de.md
+++ b/docs/readme/README_de.md
@@ -19,10 +19,10 @@
 
 ## 📥 Download & Installation
 
-[![Für Windows herunterladen](https://img.shields.io/badge/⬇️%20Download-Windows%20(.exe)-blue?style=for-the-badge&logo=windows)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/v6.10-x86-setup.exe)
-[![Für Linux herunterladen (.deb)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.deb)-orange?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/iphotron_6.1.0_amd64.deb)
-[![Für Linux herunterladen (.AppImage)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.AppImage)-brightgreen?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/iPhotron-6.1.0-x86_64.AppImage)
-[![Für Linux herunterladen (.flatpak)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.flatpak)-purple?style=for-the-badge&logo=flatpak&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/com.github.OliverZhaohaibin.iPhotron-6.1.0-x86_64.flatpak)
+[![Für Windows herunterladen](https://img.shields.io/badge/⬇️%20Download-Windows%20(.exe)-blue?style=for-the-badge&logo=windows)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/v6.50-x86-setup.exe)
+[![Für Linux herunterladen (.deb)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.deb)-orange?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/iphotron_6.5.0_amd64.deb)
+[![Für Linux herunterladen (.AppImage)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.AppImage)-brightgreen?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/iPhotron-6.5.0-x86_64.AppImage)
+[![Für Linux herunterladen (.flatpak)](https://img.shields.io/badge/⬇️%20Download-Linux%20(.flatpak)-purple?style=for-the-badge&logo=flatpak&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/com.github.OliverZhaohaibin.iPhotron-6.5.0-x86_64.flatpak)
 
 
 **💡 Schnellinstallation:** Klicken Sie auf die Schaltflächen oben, um das neueste Installationsprogramm direkt herunterzuladen.
@@ -31,20 +31,20 @@
 - **Linux:** Installationsbefehl:
 
 ```bash
-sudo apt install ./iphotron_6.1.0_amd64.deb
+sudo apt install ./iphotron_6.5.0_amd64.deb
 ```
 
 - **Linux (AppImage):** Datei ausführbar machen und direkt starten:
 
 ```bash
-chmod +x iPhotron-6.1.0-x86_64.AppImage
-./iPhotron-6.1.0-x86_64.AppImage
+chmod +x iPhotron-6.5.0-x86_64.AppImage
+./iPhotron-6.5.0-x86_64.AppImage
 ```
 
 - **Linux (Flatpak):** Bundle mit Flatpak installieren:
 
 ```bash
-flatpak install --user ./com.github.OliverZhaohaibin.iPhotron-6.1.0-x86_64.flatpak
+flatpak install --user ./com.github.OliverZhaohaibin.iPhotron-6.5.0-x86_64.flatpak
 ```
 
 **Für Entwickler:**

--- a/docs/readme/README_zh-CN.md
+++ b/docs/readme/README_zh-CN.md
@@ -19,10 +19,10 @@
 
 ## 📥 下载与安装
 
-[![下载 Windows 版本](https://img.shields.io/badge/⬇️%20下载-Windows%20(.exe)-blue?style=for-the-badge&logo=windows)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/v6.10-x86-setup.exe)
-[![下载 Linux 版本（.deb）](https://img.shields.io/badge/⬇️%20下载-Linux%20(.deb)-orange?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/iphotron_6.1.0_amd64.deb)
-[![下载 Linux 版本（.AppImage）](https://img.shields.io/badge/⬇️%20下载-Linux%20(.AppImage)-brightgreen?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/iPhotron-6.1.0-x86_64.AppImage)
-[![下载 Linux 版本（.flatpak）](https://img.shields.io/badge/⬇️%20下载-Linux%20(.flatpak)-purple?style=for-the-badge&logo=flatpak&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.1.0/com.github.OliverZhaohaibin.iPhotron-6.1.0-x86_64.flatpak)
+[![下载 Windows 版本](https://img.shields.io/badge/⬇️%20下载-Windows%20(.exe)-blue?style=for-the-badge&logo=windows)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/v6.50-x86-setup.exe)
+[![下载 Linux 版本（.deb）](https://img.shields.io/badge/⬇️%20下载-Linux%20(.deb)-orange?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/iphotron_6.5.0_amd64.deb)
+[![下载 Linux 版本（.AppImage）](https://img.shields.io/badge/⬇️%20下载-Linux%20(.AppImage)-brightgreen?style=for-the-badge&logo=linux&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/iPhotron-6.5.0-x86_64.AppImage)
+[![下载 Linux 版本（.flatpak）](https://img.shields.io/badge/⬇️%20下载-Linux%20(.flatpak)-purple?style=for-the-badge&logo=flatpak&logoColor=white)](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/releases/download/v6.5.0/com.github.OliverZhaohaibin.iPhotron-6.5.0-x86_64.flatpak)
 
 **💡 快速安装：** 点击上方按钮直接下载最新安装程序。
 
@@ -30,20 +30,20 @@
 - **Linux：** 安装命令为：
 
 ```bash
-sudo apt install ./iphotron_6.1.0_amd64.deb
+sudo apt install ./iphotron_6.5.0_amd64.deb
 ```
 
 - **Linux（AppImage）：** 赋予执行权限后直接运行：
 
 ```bash
-chmod +x iPhotron-6.1.0-x86_64.AppImage
-./iPhotron-6.1.0-x86_64.AppImage
+chmod +x iPhotron-6.5.0-x86_64.AppImage
+./iPhotron-6.5.0-x86_64.AppImage
 ```
 
 - **Linux（Flatpak）：** 使用 Flatpak 安装 bundle：
 
 ```bash
-flatpak install --user ./com.github.OliverZhaohaibin.iPhotron-6.1.0-x86_64.flatpak
+flatpak install --user ./com.github.OliverZhaohaibin.iPhotron-6.5.0-x86_64.flatpak
 ```
 
 **开发者安装：**


### PR DESCRIPTION
This pull request updates the download and installation instructions across the English, German, and Chinese README files to reference the latest v6.5.0 release of the application. It also fixes a broken image link in the English README.

Documentation updates:

* Updated all download badges, links, and installation commands in `README.md`, `docs/readme/README_de.md`, and `docs/readme/README_zh-CN.md` to point to the new v6.5.0 release files for Windows and Linux (.deb, .AppImage, .flatpak). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R47) [[2]](diffhunk://#diff-41f0ab9c9864fb5f2035ce11bd41c88593bc57502a77b7d99c2706d31eef7eaeL22-R25) [[3]](diffhunk://#diff-41f0ab9c9864fb5f2035ce11bd41c88593bc57502a77b7d99c2706d31eef7eaeL34-R47) [[4]](diffhunk://#diff-f8e5852402c72bba1699a473823adb17c344fe5aa8a015e5797a3d793dd54b8dL22-R46)
* Fixed the "People and groups interface" image link in `README.md` by encoding the space and ampersand in the file name.… 6.5.0