### PR TITLE
docs: update star history section in README files with responsive images

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ iphoto-gui /photos/LondonTrip
 
 ## 🌟 Star History
 
-<p align="center">
-  <a href="https://www.star-history.com/#OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right">
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
-  </a>
-</p>
+<a href="https://www.star-history.com/?type=date&legend=bottom-right&repos=OliverZhaohaibin%2FiPhotron-LocalPhotoAlbumManager">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&theme=dark&legend=bottom-right" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
+ </picture>
+</a>
 
 ## 🚀 Product Hunt
 <p align="center">

--- a/docs/readme/README_de.md
+++ b/docs/readme/README_de.md
@@ -71,11 +71,13 @@ iphoto-gui /fotos/LondonReise
 
 ## 🌟 Star-Verlauf
 
-<p align="center">
-  <a href="https://www.star-history.com/#OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right">
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
-  </a>
-</p>
+<a href="https://www.star-history.com/?type=date&legend=bottom-right&repos=OliverZhaohaibin%2FiPhotron-LocalPhotoAlbumManager">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&theme=dark&legend=bottom-right" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
+ </picture>
+</a>
 
 ## 🚀 Product Hunt
 <p align="center">

--- a/docs/readme/README_zh-CN.md
+++ b/docs/readme/README_zh-CN.md
@@ -70,11 +70,13 @@ iphoto-gui /photos/LondonTrip
 
 ## 🌟 Star 历史
 
-<p align="center">
-  <a href="https://www.star-history.com/#OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right">
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
-  </a>
-</p>
+<a href="https://www.star-history.com/?type=date&legend=bottom-right&repos=OliverZhaohaibin%2FiPhotron-LocalPhotoAlbumManager">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&theme=dark&legend=bottom-right" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager&type=date&legend=bottom-right" />
+ </picture>
+</a>
 
 ## 🚀 Product Hunt
 <p align="center">


### PR DESCRIPTION
This pull request updates the "Star History" chart section in the project's README files across multiple languages. The main improvement is replacing the old static image embed with a more modern and theme-aware implementation that supports both dark and light modes using the `<picture>` HTML element. This enhances the visual consistency and accessibility of the documentation for users with different display preferences.

Documentation improvements:

* Updated the "Star History" chart embed in the English `README.md` to use a `<picture>` element, providing theme-aware support for dark and light modes.
* Applied the same theme-aware "Star History" chart update to the German `docs/readme/README_de.md` file.
* Applied the same theme-aware "Star History" chart update to the Chinese `docs/readme/README_zh-CN.md` file.