### PR TITLE
Fix CI routing for edit-base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, edit-base]
   pull_request:
-    branches: [main]
+    branches: [main, edit-base]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What changed

- Run the test workflow for pull requests targeting `edit-base` as well as `main`.
- Run the workflow for pushes to `edit-base` as well as `main`.

## Why

PR #890 targets `edit-base`, but its workflow filtered on head-branch names. GitHub evaluates `pull_request.branches` against the base branch, so the advertised cross-platform contracts were never scheduled for that PR.

## Impact

This is the first, intentionally minimal replacement PR for #890. It establishes CI coverage before the remaining remediation work is split into focused PRs.

## Validation

- Parsed `.github/workflows/test.yml` successfully.
- `git diff --check` passed.
- Confirmed the commit changes only `.github/workflows/test.yml`.