### PR TITLE
Build bounded Detail decode and cache core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,3 +94,44 @@ jobs:
           tests/test_startup_profile.py
           tests/test_appimage_packaging.py
           tests/test_macos_detection_report.py
+
+  detail-core-contracts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libegl1 libgl1 libxkbcommon0 libpulse0
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run Detail core contracts
+        env:
+          QT_QPA_PLATFORM: offscreen
+          NUMBA_DISABLE_JIT: "1"
+        run: >-
+          python -m pytest -q
+          tests/gui/test_detail_profile.py
+          tests/gui/test_detail_pipeline.py
+          tests/gui/test_detail_request_scheduler.py
+          tests/gui/test_detail_decode_backend.py
+          tests/gui/test_detail_surface_cache.py
+          tests/gui/test_detail_render_coordinator.py

--- a/src/iPhoto/gui/detail_decode_backend.py
+++ b/src/iPhoto/gui/detail_decode_backend.py
@@ -1,0 +1,679 @@
+"""Viewport-aware neutral still-image decode backends for Detail."""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from PySide6.QtCore import QBuffer, QByteArray, QIODevice, QSize, Qt
+from PySide6.QtGui import QColorSpace, QImage, QImageReader
+
+from iPhoto.core.color_resolver import ColorStats
+from iPhoto.core.raw_processor import is_raw_extension
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailDecodeLevel,
+    DetailRenderRequest,
+)
+from iPhoto.gui.detail_profile import emit_detail_event
+from iPhoto.utils.deps import load_pillow
+
+_MAX_DETAIL_SURFACE_BYTES = 192 * 1024 * 1024
+_DEFAULT_RAW_WORKING_MEMORY_BYTES = 384 * 1024 * 1024
+
+
+class DecodeCancelledError(RuntimeError):
+    """Raised at a cooperative checkpoint after a request becomes stale."""
+
+
+class CancellationToken(Protocol):
+    def is_cancelled(self) -> bool: ...
+
+
+class StillDecodeBackend(Protocol):
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface: ...
+
+
+class StillDecodeBackendRegistry:
+    """Select native-capable platform decoders without coupling the scheduler."""
+
+    def __init__(
+        self,
+        *,
+        platform: str | None = None,
+        macos_backend: StillDecodeBackend | None = None,
+        windows_backend: StillDecodeBackend | None = None,
+        qt_backend: StillDecodeBackend | None = None,
+        raw_backend: StillDecodeBackend | None = None,
+    ) -> None:
+        self._platform = sys.platform if platform is None else platform
+        self._qt = qt_backend or QtStillDecodeBackend()
+        self._raw = raw_backend or RawStillDecodeBackend()
+        self._macos = macos_backend or (
+            _load_macos_imageio_backend() if self._platform == "darwin" else None
+        )
+        self._windows = windows_backend or (
+            _load_windows_wic_backend() if self._platform == "win32" else None
+        )
+
+    def backend_for(self, request: DetailRenderRequest) -> StillDecodeBackend:
+        if is_raw_extension(request.source_identity.path.suffix):
+            return self._raw
+        if self._platform == "darwin" and self._macos is not None:
+            return FallbackStillDecodeBackend(
+                self._macos,
+                self._qt,
+                fallback_name="imageio_to_qt",
+            )
+        if self._platform == "win32" and self._windows is not None:
+            return FallbackStillDecodeBackend(
+                self._windows,
+                self._qt,
+                fallback_name="wic_to_qt",
+            )
+        return self._qt
+
+
+class FallbackStillDecodeBackend:
+    """Try one platform backend and fall back to Qt inside the worker lane."""
+
+    def __init__(
+        self,
+        primary: StillDecodeBackend,
+        fallback: StillDecodeBackend,
+        *,
+        fallback_name: str,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+        self._fallback_name = fallback_name
+
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface:
+        try:
+            return self._primary.decode(request, cancellation)
+        except DecodeCancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - platform codecs have backend-specific failures
+            _check_cancelled(cancellation)
+            surface = self._fallback.decode(request, cancellation)
+            return DecodedSurface(
+                image=surface.image,
+                decode_key=surface.decode_key,
+                source_size=surface.source_size,
+                decoded_size=surface.decoded_size,
+                decode_level=surface.decode_level,
+                backend=surface.backend,
+                color_stats=surface.color_stats,
+                fallback=self._fallback_name,
+                pixel_format=surface.pixel_format,
+                color_space=surface.color_space,
+                orientation_applied=surface.orientation_applied,
+                cache_tier=surface.cache_tier,
+                backing_owner=surface.backing_owner,
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedSurface:
+    """Detached neutral upload surface owned by one scheduler delivery."""
+
+    image: QImage
+    decode_key: DetailDecodeKey
+    source_size: tuple[int, int]
+    decoded_size: tuple[int, int]
+    decode_level: DetailDecodeLevel
+    backend: str
+    color_stats: ColorStats = ColorStats()
+    fallback: str | None = None
+    pixel_format: str = "rgba8888"
+    color_space: str = "srgb"
+    orientation_applied: bool = True
+    cache_tier: Literal["decode", "memory", "disk"] = "decode"
+    backing_owner: object | None = None
+
+
+def _check_cancelled(token: CancellationToken) -> None:
+    if token.is_cancelled():
+        raise DecodeCancelledError("Still-image decode cancelled")
+
+
+def _load_macos_imageio_backend() -> StillDecodeBackend | None:
+    try:
+        from iPhoto.gui.detail_decode_macos import create_macos_imageio_backend
+    except ImportError:
+        return None
+    return create_macos_imageio_backend()
+
+
+def _load_windows_wic_backend() -> StillDecodeBackend | None:
+    try:
+        from iPhoto.gui.detail_decode_windows import create_windows_wic_backend
+    except ImportError:
+        return None
+    return create_windows_wic_backend()
+
+
+def _target_longest_edge(request: DetailRenderRequest) -> int:
+    prepared = request.with_decode_level()
+    identity = prepared.source_identity
+    source_longest = max(1, identity.width, identity.height)
+    if prepared.decode_level == "full":
+        if identity.width <= 0 or identity.height <= 0:
+            return max(1, prepared.texture_limit)
+        return min(source_longest, max(1, prepared.texture_limit))
+    return min(int(prepared.decode_level or source_longest), max(1, prepared.texture_limit))
+
+
+def _target_size(request: DetailRenderRequest) -> QSize:
+    identity = request.source_identity
+    width = max(1, identity.width)
+    height = max(1, identity.height)
+    longest = _target_longest_edge(request)
+    if width >= height:
+        target = QSize(longest, max(1, round(longest * height / width)))
+    else:
+        target = QSize(max(1, round(longest * width / height)), longest)
+    estimated_bytes = target.width() * target.height() * 4
+    if estimated_bytes > _MAX_DETAIL_SURFACE_BYTES:
+        scale = (_MAX_DETAIL_SURFACE_BYTES / float(estimated_bytes)) ** 0.5
+        target = QSize(
+            max(1, int(target.width() * scale)),
+            max(1, int(target.height() * scale)),
+        )
+    return target
+
+
+def _normalise_surface(
+    image: QImage,
+    target: QSize,
+    *,
+    detached: bool = False,
+) -> QImage:
+    if image.isNull():
+        return QImage()
+    if target.isValid() and not target.isEmpty() and (
+        image.width() > target.width() or image.height() > target.height()
+    ):
+        image = image.scaled(
+            target,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+    srgb = QColorSpace(QColorSpace.NamedColorSpace.SRgb)
+    try:
+        if image.colorSpace().isValid() and image.colorSpace() != srgb:
+            image = image.convertedToColorSpace(srgb)
+    except (AttributeError, RuntimeError, TypeError):
+        pass
+    normalised = image.convertToFormat(QImage.Format.Format_RGBA8888)
+    if not detached:
+        normalised = normalised.copy()
+    if not normalised.colorSpace().isValid():
+        normalised.setColorSpace(srgb)
+    return normalised
+
+
+class QtStillDecodeBackend:
+    """Use QImageReader scaled decode, with Pillow as a compatibility fallback."""
+
+    name = "qt"
+
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface:
+        prepared = request.with_decode_level()
+        source = prepared.source_identity.path
+        target = _target_size(prepared)
+        _check_cancelled(cancellation)
+        reader = QImageReader(str(source))
+        disable_cache = getattr(reader, "setCacheEnabled", None)
+        if callable(disable_cache):
+            disable_cache(False)
+        reader.setAutoTransform(True)
+        intrinsic = reader.size()
+        if intrinsic.isValid() and not intrinsic.isEmpty():
+            reader_target = target
+            if prepared.source_identity.orientation in (5, 6, 7, 8):
+                reader_target = QSize(target.height(), target.width())
+            scaled = intrinsic.scaled(reader_target, Qt.AspectRatioMode.KeepAspectRatio)
+            if scaled.width() < intrinsic.width() or scaled.height() < intrinsic.height():
+                reader.setScaledSize(scaled)
+        image = reader.read()
+        _check_cancelled(cancellation)
+        fallback = None
+        if image.isNull():
+            image = _load_with_pillow(source, target)
+            fallback = "pillow"
+        elif image.width() > target.width() or image.height() > target.height():
+            fallback = "qt_full_scale"
+        if image.isNull():
+            raise RuntimeError(reader.errorString() or "Image decoder returned an empty frame")
+        surface = _normalise_surface(image, target)
+        _check_cancelled(cancellation)
+        if surface.isNull():
+            raise RuntimeError("Image decoder returned an empty neutral surface")
+        source_size = (
+            max(1, prepared.source_identity.width or intrinsic.width() or surface.width()),
+            max(1, prepared.source_identity.height or intrinsic.height() or surface.height()),
+        )
+        return DecodedSurface(
+            image=surface,
+            decode_key=DetailDecodeKey.from_request(prepared),
+            source_size=source_size,
+            decoded_size=(surface.width(), surface.height()),
+            decode_level=prepared.decode_level or "full",
+            backend=self.name,
+            fallback=fallback,
+        )
+
+
+class RawStillDecodeBackend:
+    """Prefer an adequate embedded RAW preview, then half/full demosaic."""
+
+    name = "rawpy"
+
+    def __init__(
+        self,
+        *,
+        working_memory_budget_bytes: int = _DEFAULT_RAW_WORKING_MEMORY_BYTES,
+    ) -> None:
+        self._working_memory_budget_bytes = max(
+            1,
+            int(working_memory_budget_bytes),
+        )
+
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface:
+        prepared = request.with_decode_level()
+        target = _target_size(prepared)
+        _check_cancelled(cancellation)
+        rawpy = _import_rawpy()
+        if rawpy is None:
+            raise RuntimeError("rawpy is unavailable")
+        source = prepared.source_identity.path
+        fallback: str | None = None
+        image = QImage()
+        preview_size = QSize()
+        half_size = QSize()
+        with rawpy.imread(str(source)) as raw:
+            _check_cancelled(cancellation)
+            raw_size = _raw_visible_size(raw, prepared.source_identity)
+            half_size = QSize(
+                max(1, (raw_size.width() + 1) // 2),
+                max(1, (raw_size.height() + 1) // 2),
+            )
+            thumb = None
+            try:
+                thumb = raw.extract_thumb()
+            except Exception:  # noqa: BLE001 - embedded previews are optional codec data
+                thumb = None
+            preview_size = _raw_thumb_size(thumb, rawpy)
+            if _size_satisfies(preview_size, target):
+                candidate = "embedded"
+            elif _size_satisfies(half_size, target):
+                candidate = "half"
+                fallback = "half"
+            else:
+                candidate = "full"
+                fallback = "full"
+            if candidate == "embedded":
+                started = time.perf_counter()
+                image = _qimage_from_raw_thumb(
+                    thumb,
+                    rawpy,
+                    target,
+                    orientation=prepared.source_identity.orientation,
+                )
+                emit_detail_event(
+                    "raw_thumb_decode",
+                    generation=prepared.generation,
+                    asset_id=prepared.asset_id,
+                    duration_ms=(time.perf_counter() - started) * 1000.0,
+                    width=image.width(),
+                    height=image.height(),
+                )
+                _check_cancelled(cancellation)
+                if image.isNull():
+                    candidate = "half" if _size_satisfies(half_size, target) else "full"
+                    fallback = candidate
+            if candidate == "full" and not _raw_peak_fits_budget(
+                raw_size,
+                target,
+                self._working_memory_budget_bytes,
+                half_size=False,
+            ):
+                candidate = "half"
+                fallback = "half_budget"
+            emit_detail_event(
+                "raw_candidate_selected",
+                generation=prepared.generation,
+                asset_id=prepared.asset_id,
+                suffix=source.suffix.lower(),
+                candidate=candidate,
+                decode_level=prepared.decode_level or "full",
+                target_width=target.width(),
+                target_height=target.height(),
+                preview_width=preview_size.width(),
+                preview_height=preview_size.height(),
+                half_width=half_size.width(),
+                half_height=half_size.height(),
+            )
+            if candidate != "embedded":
+                started = time.perf_counter()
+                rgb = _postprocess_raw(raw, half_size=candidate == "half")
+                emit_detail_event(
+                    "raw_postprocess",
+                    generation=prepared.generation,
+                    asset_id=prepared.asset_id,
+                    duration_ms=(time.perf_counter() - started) * 1000.0,
+                    candidate=candidate,
+                )
+                _check_cancelled(cancellation)
+                started = time.perf_counter()
+                image = _qimage_from_array(rgb, target=target)
+                emit_detail_event(
+                    "raw_surface_convert",
+                    generation=prepared.generation,
+                    asset_id=prepared.asset_id,
+                    duration_ms=(time.perf_counter() - started) * 1000.0,
+                    candidate=candidate,
+                    phase="array_bridge",
+                    width=image.width(),
+                    height=image.height(),
+                )
+            _check_cancelled(cancellation)
+        _check_cancelled(cancellation)
+        if image.isNull():
+            raise RuntimeError("RAW decoder returned an empty frame")
+        started = time.perf_counter()
+        surface = _normalise_surface(
+            image,
+            target,
+            detached=candidate != "embedded",
+        )
+        emit_detail_event(
+            "raw_surface_convert",
+            generation=prepared.generation,
+            asset_id=prepared.asset_id,
+            duration_ms=(time.perf_counter() - started) * 1000.0,
+            candidate=candidate,
+            phase="normalise",
+            width=surface.width(),
+            height=surface.height(),
+        )
+        _check_cancelled(cancellation)
+        return DecodedSurface(
+            image=surface,
+            decode_key=DetailDecodeKey.from_request(prepared),
+            source_size=(
+                max(1, prepared.source_identity.width or image.width()),
+                max(1, prepared.source_identity.height or image.height()),
+            ),
+            decoded_size=(surface.width(), surface.height()),
+            decode_level=prepared.decode_level or "full",
+            backend=self.name,
+            fallback=fallback,
+        )
+
+
+class DefaultStillDecodeBackend:
+    """Route RAW formats to rawpy and all other stills to Qt."""
+
+    def __init__(self, registry: StillDecodeBackendRegistry | None = None) -> None:
+        self._registry = registry or StillDecodeBackendRegistry()
+
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface:
+        return self._registry.backend_for(request).decode(request, cancellation)
+
+
+def _load_with_pillow(source: Path, target: QSize) -> QImage:
+    pillow = load_pillow()
+    if pillow is None:
+        return QImage()
+    try:
+        with pillow.Image.open(source) as opened:
+            image = pillow.ImageOps.exif_transpose(opened)
+            resampling = getattr(pillow.Image, "Resampling", pillow.Image)
+            image.thumbnail(
+                (target.width(), target.height()),
+                getattr(resampling, "LANCZOS", pillow.Image.BICUBIC),
+            )
+            return QImage(pillow.ImageQt(image.convert("RGBA"))).copy()
+    except Exception:  # noqa: BLE001 - Pillow plugins raise codec-specific exceptions
+        return QImage()
+
+
+def _import_rawpy() -> Any | None:
+    try:
+        import rawpy  # type: ignore[import-untyped]
+    except ImportError:
+        return None
+    return rawpy
+
+
+def probe_raw_source_identity(identity: AssetSourceIdentity) -> AssetSourceIdentity:
+    """Resolve missing RAW geometry from LibRaw without filesystem metadata I/O."""
+
+    if identity.width > 0 and identity.height > 0:
+        return identity
+    rawpy = _import_rawpy()
+    if rawpy is None:
+        raise RuntimeError("rawpy is unavailable")
+    try:
+        with rawpy.imread(str(identity.path)) as raw:
+            size = _raw_visible_size(raw, identity)
+            flip = _raw_flip(raw)
+    except Exception as exc:  # noqa: BLE001 - LibRaw exposes format-specific failures
+        raise RuntimeError(f"Unable to probe RAW geometry: {exc}") from exc
+    if size.isEmpty() or not size.isValid():
+        raise RuntimeError("RAW decoder did not report valid source geometry")
+    orientation = identity.orientation
+    if flip in (5, 6):
+        orientation = 8 if flip == 5 else 6
+    elif flip == 3:
+        orientation = 3
+    return AssetSourceIdentity.create(
+        identity.path,
+        size_bytes=identity.size_bytes,
+        source_mtime_ns=identity.source_mtime_ns,
+        index_revision=identity.index_revision,
+        width=size.width(),
+        height=size.height(),
+        orientation=orientation,
+    )
+
+
+def _raw_flip(raw: Any) -> int:
+    try:
+        return int(getattr(raw.sizes, "flip", 0) or 0)
+    except (AttributeError, TypeError, ValueError):
+        return 0
+
+
+def _raw_visible_size(raw: Any, identity: AssetSourceIdentity) -> QSize:
+    sizes = getattr(raw, "sizes", None)
+    width = _positive_int(getattr(sizes, "iwidth", 0))
+    height = _positive_int(getattr(sizes, "iheight", 0))
+    if width <= 0 or height <= 0:
+        width = _positive_int(getattr(sizes, "width", 0))
+        height = _positive_int(getattr(sizes, "height", 0))
+    if width <= 0 or height <= 0:
+        width = max(0, int(identity.width))
+        height = max(0, int(identity.height))
+    if _raw_flip(raw) in (5, 6):
+        width, height = height, width
+    return QSize(width, height)
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _size_satisfies(candidate: QSize, target: QSize) -> bool:
+    if candidate.isEmpty() or not candidate.isValid():
+        return False
+    return (
+        candidate.width() >= target.width()
+        and candidate.height() >= target.height()
+    ) or (
+        candidate.width() >= target.height()
+        and candidate.height() >= target.width()
+    )
+
+
+def _raw_thumb_size(thumb: Any, rawpy: Any) -> QSize:
+    if thumb is None:
+        return QSize()
+    if thumb.format == rawpy.ThumbFormat.JPEG:
+        payload = QByteArray(bytes(thumb.data))
+        buffer = QBuffer(payload)
+        if not buffer.open(QIODevice.OpenModeFlag.ReadOnly):
+            return QSize()
+        try:
+            return QImageReader(buffer, b"JPEG").size()
+        finally:
+            buffer.close()
+    if thumb.format == rawpy.ThumbFormat.BITMAP:
+        shape = getattr(thumb.data, "shape", ())
+        if len(shape) >= 2:
+            return QSize(_positive_int(shape[1]), _positive_int(shape[0]))
+    return QSize()
+
+
+def _qimage_from_raw_thumb(
+    thumb: Any,
+    rawpy: Any,
+    target: QSize,
+    *,
+    orientation: int = 1,
+) -> QImage:
+    if thumb is None:
+        return QImage()
+    if thumb.format == rawpy.ThumbFormat.JPEG:
+        payload = QByteArray(bytes(thumb.data))
+        buffer = QBuffer(payload)
+        if not buffer.open(QIODevice.OpenModeFlag.ReadOnly):
+            return QImage()
+        try:
+            reader = QImageReader(buffer, b"JPEG")
+            reader.setAutoTransform(True)
+            intrinsic = reader.size()
+            if intrinsic.isValid() and not intrinsic.isEmpty():
+                reader_target = target
+                if orientation in (5, 6, 7, 8):
+                    reader_target = QSize(target.height(), target.width())
+                scaled = intrinsic.scaled(
+                    reader_target,
+                    Qt.AspectRatioMode.KeepAspectRatio,
+                )
+                if scaled.width() < intrinsic.width() or scaled.height() < intrinsic.height():
+                    reader.setScaledSize(scaled)
+            return reader.read()
+        finally:
+            buffer.close()
+    if thumb.format == rawpy.ThumbFormat.BITMAP:
+        return _qimage_from_array(thumb.data)
+    return QImage()
+
+
+def _postprocess_raw(raw: Any, *, half_size: bool) -> Any:
+    try:
+        return raw.postprocess(
+            use_camera_wb=True,
+            half_size=half_size,
+            no_auto_bright=False,
+            output_bps=8,
+        )
+    except Exception as exc:  # noqa: BLE001 - rawpy surfaces native codec failures variably
+        raise RuntimeError(f"RAW {('half' if half_size else 'full')} decode failed: {exc}") from exc
+
+
+def _raw_peak_fits_budget(
+    raw_size: QSize,
+    target: QSize,
+    budget_bytes: int,
+    *,
+    half_size: bool,
+) -> bool:
+    divisor = 4 if half_size else 1
+    array_bytes = max(1, raw_size.width()) * max(1, raw_size.height()) * 3 // divisor
+    output_w = min(
+        max(1, target.width()),
+        max(1, (raw_size.width() + (1 if half_size else 0)) // (2 if half_size else 1)),
+    )
+    output_h = min(
+        max(1, target.height()),
+        max(1, (raw_size.height() + (1 if half_size else 0)) // (2 if half_size else 1)),
+    )
+    # Scaling an RGB ndarray may briefly coexist with both the RGB target and
+    # its final RGBA surface.  Account for that peak before choosing full RAW.
+    target_bridge_bytes = output_w * output_h * 7
+    return array_bytes + target_bridge_bytes <= max(1, int(budget_bytes))
+
+
+def _qimage_from_array(array: Any, *, target: QSize | None = None) -> QImage:
+    shape = getattr(array, "shape", ())
+    strides = getattr(array, "strides", ())
+    if len(shape) != 3 or shape[2] not in (3, 4) or len(strides) < 1:
+        return QImage()
+    try:
+        height = int(shape[0])
+        width = int(shape[1])
+        stride = int(strides[0])
+        image_format = (
+            QImage.Format.Format_RGB888
+            if int(shape[2]) == 3
+            else QImage.Format.Format_RGBA8888
+        )
+        borrowed = QImage(array.data, width, height, stride, image_format)
+        if borrowed.isNull():
+            return QImage()
+        if target is not None and target.isValid() and not target.isEmpty() and (
+            borrowed.width() > target.width() or borrowed.height() > target.height()
+        ):
+            borrowed = borrowed.scaled(
+                target,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            return borrowed.convertToFormat(QImage.Format.Format_RGBA8888)
+        return borrowed.copy().convertToFormat(QImage.Format.Format_RGBA8888)
+    except (AttributeError, BufferError, TypeError, ValueError):
+        return QImage()
+
+
+__all__ = [
+    "CancellationToken",
+    "DecodeCancelledError",
+    "DecodedSurface",
+    "DefaultStillDecodeBackend",
+    "QtStillDecodeBackend",
+    "RawStillDecodeBackend",
+    "StillDecodeBackend",
+    "StillDecodeBackendRegistry",
+    "probe_raw_source_identity",
+]

--- a/src/iPhoto/gui/detail_decode_macos.py
+++ b/src/iPhoto/gui/detail_decode_macos.py
@@ -1,0 +1,114 @@
+"""Optional ImageIO/CoreGraphics still decoder for packaged macOS builds."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtGui import QImage
+
+
+class MacOSImageIOStillDecodeBackend:
+    name = "imageio"
+
+    def __init__(self, quartz: Any, foundation: Any) -> None:
+        self._quartz = quartz
+        self._foundation = foundation
+
+    def decode(self, request, cancellation):
+        from iPhoto.gui.detail_decode_backend import (
+            DecodedSurface,
+            _check_cancelled,
+            _normalise_surface,
+            _target_size,
+        )
+        from iPhoto.gui.detail_pipeline import DetailDecodeKey
+
+        prepared = request.with_decode_level()
+        target = _target_size(prepared)
+        _check_cancelled(cancellation)
+        url = self._foundation.NSURL.fileURLWithPath_(
+            str(prepared.source_identity.path)
+        )
+        source = self._quartz.CGImageSourceCreateWithURL(url, None)
+        if source is None:
+            raise RuntimeError("ImageIO could not create an image source")
+        options = {
+            self._quartz.kCGImageSourceCreateThumbnailFromImageAlways: True,
+            self._quartz.kCGImageSourceCreateThumbnailWithTransform: True,
+            self._quartz.kCGImageSourceThumbnailMaxPixelSize: max(
+                target.width(),
+                target.height(),
+            ),
+        }
+        cg_image = self._quartz.CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            options,
+        )
+        _check_cancelled(cancellation)
+        if cg_image is None:
+            raise RuntimeError("ImageIO could not decode a thumbnail surface")
+        width = int(self._quartz.CGImageGetWidth(cg_image))
+        height = int(self._quartz.CGImageGetHeight(cg_image))
+        if width <= 0 or height <= 0:
+            raise RuntimeError("ImageIO returned an empty surface")
+        stride = width * 4
+        pixels = bytearray(stride * height)
+        color_space = self._quartz.CGColorSpaceCreateWithName(
+            self._quartz.kCGColorSpaceSRGB
+        )
+        bitmap_info = (
+            self._quartz.kCGImageAlphaPremultipliedLast
+            | self._quartz.kCGBitmapByteOrder32Big
+        )
+        context = self._quartz.CGBitmapContextCreate(
+            pixels,
+            width,
+            height,
+            8,
+            stride,
+            color_space,
+            bitmap_info,
+        )
+        if context is None:
+            raise RuntimeError("CoreGraphics could not allocate a bitmap context")
+        self._quartz.CGContextDrawImage(
+            context,
+            self._quartz.CGRectMake(0, 0, width, height),
+            cg_image,
+        )
+        image = QImage(
+            bytes(pixels),
+            width,
+            height,
+            stride,
+            QImage.Format.Format_RGBA8888,
+        ).copy()
+        surface = _normalise_surface(image, target)
+        _check_cancelled(cancellation)
+        if surface.isNull():
+            raise RuntimeError("ImageIO returned an unusable RGBA surface")
+        return DecodedSurface(
+            image=surface,
+            decode_key=DetailDecodeKey.from_request(prepared),
+            source_size=(
+                max(1, prepared.source_identity.width or width),
+                max(1, prepared.source_identity.height or height),
+            ),
+            decoded_size=(surface.width(), surface.height()),
+            decode_level=prepared.decode_level or "full",
+            backend=self.name,
+        )
+
+
+def create_macos_imageio_backend() -> MacOSImageIOStillDecodeBackend | None:
+    try:
+        import Foundation  # type: ignore[import-not-found]
+        import Quartz  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    return MacOSImageIOStillDecodeBackend(Quartz, Foundation)
+
+
+__all__ = ["MacOSImageIOStillDecodeBackend", "create_macos_imageio_backend"]
+

--- a/src/iPhoto/gui/detail_decode_windows.py
+++ b/src/iPhoto/gui/detail_decode_windows.py
@@ -1,0 +1,524 @@
+"""Windows Imaging Component still-image decoder for Detail surfaces."""
+
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Any
+import uuid
+
+from PySide6.QtGui import QColorSpace, QImage
+
+from iPhoto.gui.detail_decode_backend import (
+    CancellationToken,
+    DecodedSurface,
+    _check_cancelled,
+    _target_size,
+)
+from iPhoto.gui.detail_pipeline import DetailDecodeKey, DetailRenderRequest
+
+
+class _GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", ctypes.c_uint32),
+        ("Data2", ctypes.c_uint16),
+        ("Data3", ctypes.c_uint16),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+    @classmethod
+    def from_string(cls, value: str) -> _GUID:
+        return cls.from_buffer_copy(uuid.UUID(value).bytes_le)
+
+
+_CLSID_WIC_FACTORY = _GUID.from_string("cacaf262-9370-4615-a13b-9f5539da4c0a")
+_IID_WIC_FACTORY = _GUID.from_string("ec5ec8a9-c395-4314-9c77-54d7a935ff70")
+_PIXEL_FORMAT_32BPP_RGBA = _GUID.from_string("f5c7ad2d-6a8d-43dd-a7a8-a29935261ae9")
+
+_CLSCTX_INPROC_SERVER = 0x1
+_COINIT_MULTITHREADED = 0x0
+_RPC_E_CHANGED_MODE = -2147417850
+_GENERIC_READ = 0x80000000
+_WIC_DECODE_METADATA_ON_DEMAND = 0
+_WIC_INTERPOLATION_FANT = 3
+# HRESULT is a signed 32-bit value.  ``ctypes.wintypes`` deliberately does not
+# define it on every supported CPython build, so use the ABI type directly.
+_HRESULT = ctypes.c_int32
+
+
+def _failed(result: int) -> bool:
+    return _HRESULT(result).value < 0
+
+
+def _check_hresult(result: int, operation: str) -> None:
+    if _failed(result):
+        code = ctypes.c_uint32(result).value
+        raise OSError(code, f"{operation} failed with HRESULT 0x{code:08X}")
+
+
+def _method(
+    interface: ctypes.c_void_p,
+    index: int,
+    result_type: Any,
+    *argument_types: Any,
+) -> Any:
+    vtable = ctypes.cast(
+        interface,
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ).contents
+    prototype = ctypes.WINFUNCTYPE(
+        result_type,
+        ctypes.c_void_p,
+        *argument_types,
+    )
+    return prototype(vtable[index])
+
+
+def _release(interface: ctypes.c_void_p | None) -> None:
+    if interface and interface.value:
+        _method(interface, 2, wintypes.ULONG)(interface)
+
+
+@dataclass(slots=True)
+class _ComApartment:
+    ole32: Any
+    must_uninitialize: bool
+
+    @classmethod
+    def enter(cls) -> _ComApartment:
+        ole32 = ctypes.WinDLL("ole32", use_last_error=True)
+        ole32.CoInitializeEx.argtypes = (ctypes.c_void_p, wintypes.DWORD)
+        ole32.CoInitializeEx.restype = _HRESULT
+        result = ole32.CoInitializeEx(None, _COINIT_MULTITHREADED)
+        signed = _HRESULT(result).value
+        if _failed(result) and signed != _RPC_E_CHANGED_MODE:
+            _check_hresult(result, "CoInitializeEx")
+        return cls(ole32=ole32, must_uninitialize=signed != _RPC_E_CHANGED_MODE)
+
+    def close(self) -> None:
+        if self.must_uninitialize:
+            self.ole32.CoUninitialize()
+
+
+def _create_factory(apartment: _ComApartment) -> ctypes.c_void_p:
+    factory = ctypes.c_void_p()
+    apartment.ole32.CoCreateInstance.argtypes = (
+        ctypes.POINTER(_GUID),
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(_GUID),
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    apartment.ole32.CoCreateInstance.restype = _HRESULT
+    result = apartment.ole32.CoCreateInstance(
+        ctypes.byref(_CLSID_WIC_FACTORY),
+        None,
+        _CLSCTX_INPROC_SERVER,
+        ctypes.byref(_IID_WIC_FACTORY),
+        ctypes.byref(factory),
+    )
+    _check_hresult(result, "CoCreateInstance(IWICImagingFactory)")
+    return factory
+
+
+def _create_decoder(
+    factory: ctypes.c_void_p,
+    source: Path,
+) -> ctypes.c_void_p:
+    decoder = ctypes.c_void_p()
+    create = _method(
+        factory,
+        3,
+        _HRESULT,
+        wintypes.LPCWSTR,
+        ctypes.POINTER(_GUID),
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    result = create(
+        factory,
+        str(source),
+        None,
+        _GENERIC_READ,
+        _WIC_DECODE_METADATA_ON_DEMAND,
+        ctypes.byref(decoder),
+    )
+    _check_hresult(result, "IWICImagingFactory.CreateDecoderFromFilename")
+    return decoder
+
+
+def _first_frame(decoder: ctypes.c_void_p) -> ctypes.c_void_p:
+    frame = ctypes.c_void_p()
+    get_frame = _method(
+        decoder,
+        13,
+        _HRESULT,
+        wintypes.UINT,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    _check_hresult(get_frame(decoder, 0, ctypes.byref(frame)), "IWICBitmapDecoder.GetFrame")
+    return frame
+
+
+def _source_size(source: ctypes.c_void_p) -> tuple[int, int]:
+    width = wintypes.UINT()
+    height = wintypes.UINT()
+    get_size = _method(
+        source,
+        3,
+        _HRESULT,
+        ctypes.POINTER(wintypes.UINT),
+        ctypes.POINTER(wintypes.UINT),
+    )
+    _check_hresult(get_size(source, ctypes.byref(width), ctypes.byref(height)), "IWICBitmapSource.GetSize")
+    return int(width.value), int(height.value)
+
+
+def _orientation_transform(orientation: int) -> int:
+    # WICBitmapTransformOptions: Rotate90/180/270=1/2/3, FlipHorizontal=8.
+    return {
+        2: 8,
+        3: 2,
+        4: 10,
+        5: 9,
+        6: 1,
+        7: 11,
+        8: 3,
+    }.get(orientation, 0)
+
+
+def _apply_orientation(
+    factory: ctypes.c_void_p,
+    source: ctypes.c_void_p,
+    orientation: int,
+) -> ctypes.c_void_p:
+    transform = _orientation_transform(orientation)
+    if transform == 0:
+        return ctypes.c_void_p()
+    rotator = ctypes.c_void_p()
+    create = _method(
+        factory,
+        13,
+        _HRESULT,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    _check_hresult(create(factory, ctypes.byref(rotator)), "IWICImagingFactory.CreateBitmapFlipRotator")
+    initialize = _method(
+        rotator,
+        8,
+        _HRESULT,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    )
+    try:
+        _check_hresult(initialize(rotator, source, transform), "IWICBitmapFlipRotator.Initialize")
+    except Exception:
+        _release(rotator)
+        raise
+    return rotator
+
+
+def _scale_source(
+    factory: ctypes.c_void_p,
+    source: ctypes.c_void_p,
+    width: int,
+    height: int,
+) -> ctypes.c_void_p:
+    scaler = ctypes.c_void_p()
+    create = _method(
+        factory,
+        11,
+        _HRESULT,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    _check_hresult(create(factory, ctypes.byref(scaler)), "IWICImagingFactory.CreateBitmapScaler")
+    initialize = _method(
+        scaler,
+        8,
+        _HRESULT,
+        ctypes.c_void_p,
+        wintypes.UINT,
+        wintypes.UINT,
+        wintypes.DWORD,
+    )
+    try:
+        _check_hresult(
+            initialize(scaler, source, width, height, _WIC_INTERPOLATION_FANT),
+            "IWICBitmapScaler.Initialize",
+        )
+    except Exception:
+        _release(scaler)
+        raise
+    return scaler
+
+
+def _convert_rgba(factory: ctypes.c_void_p, source: ctypes.c_void_p) -> ctypes.c_void_p:
+    converter = ctypes.c_void_p()
+    create = _method(
+        factory,
+        10,
+        _HRESULT,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    _check_hresult(create(factory, ctypes.byref(converter)), "IWICImagingFactory.CreateFormatConverter")
+    initialize = _method(
+        converter,
+        8,
+        _HRESULT,
+        ctypes.c_void_p,
+        ctypes.POINTER(_GUID),
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.c_double,
+        wintypes.DWORD,
+    )
+    try:
+        _check_hresult(
+            initialize(
+                converter,
+                source,
+                ctypes.byref(_PIXEL_FORMAT_32BPP_RGBA),
+                0,
+                None,
+                0.0,
+                0,
+            ),
+            "IWICFormatConverter.Initialize",
+        )
+    except Exception:
+        _release(converter)
+        raise
+    return converter
+
+
+def _create_color_context(factory: ctypes.c_void_p) -> ctypes.c_void_p:
+    context = ctypes.c_void_p()
+    create = _method(
+        factory,
+        15,
+        _HRESULT,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    _check_hresult(
+        create(factory, ctypes.byref(context)),
+        "IWICImagingFactory.CreateColorContext",
+    )
+    return context
+
+
+def _frame_color_context(
+    factory: ctypes.c_void_p,
+    frame: ctypes.c_void_p,
+) -> ctypes.c_void_p:
+    """Return the frame's first embedded color context, if it has one."""
+
+    actual_count = wintypes.UINT()
+    get_contexts = _method(
+        frame,
+        9,
+        _HRESULT,
+        wintypes.UINT,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(wintypes.UINT),
+    )
+    result = get_contexts(frame, 0, None, ctypes.byref(actual_count))
+    if _failed(result) or actual_count.value == 0:
+        return ctypes.c_void_p()
+
+    context = _create_color_context(factory)
+    contexts = (ctypes.c_void_p * 1)(context.value)
+    try:
+        _check_hresult(
+            get_contexts(frame, 1, contexts, ctypes.byref(actual_count)),
+            "IWICBitmapFrameDecode.GetColorContexts",
+        )
+        if actual_count.value == 0:
+            _release(context)
+            return ctypes.c_void_p()
+    except Exception:
+        _release(context)
+        raise
+    return context
+
+
+def _create_srgb_color_context(factory: ctypes.c_void_p) -> ctypes.c_void_p:
+    context = _create_color_context(factory)
+    initialize = _method(
+        context,
+        5,
+        _HRESULT,
+        wintypes.UINT,
+    )
+    try:
+        _check_hresult(
+            initialize(context, 1),
+            "IWICColorContext.InitializeFromExifColorSpace(sRGB)",
+        )
+    except Exception:
+        _release(context)
+        raise
+    return context
+
+
+def _transform_to_srgb(
+    factory: ctypes.c_void_p,
+    source: ctypes.c_void_p,
+    source_context: ctypes.c_void_p,
+    target_context: ctypes.c_void_p,
+) -> ctypes.c_void_p:
+    transform = ctypes.c_void_p()
+    create = _method(
+        factory,
+        16,
+        _HRESULT,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    _check_hresult(
+        create(factory, ctypes.byref(transform)),
+        "IWICImagingFactory.CreateColorTransformer",
+    )
+    initialize = _method(
+        transform,
+        8,
+        _HRESULT,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(_GUID),
+    )
+    try:
+        _check_hresult(
+            initialize(
+                transform,
+                source,
+                source_context,
+                target_context,
+                ctypes.byref(_PIXEL_FORMAT_32BPP_RGBA),
+            ),
+            "IWICColorTransform.Initialize",
+        )
+    except Exception:
+        _release(transform)
+        raise
+    return transform
+
+
+def _copy_rgba(source: ctypes.c_void_p, width: int, height: int) -> QImage:
+    stride = width * 4
+    size = stride * height
+    pixels = (ctypes.c_ubyte * size)()
+    copy_pixels = _method(
+        source,
+        7,
+        _HRESULT,
+        ctypes.c_void_p,
+        wintypes.UINT,
+        wintypes.UINT,
+        ctypes.POINTER(ctypes.c_ubyte),
+    )
+    _check_hresult(
+        copy_pixels(source, None, stride, size, pixels),
+        "IWICBitmapSource.CopyPixels",
+    )
+    image = QImage(bytes(pixels), width, height, stride, QImage.Format.Format_RGBA8888).copy()
+    image.setColorSpace(QColorSpace(QColorSpace.NamedColorSpace.SRgb))
+    return image
+
+
+class WindowsWicStillDecodeBackend:
+    """Decode an indexed still through WIC and return detached RGBA8888/sRGB."""
+
+    name = "wic"
+
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface:
+        prepared = request.with_decode_level()
+        target = _target_size(prepared)
+        _check_cancelled(cancellation)
+        apartment = _ComApartment.enter()
+        factory = decoder = frame = oriented = scaler = converter = None
+        source_color = target_color = color_transform = None
+        try:
+            factory = _create_factory(apartment)
+            decoder = _create_decoder(factory, prepared.source_identity.path)
+            frame = _first_frame(decoder)
+            intrinsic = _source_size(frame)
+            oriented = _apply_orientation(
+                factory,
+                frame,
+                prepared.source_identity.orientation,
+            )
+            current = oriented if oriented and oriented.value else frame
+            current_size = _source_size(current)
+            scaled_width, scaled_height = current_size
+            if current_size[0] > target.width() or current_size[1] > target.height():
+                ratio = min(
+                    target.width() / current_size[0],
+                    target.height() / current_size[1],
+                )
+                scaled_width = max(1, round(current_size[0] * ratio))
+                scaled_height = max(1, round(current_size[1] * ratio))
+                scaler = _scale_source(factory, current, scaled_width, scaled_height)
+                current = scaler
+            _check_cancelled(cancellation)
+            source_color = _frame_color_context(factory, frame)
+            if source_color and source_color.value:
+                target_color = _create_srgb_color_context(factory)
+                color_transform = _transform_to_srgb(
+                    factory,
+                    current,
+                    source_color,
+                    target_color,
+                )
+                rgba_source = color_transform
+            else:
+                converter = _convert_rgba(factory, current)
+                rgba_source = converter
+            image = _copy_rgba(rgba_source, scaled_width, scaled_height)
+            _check_cancelled(cancellation)
+        finally:
+            for interface in (
+                converter,
+                color_transform,
+                target_color,
+                source_color,
+                scaler,
+                oriented,
+                frame,
+                decoder,
+                factory,
+            ):
+                _release(interface)
+            apartment.close()
+        if image.isNull():
+            raise RuntimeError("WIC returned an empty neutral surface")
+        return DecodedSurface(
+            image=image,
+            decode_key=DetailDecodeKey.from_request(prepared),
+            source_size=(
+                max(1, prepared.source_identity.width or intrinsic[0]),
+                max(1, prepared.source_identity.height or intrinsic[1]),
+            ),
+            decoded_size=(image.width(), image.height()),
+            decode_level=prepared.decode_level or "full",
+            backend=self.name,
+        )
+
+
+def create_windows_wic_backend() -> WindowsWicStillDecodeBackend | None:
+    """Return the production WIC backend only on Windows."""
+
+    if sys.platform != "win32" or not hasattr(ctypes, "WinDLL"):
+        return None
+    return WindowsWicStillDecodeBackend()
+
+
+__all__ = ["WindowsWicStillDecodeBackend", "create_windows_wic_backend"]
+

--- a/src/iPhoto/gui/detail_pipeline.py
+++ b/src/iPhoto/gui/detail_pipeline.py
@@ -1,0 +1,427 @@
+"""Shared values and bounded caches for the Detail opening pipeline."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Literal
+
+DETAIL_DECODE_LEVELS = (1024, 2048, 3072, 4096)
+
+DetailMediaKind = Literal["image", "video", "live_motion"]
+DetailTransactionReason = Literal[
+    "click",
+    "prefetch",
+    "resize",
+    "zoom",
+    "live_replay",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AssetSourceIdentity:
+    """Indexed identity for neutral source pixels without GUI-thread stat I/O."""
+
+    path: Path
+    size_bytes: int = 0
+    source_mtime_ns: int = 0
+    index_revision: int = 0
+    width: int = 0
+    height: int = 0
+    orientation: int = 1
+
+    @classmethod
+    def create(
+        cls,
+        path: Path,
+        *,
+        size_bytes: object = 0,
+        source_mtime_ns: object = 0,
+        index_revision: object = 0,
+        width: object = 0,
+        height: object = 0,
+        orientation: object = 1,
+    ) -> AssetSourceIdentity:
+        return cls(
+            path=Path(path).expanduser().absolute(),
+            size_bytes=_non_negative_int(size_bytes),
+            source_mtime_ns=_non_negative_int(source_mtime_ns),
+            index_revision=_non_negative_int(index_revision),
+            width=_non_negative_int(width),
+            height=_non_negative_int(height),
+            orientation=_orientation_value(orientation),
+        )
+
+    @classmethod
+    def from_info(cls, path: Path, info: Mapping[str, Any] | None) -> AssetSourceIdentity:
+        values = info or {}
+        return cls.create(
+            path,
+            size_bytes=values.get("bytes", values.get("size_bytes", 0)),
+            source_mtime_ns=values.get("source_mtime_ns", 0),
+            index_revision=values.get("index_revision", 0),
+            width=values.get("w", values.get("width", 0)),
+            height=values.get("h", values.get("height", 0)),
+            orientation=values.get("orientation", values.get("image_orientation", 1)),
+        )
+
+    @property
+    def revision(self) -> tuple[str, int, int]:
+        if self.source_mtime_ns > 0:
+            return ("mtime", self.size_bytes, self.source_mtime_ns)
+        if self.index_revision > 0:
+            return ("index", self.size_bytes, self.index_revision)
+        return ("legacy", self.size_bytes, 0)
+
+    @property
+    def has_stable_revision(self) -> bool:
+        """Whether this identity can safely participate in a reusable cache."""
+
+        return self.source_mtime_ns > 0 or self.index_revision > 0
+
+    def repair_revision_from_stat(self) -> AssetSourceIdentity:
+        """Fill a missing revision on a preparation worker.
+
+        Callers must not invoke this from the GUI thread.  A failed stat leaves
+        the identity unstable so cache layers can bypass it safely.
+        """
+
+        if self.has_stable_revision:
+            return self
+        try:
+            source_stat = self.path.stat()
+        except OSError:
+            return self
+        mtime_ns = max(0, int(getattr(source_stat, "st_mtime_ns", 0) or 0))
+        if mtime_ns <= 0:
+            return self
+        return replace(
+            self,
+            size_bytes=max(0, int(source_stat.st_size)),
+            source_mtime_ns=mtime_ns,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DetailRenderTransaction:
+    """Immutable identity shared by still and video Detail render work."""
+
+    generation: int
+    asset_id: str
+    media_kind: DetailMediaKind
+    source_identity: AssetSourceIdentity
+    viewport_physical_size: tuple[int, int] = (0, 0)
+    device_pixel_ratio: float = 1.0
+    reason: DetailTransactionReason = "click"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "generation", _non_negative_int(self.generation))
+        object.__setattr__(self, "asset_id", str(self.asset_id).strip())
+        object.__setattr__(
+            self,
+            "viewport_physical_size",
+            (
+                _non_negative_int(self.viewport_physical_size[0]),
+                _non_negative_int(self.viewport_physical_size[1]),
+            ),
+        )
+        object.__setattr__(
+            self,
+            "device_pixel_ratio",
+            max(0.1, _finite_float(self.device_pixel_ratio, 1.0)),
+        )
+
+    def with_viewport(
+        self,
+        viewport_physical_size: tuple[int, int],
+        device_pixel_ratio: float,
+    ) -> DetailRenderTransaction:
+        """Return the same transaction identity with current render metrics."""
+
+        return DetailRenderTransaction(
+            generation=self.generation,
+            asset_id=self.asset_id,
+            media_kind=self.media_kind,
+            source_identity=self.source_identity,
+            viewport_physical_size=viewport_physical_size,
+            device_pixel_ratio=device_pixel_ratio,
+            reason=self.reason,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DetailGeometryState:
+    crop_cx: float = 0.5
+    crop_cy: float = 0.5
+    crop_width: float = 1.0
+    crop_height: float = 1.0
+    rotate90: int = 0
+    straighten: float = 0.0
+    perspective_vertical: float = 0.0
+    perspective_horizontal: float = 0.0
+
+    @classmethod
+    def from_adjustments(cls, values: Mapping[str, Any] | None) -> DetailGeometryState:
+        source = values or {}
+        return cls(
+            crop_cx=_finite_float(source.get("Crop_CX", 0.5), 0.5),
+            crop_cy=_finite_float(source.get("Crop_CY", 0.5), 0.5),
+            crop_width=max(0.0001, _finite_float(source.get("Crop_W", 1.0), 1.0)),
+            crop_height=max(0.0001, _finite_float(source.get("Crop_H", 1.0), 1.0)),
+            rotate90=_non_negative_int(source.get("Crop_Rotate90", 0)) % 4,
+            straighten=_clamp_float(source.get("Crop_Straighten", 0.0), -45.0, 45.0, 0.0),
+            perspective_vertical=_clamp_float(
+                source.get("Perspective_Vertical", 0.0), -1.0, 1.0, 0.0
+            ),
+            perspective_horizontal=_clamp_float(
+                source.get("Perspective_Horizontal", 0.0), -1.0, 1.0, 0.0
+            ),
+        )
+
+
+DetailRequestReason = Literal["prefetch", "initial", "resize", "zoom"]
+DetailResidencySlot = Literal["previous", "next"]
+DetailDecodeLevel = int | Literal["full"]
+
+
+@dataclass(frozen=True, slots=True)
+class DetailRenderRequest:
+    generation: int
+    asset_id: str
+    source_identity: AssetSourceIdentity
+    viewport_physical_size: tuple[int, int]
+    device_pixel_ratio: float
+    geometry: DetailGeometryState
+    reason: DetailRequestReason
+    texture_limit: int = 8192
+    raw_adjustments: Mapping[str, Any] | None = None
+    decode_level: DetailDecodeLevel | None = None
+    zoom_factor: float = 1.0
+    residency_slot: DetailResidencySlot | None = None
+    window_generation: int = 0
+
+    @classmethod
+    def from_transaction(
+        cls,
+        transaction: DetailRenderTransaction,
+        *,
+        geometry: DetailGeometryState,
+        reason: DetailRequestReason,
+        texture_limit: int = 8192,
+        raw_adjustments: Mapping[str, Any] | None = None,
+        decode_level: DetailDecodeLevel | None = None,
+        zoom_factor: float = 1.0,
+        residency_slot: DetailResidencySlot | None = None,
+        window_generation: int = 0,
+    ) -> DetailRenderRequest:
+        if transaction.media_kind == "video":
+            raise ValueError("Video transactions cannot create still decode requests")
+        return cls(
+            generation=transaction.generation,
+            asset_id=transaction.asset_id,
+            source_identity=transaction.source_identity,
+            viewport_physical_size=transaction.viewport_physical_size,
+            device_pixel_ratio=transaction.device_pixel_ratio,
+            geometry=geometry,
+            reason=reason,
+            texture_limit=texture_limit,
+            raw_adjustments=raw_adjustments,
+            decode_level=decode_level,
+            zoom_factor=zoom_factor,
+            residency_slot=residency_slot,
+            window_generation=window_generation,
+        )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "raw_adjustments",
+            MappingProxyType(dict(self.raw_adjustments or {})),
+        )
+        object.__setattr__(self, "zoom_factor", max(1.0, _finite_float(self.zoom_factor, 1.0)))
+        object.__setattr__(self, "window_generation", _non_negative_int(self.window_generation))
+
+    def with_decode_level(self) -> DetailRenderRequest:
+        if self.decode_level is not None:
+            return self
+        return DetailRenderRequest(
+            generation=self.generation,
+            asset_id=self.asset_id,
+            source_identity=self.source_identity,
+            viewport_physical_size=self.viewport_physical_size,
+            device_pixel_ratio=self.device_pixel_ratio,
+            geometry=self.geometry,
+            reason=self.reason,
+            texture_limit=self.texture_limit,
+            raw_adjustments=dict(self.raw_adjustments or {}),
+            decode_level=select_detail_decode_level(self),
+            zoom_factor=self.zoom_factor,
+            residency_slot=self.residency_slot,
+            window_generation=max(0, int(self.window_generation)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DetailDecodeKey:
+    asset_id: str
+    source: Path
+    source_revision: tuple[str, int, int]
+    orientation: int
+    decode_level: DetailDecodeLevel
+
+    @classmethod
+    def from_request(cls, request: DetailRenderRequest) -> DetailDecodeKey:
+        prepared = request.with_decode_level()
+        decode_level = prepared.decode_level or "full"
+        identity = prepared.source_identity
+        return cls(
+            asset_id=str(prepared.asset_id).strip() or identity.path.name,
+            source=identity.path,
+            source_revision=identity.revision,
+            orientation=identity.orientation,
+            decode_level=decode_level,
+        )
+
+
+def select_detail_decode_level(request: DetailRenderRequest) -> DetailDecodeLevel:
+    """Choose the smallest neutral-surface tier satisfying the visible viewport."""
+
+    identity = request.source_identity
+    if identity.width <= 0 or identity.height <= 0:
+        return "full"
+    source_w = max(1, identity.width)
+    source_h = max(1, identity.height)
+    viewport_w = max(1, int(request.viewport_physical_size[0]))
+    viewport_h = max(1, int(request.viewport_physical_size[1]))
+    geometry = request.geometry
+
+    crop_pixel_w = max(1.0, source_w * geometry.crop_width)
+    crop_pixel_h = max(1.0, source_h * geometry.crop_height)
+    if geometry.rotate90 % 2:
+        visible_w, visible_h = crop_pixel_h, crop_pixel_w
+    else:
+        visible_w, visible_h = crop_pixel_w, crop_pixel_h
+    fit_scale = min(viewport_w / visible_w, viewport_h / visible_h)
+
+    angle = math.radians(abs(geometry.straighten))
+    straighten_scale = max(1.0, abs(math.cos(angle)) + abs(math.sin(angle)))
+    perspective_scale = 1.0 + 0.5 * max(
+        abs(geometry.perspective_vertical),
+        abs(geometry.perspective_horizontal),
+    )
+    zoom_factor = max(1.0, _finite_float(request.zoom_factor, 1.0))
+    required = math.ceil(
+        max(source_w, source_h)
+        * fit_scale
+        * straighten_scale
+        * perspective_scale
+        * zoom_factor
+    )
+    source_longest = max(source_w, source_h)
+    required = min(source_longest, max(1, required))
+    effective_limit = max(1, min(source_longest, int(request.texture_limit or 8192)))
+    if required > DETAIL_DECODE_LEVELS[-1]:
+        return "full"
+    for level in DETAIL_DECODE_LEVELS:
+        if required <= level:
+            return min(level, effective_limit, source_longest)
+    return "full"
+
+
+@dataclass(frozen=True, slots=True)
+class DetailMediaPreparation:
+    request_generation: int
+    path: Path
+    adjustments: dict[str, Any]
+    trim_range_ms: tuple[int, int] | None = None
+    adjusted_preview: bool = False
+    rotation_cw: int = 0
+    raw_width: int = 0
+    raw_height: int = 0
+    linux_180_hint: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class VideoPresentationState:
+    request_generation: int
+    adjustments: dict[str, Any]
+    trim_range_ms: tuple[int, int] | None
+    adjusted_preview: bool
+    rotation_cw: int
+    raw_width: int
+    raw_height: int
+    linux_180_hint: bool
+    transaction: DetailRenderTransaction | None = None
+
+    @property
+    def generation(self) -> int:
+        if self.transaction is not None:
+            return self.transaction.generation
+        return self.request_generation
+
+
+@dataclass(slots=True)
+class DetailOpenTrace:
+    request_generation: int
+    row: int
+    asset_id: str = ""
+    media_kind: str = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class DetailPrefetchDescriptor:
+    row: int
+    asset_id: str
+    path: Path
+    is_video: bool
+    source_identity: AssetSourceIdentity | None = None
+
+
+def _non_negative_int(value: object) -> int:
+    try:
+        return max(0, int(float(value)))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _orientation_value(value: object) -> int:
+    numeric = _non_negative_int(value)
+    return numeric if 1 <= numeric <= 8 else 1
+
+
+def _clamp_float(value: object, minimum: float, maximum: float, default: float) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    if not math.isfinite(numeric):
+        return default
+    return max(minimum, min(maximum, numeric))
+
+
+def _finite_float(value: object, default: float) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return numeric if math.isfinite(numeric) else default
+
+
+__all__ = [
+    "DETAIL_DECODE_LEVELS",
+    "AssetSourceIdentity",
+    "DetailDecodeKey",
+    "DetailDecodeLevel",
+    "DetailGeometryState",
+    "DetailMediaPreparation",
+    "DetailOpenTrace",
+    "DetailPrefetchDescriptor",
+    "DetailRenderTransaction",
+    "DetailRenderRequest",
+    "DetailResidencySlot",
+    "VideoPresentationState",
+    "select_detail_decode_level",
+]

--- a/src/iPhoto/gui/detail_profile.py
+++ b/src/iPhoto/gui/detail_profile.py
@@ -1,17 +1,26 @@
-"""Helpers for lightweight detail-view performance diagnostics."""
+"""Asynchronous, privacy-safe Detail performance diagnostics."""
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import time
+from pathlib import Path
+from queue import Empty, Full, Queue
+from threading import Lock, Thread
+from typing import Final
 
 LOGGER = logging.getLogger(__name__)
 
-_TRUTHY = {"1", "true", "yes", "on"}
+_TRUTHY: Final = {"1", "true", "yes", "on"}
+_PROFILE_LOCK = Lock()
+_STOP: Final = object()
+_WRITER: _AsyncDetailEventWriter | None = None
 
 
 def detail_profile_enabled() -> bool:
-    """Return whether detail-view profiling logs should be emitted."""
+    """Return whether Detail profiling is enabled for this process."""
 
     return os.environ.get("IPHOTO_DETAIL_PROFILE", "").strip().lower() in _TRUTHY
 
@@ -22,7 +31,7 @@ def log_detail_profile(
     elapsed_ms: float | None = None,
     **details: object,
 ) -> None:
-    """Emit a structured profiling line when detail profiling is enabled."""
+    """Emit a human-readable diagnostic line when profiling is enabled."""
 
     if not detail_profile_enabled():
         return
@@ -30,18 +39,171 @@ def log_detail_profile(
     suffix = ""
     if details:
         suffix = " " + " ".join(f"{key}={value}" for key, value in details.items())
-
     if elapsed_ms is None:
         LOGGER.info("[detail_profile][%s] %s%s", component, stage, suffix)
+    else:
+        LOGGER.info(
+            "[detail_profile][%s] %s %.1fms%s",
+            component,
+            stage,
+            elapsed_ms,
+            suffix,
+        )
+
+
+def _privacy_safe(value: object) -> object:
+    if isinstance(value, Path):
+        return value.name
+    if isinstance(value, str) and os.path.isabs(value):
+        return Path(value).name
+    if isinstance(value, dict):
+        return {
+            str(key): _privacy_safe(item)
+            for key, item in value.items()
+            if str(key) not in {"path", "absolute_path", "source"}
+        }
+    if isinstance(value, (list, tuple)):
+        return [_privacy_safe(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+class _AsyncDetailEventWriter:
+    """Own the only thread allowed to open and append the JSONL target."""
+
+    def __init__(self, target: Path | None) -> None:
+        self.target = target
+        self._queue: Queue[dict[str, object] | object] = Queue(maxsize=8192)
+        self._thread = Thread(
+            target=self._run,
+            name="iPhoto-detail-profile-writer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def enqueue(self, payload: dict[str, object]) -> None:
+        try:
+            self._queue.put_nowait(payload)
+        except Full:
+            LOGGER.debug("Dropping Detail profile event because the queue is full")
+
+    def close(self, timeout_ms: int) -> None:
+        try:
+            self._queue.put_nowait(_STOP)
+        except Full:
+            # A bounded shutdown is more important than preserving diagnostics.
+            try:
+                self._queue.get_nowait()
+            except Empty:
+                pass
+            try:
+                self._queue.put_nowait(_STOP)
+            except Full:
+                return
+        self._thread.join(max(0, int(timeout_ms)) / 1000.0)
+
+    def _run(self) -> None:
+        stream = None
+        try:
+            if self.target is not None:
+                self.target.parent.mkdir(parents=True, exist_ok=True)
+                stream = self.target.open("a", encoding="utf-8")
+            batch: list[dict[str, object]] = []
+            stopping = False
+            while not stopping:
+                try:
+                    item = self._queue.get(timeout=0.1)
+                except Empty:
+                    item = None
+                if item is _STOP:
+                    stopping = True
+                elif isinstance(item, dict):
+                    batch.append(item)
+
+                while len(batch) < 64 and not stopping:
+                    try:
+                        item = self._queue.get_nowait()
+                    except Empty:
+                        break
+                    if item is _STOP:
+                        stopping = True
+                        break
+                    if isinstance(item, dict):
+                        batch.append(item)
+
+                if not batch:
+                    continue
+                for payload in batch:
+                    LOGGER.info(
+                        "[detail_profile][open] %s generation=%s",
+                        payload["stage"],
+                        payload["generation"],
+                    )
+                    if stream is not None:
+                        stream.write(
+                            json.dumps(payload, ensure_ascii=False, default=str) + "\n"
+                        )
+                if stream is not None:
+                    stream.flush()
+                batch.clear()
+        except OSError:
+            LOGGER.debug("Detail profile writer failed", exc_info=True)
+        finally:
+            if stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+
+
+def _writer_for_current_configuration() -> _AsyncDetailEventWriter:
+    global _WRITER
+
+    profile_path = os.environ.get("IPHOTO_DETAIL_PROFILE_PATH", "").strip()
+    target = Path(profile_path).expanduser() if profile_path else None
+    with _PROFILE_LOCK:
+        if _WRITER is None or _WRITER.target != target:
+            if _WRITER is not None:
+                _WRITER.close(500)
+            _WRITER = _AsyncDetailEventWriter(target)
+        return _WRITER
+
+
+def emit_detail_event(stage: str, *, generation: int, **details: object) -> None:
+    """Queue one timestamped event without filesystem I/O on the caller thread."""
+
+    if not detail_profile_enabled():
         return
+    safe_details = {
+        key: _privacy_safe(value)
+        for key, value in details.items()
+        if key not in {"path", "absolute_path", "source"}
+    }
+    payload: dict[str, object] = {
+        "stage": str(stage),
+        "monotonic_ms": round(time.perf_counter() * 1000.0, 3),
+        "wall_time": time.time(),
+        "generation": int(generation),
+        "details": safe_details,
+    }
+    _writer_for_current_configuration().enqueue(payload)
 
-    LOGGER.info(
-        "[detail_profile][%s] %s %.1fms%s",
-        component,
-        stage,
-        elapsed_ms,
-        suffix,
-    )
+
+def shutdown_detail_profile(*, timeout_ms: int = 1000) -> None:
+    """Flush queued events within a bounded application-shutdown window."""
+
+    global _WRITER
+    with _PROFILE_LOCK:
+        writer = _WRITER
+        _WRITER = None
+    if writer is not None:
+        writer.close(timeout_ms)
 
 
-__all__ = ["detail_profile_enabled", "log_detail_profile"]
+__all__ = [
+    "detail_profile_enabled",
+    "emit_detail_event",
+    "log_detail_profile",
+    "shutdown_detail_profile",
+]

--- a/src/iPhoto/gui/detail_render_coordinator.py
+++ b/src/iPhoto/gui/detail_render_coordinator.py
@@ -1,0 +1,174 @@
+"""GUI-owned lifecycle coordinator for Detail still and video transactions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from PySide6.QtCore import QObject, Signal
+
+from iPhoto.gui.detail_pipeline import DetailRenderTransaction
+from iPhoto.gui.detail_profile import emit_detail_event
+
+
+class DetailRenderState(str, Enum):
+    CREATED = "created"
+    ROUTED = "routed"
+    PREPARING = "preparing"
+    PRESENTED = "presented"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+_TERMINAL_STATES = {
+    DetailRenderState.PRESENTED,
+    DetailRenderState.FAILED,
+    DetailRenderState.CANCELLED,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DetailRenderSnapshot:
+    transaction: DetailRenderTransaction
+    state: DetailRenderState
+    message: str = ""
+
+
+class DetailRenderCoordinator(QObject):
+    """Own the active transaction and enforce one current terminal result."""
+
+    stateChanged = Signal(object)
+    presented = Signal(object)
+    failed = Signal(object)
+    cancelled = Signal(object)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._snapshot: DetailRenderSnapshot | None = None
+
+    @property
+    def snapshot(self) -> DetailRenderSnapshot | None:
+        return self._snapshot
+
+    @property
+    def current_generation(self) -> int:
+        snapshot = self._snapshot
+        return snapshot.transaction.generation if snapshot is not None else 0
+
+    def is_current(self, generation: int) -> bool:
+        snapshot = self._snapshot
+        return bool(
+            snapshot is not None
+            and snapshot.transaction.generation == int(generation)
+            and snapshot.state not in _TERMINAL_STATES
+        )
+
+    def begin(self, transaction: DetailRenderTransaction) -> bool:
+        if transaction.generation <= 0:
+            raise ValueError("Detail render transaction generation must be positive")
+        current = self._snapshot
+        if current is not None:
+            if current.transaction == transaction and current.state not in _TERMINAL_STATES:
+                return False
+            if current.state not in _TERMINAL_STATES:
+                self._transition(DetailRenderState.CANCELLED)
+        self._snapshot = DetailRenderSnapshot(transaction, DetailRenderState.CREATED)
+        self.stateChanged.emit(self._snapshot)
+        return True
+
+    def mark_routed(self, generation: int, *, row: int) -> bool:
+        if not self._can_transition(generation, {DetailRenderState.CREATED}):
+            return False
+        transaction = self._snapshot.transaction  # type: ignore[union-attr]
+        emit_detail_event(
+            "route_visible",
+            generation=transaction.generation,
+            row=int(row),
+            media_type=transaction.media_kind,
+        )
+        self._transition(DetailRenderState.ROUTED)
+        return True
+
+    def mark_preparing(self, generation: int) -> bool:
+        if not self._can_transition(
+            generation,
+            {DetailRenderState.CREATED, DetailRenderState.ROUTED},
+        ):
+            return False
+        self._transition(DetailRenderState.PREPARING)
+        return True
+
+    def mark_presented(self, generation: int) -> bool:
+        if not self._can_transition(
+            generation,
+            {
+                DetailRenderState.CREATED,
+                DetailRenderState.ROUTED,
+                DetailRenderState.PREPARING,
+            },
+        ):
+            return False
+        transaction = self._snapshot.transaction  # type: ignore[union-attr]
+        emit_detail_event(
+            "presented",
+            generation=transaction.generation,
+            media_type=transaction.media_kind,
+        )
+        if transaction.media_kind in {"video", "live_motion"}:
+            emit_detail_event(
+                "video_first_frame_presented",
+                generation=transaction.generation,
+                media_type=transaction.media_kind,
+            )
+        self._transition(DetailRenderState.PRESENTED)
+        return True
+
+    def mark_failed(self, generation: int, message: str) -> bool:
+        if not self.is_current(generation):
+            return False
+        emit_detail_event("failed", generation=int(generation), message=str(message))
+        self._transition(DetailRenderState.FAILED, message=str(message))
+        return True
+
+    def cancel_current(self) -> bool:
+        snapshot = self._snapshot
+        if snapshot is None or snapshot.state in _TERMINAL_STATES:
+            return False
+        self._transition(DetailRenderState.CANCELLED)
+        return True
+
+    def _can_transition(
+        self,
+        generation: int,
+        allowed: set[DetailRenderState],
+    ) -> bool:
+        snapshot = self._snapshot
+        return bool(
+            snapshot is not None
+            and snapshot.transaction.generation == int(generation)
+            and snapshot.state in allowed
+        )
+
+    def _transition(self, state: DetailRenderState, *, message: str = "") -> None:
+        snapshot = self._snapshot
+        if snapshot is None:
+            return
+        self._snapshot = DetailRenderSnapshot(snapshot.transaction, state, message)
+        emit = {
+            DetailRenderState.PRESENTED: self.presented,
+            DetailRenderState.FAILED: self.failed,
+            DetailRenderState.CANCELLED: self.cancelled,
+        }.get(state)
+        if state == DetailRenderState.CANCELLED:
+            emit_detail_event("cancelled", generation=snapshot.transaction.generation)
+        self.stateChanged.emit(self._snapshot)
+        if emit is not None:
+            emit.emit(self._snapshot)
+
+
+__all__ = [
+    "DetailRenderCoordinator",
+    "DetailRenderSnapshot",
+    "DetailRenderState",
+]
+

--- a/src/iPhoto/gui/detail_request_scheduler.py
+++ b/src/iPhoto/gui/detail_request_scheduler.py
@@ -1,0 +1,368 @@
+"""Deduplicated request scheduling for Detail still-image decoders."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from PySide6.QtCore import QObject, QThreadPool, Signal
+
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import DetailDecodeKey, DetailRenderRequest
+from iPhoto.gui.detail_profile import emit_detail_event
+
+
+@dataclass(slots=True)
+class _InflightDecode:
+    key: DetailDecodeKey
+    request: DetailRenderRequest
+    worker: Any
+    state: Literal["queued", "running"]
+    foreground_generation: int | None
+    priority: int
+
+
+class DetailStillRequestScheduler(QObject):
+    """Own and deduplicate queued/running Detail still decoders.
+
+    Native image decoders cannot reliably be interrupted once running.  The
+    scheduler therefore promotes or subscribes to an existing same-key task
+    instead of launching a second decoder, while unrelated running stale tasks
+    are allowed to finish without publishing into the active generation.
+    """
+
+    ready = Signal(int, object)
+    warmed = Signal(object, object)
+    failed = Signal(int, Path, str)
+    finished = Signal(object)
+
+    def __init__(
+        self,
+        *,
+        pool: QThreadPool,
+        worker_factory: Callable[[DetailRenderRequest], Any],
+        reuse_enabled: bool = True,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._pool = pool
+        self._worker_factory = worker_factory
+        self._reuse_enabled = bool(reuse_enabled)
+        self._inflight_by_key: dict[DetailDecodeKey, _InflightDecode] = {}
+        self._entry_by_worker_id: dict[int, _InflightDecode] = {}
+        self._current_generation = 0
+        self._active_window_generation = 0
+        self._prefetch_queue: list[DetailRenderRequest] = []
+        self._shutting_down = False
+
+    @property
+    def inflight_count(self) -> int:
+        return len(self._inflight_by_key)
+
+    def prefetch(self, request: DetailRenderRequest) -> bool:
+        """Submit one speculative source unless it is already in flight."""
+
+        if self._shutting_down:
+            return False
+        prepared = request.with_decode_level()
+        key = DetailDecodeKey.from_request(prepared)
+        if key in self._inflight_by_key:
+            return False
+
+        if prepared.window_generation > self._active_window_generation:
+            self._active_window_generation = prepared.window_generation
+            self._prefetch_queue.clear()
+        elif (
+            prepared.window_generation > 0
+            and prepared.window_generation < self._active_window_generation
+        ):
+            return False
+
+        # Keep speculative work bounded.  A running prefetch may be promoted by
+        # a click, but moving the pointer must not fill both decoder lanes with
+        # obsolete speculative work.
+        if any(
+            entry.foreground_generation is None
+            for entry in self._inflight_by_key.values()
+        ):
+            if prepared.residency_slot is not None:
+                if all(
+                    DetailDecodeKey.from_request(queued) != key
+                    for queued in self._prefetch_queue
+                ):
+                    self._prefetch_queue.append(prepared)
+                    return True
+            return False
+
+        entry = self._create_entry(prepared, generation=None, priority=-1)
+        emit_detail_event(
+            "scheduled",
+            generation=0,
+            asset_id=key.asset_id,
+            suffix=key.source.suffix.lower(),
+            decode_level=key.decode_level,
+        )
+        return self._submit(entry)
+
+    def prefetch_window(self, *requests: DetailRenderRequest) -> bool:
+        """Replace the bounded previous/next speculative window."""
+
+        prepared = [request.with_decode_level() for request in requests]
+        if not prepared:
+            self._prefetch_queue.clear()
+            self._active_window_generation += 1
+            return False
+        newest = max(request.window_generation for request in prepared)
+        if newest >= self._active_window_generation:
+            self._active_window_generation = newest
+            self._prefetch_queue.clear()
+        accepted = False
+        for request in prepared[:2]:
+            accepted = self.prefetch(request) or accepted
+        return accepted
+
+    def request(self, request: DetailRenderRequest) -> bool:
+        """Submit or attach the active foreground generation."""
+
+        if self._shutting_down:
+            return False
+        prepared = request.with_decode_level()
+        numeric_generation = int(prepared.generation)
+        self._current_generation = numeric_generation
+        self._prefetch_queue.clear()
+        self._active_window_generation += 1
+        key = DetailDecodeKey.from_request(prepared)
+        self._discard_queued_other_keys(key)
+        self._detach_running_other_keys(key)
+
+        existing = self._inflight_by_key.get(key)
+        if existing is not None and self._reuse_enabled:
+            was_prefetch = existing.foreground_generation is None
+            existing.foreground_generation = numeric_generation
+            existing.request = prepared
+            update_request = getattr(existing.worker, "update_request", None)
+            if callable(update_request):
+                update_request(prepared)
+            emit_detail_event(
+                "reused",
+                generation=numeric_generation,
+                asset_id=key.asset_id,
+                state=existing.state,
+                suffix=key.source.suffix.lower(),
+            )
+            if existing.state == "queued" and existing.priority < 1:
+                if self._pool.tryTake(existing.worker):
+                    existing.priority = 1
+                    emit_detail_event(
+                        "promoted",
+                        generation=numeric_generation,
+                        asset_id=key.asset_id,
+                        suffix=key.source.suffix.lower(),
+                    )
+                    self._pool.start(existing.worker, 1)
+                elif was_prefetch:
+                    # The worker crossed into native decode before its queued
+                    # started signal reached the scheduler.  Reusing it is still
+                    # correct and avoids a duplicate decode.
+                    existing.state = "running"
+            return True
+
+        if existing is not None:
+            if existing.state == "queued" and self._pool.tryTake(existing.worker):
+                self._retire_entry(existing, cancel=True)
+            else:
+                # Diagnostic fallback recreates the pre-v3 behaviour.  Keep the
+                # already-running worker owned until its terminal signal while
+                # preventing it from publishing into the foreground.
+                existing.foreground_generation = None
+                cancel_worker = getattr(existing.worker, "cancel", None)
+                if callable(cancel_worker):
+                    cancel_worker()
+                self._inflight_by_key.pop(existing.key, None)
+
+        entry = self._create_entry(prepared, generation=numeric_generation, priority=1)
+        emit_detail_event(
+            "scheduled",
+            generation=numeric_generation,
+            asset_id=key.asset_id,
+            suffix=key.source.suffix.lower(),
+            decode_level=key.decode_level,
+        )
+        return self._submit(entry)
+
+    def cancel_foreground(self) -> None:
+        """Invalidate foreground delivery and remove work not yet running."""
+
+        self._current_generation += 1
+        self._prefetch_queue.clear()
+        self._active_window_generation += 1
+        for entry in tuple(self._inflight_by_key.values()):
+            entry.foreground_generation = None
+            if entry.state == "queued" and self._pool.tryTake(entry.worker):
+                self._retire_entry(entry, cancel=True)
+
+    def shutdown(self, *, timeout_ms: int = 1500) -> None:
+        """Cancel queued/running work and wait for the dedicated pool."""
+
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        self._current_generation += 1
+        self._prefetch_queue.clear()
+        for entry in tuple(self._inflight_by_key.values()):
+            entry.foreground_generation = None
+            cancel = getattr(entry.worker, "cancel", None)
+            if callable(cancel):
+                cancel()
+            if entry.state == "queued" and self._pool.tryTake(entry.worker):
+                self._retire_entry(entry, cancel=False)
+        self._pool.clear()
+        completed = self._pool.waitForDone(max(0, int(timeout_ms)))
+        if completed:
+            for entry in tuple(self._inflight_by_key.values()):
+                self._retire_entry(entry, cancel=False)
+
+    def _create_entry(
+        self,
+        request: DetailRenderRequest,
+        *,
+        generation: int | None,
+        priority: int,
+    ) -> _InflightDecode:
+        key = DetailDecodeKey.from_request(request)
+        worker = self._worker_factory(request)
+        entry = _InflightDecode(
+            key=key,
+            request=request,
+            worker=worker,
+            state="queued",
+            foreground_generation=generation,
+            priority=int(priority),
+        )
+        self._inflight_by_key[key] = entry
+        self._entry_by_worker_id[id(worker)] = entry
+        signals = worker.signals
+        signals.started.connect(self._on_worker_started)
+        signals.completed.connect(
+            lambda surface, active=worker: self._on_worker_completed(surface, active)
+        )
+        signals.failed.connect(
+            lambda source, message, active=worker:
+            self._on_worker_failed(source, message, active)
+        )
+        signals.finished.connect(self._on_worker_finished)
+        return entry
+
+    def _submit(self, entry: _InflightDecode) -> bool:
+        try:
+            self._pool.start(entry.worker, entry.priority)
+        except RuntimeError:
+            generation = entry.foreground_generation
+            source = entry.key.source
+            self._retire_entry(entry, cancel=True)
+            if generation is not None and generation == self._current_generation:
+                self.failed.emit(generation, source, "Still-image decoder pool is unavailable")
+            return False
+        return True
+
+    def _discard_queued_other_keys(self, active_key: DetailDecodeKey) -> None:
+        for entry in tuple(self._inflight_by_key.values()):
+            if entry.key == active_key or entry.state != "queued":
+                continue
+            if self._pool.tryTake(entry.worker):
+                self._retire_entry(entry, cancel=True)
+
+    def _detach_running_other_keys(self, active_key: DetailDecodeKey) -> None:
+        for entry in self._inflight_by_key.values():
+            if entry.key != active_key:
+                entry.foreground_generation = None
+
+    def _on_worker_started(self, worker: object) -> None:
+        entry = self._entry_by_worker_id.get(id(worker))
+        if entry is None:
+            return
+        entry.state = "running"
+        emit_detail_event(
+            "worker_started",
+            generation=entry.foreground_generation or 0,
+            asset_id=entry.key.asset_id,
+            suffix=entry.key.source.suffix.lower(),
+        )
+
+    def _on_worker_completed(
+        self,
+        surface: DecodedSurface,
+        worker: object,
+    ) -> None:
+        entry = self._entry_by_worker_id.get(id(worker))
+        if entry is None:
+            return
+        generation = entry.foreground_generation
+        if generation is None:
+            request = entry.request
+            if (
+                request.residency_slot is not None
+                and request.window_generation == self._active_window_generation
+            ):
+                self.warmed.emit(request, surface)
+            return
+        if generation is None or generation != self._current_generation:
+            emit_detail_event(
+                "stale",
+                generation=generation or 0,
+                asset_id=entry.key.asset_id,
+                suffix=entry.key.source.suffix.lower(),
+            )
+            return
+        self.ready.emit(generation, surface)
+
+    def _on_worker_failed(self, source: Path, message: str, worker: object) -> None:
+        entry = self._entry_by_worker_id.get(id(worker))
+        if entry is None:
+            return
+        generation = entry.foreground_generation
+        if generation is not None and generation == self._current_generation:
+            self.failed.emit(generation, Path(source), str(message))
+
+    def _on_worker_finished(self, worker: object) -> None:
+        entry = self._entry_by_worker_id.get(id(worker))
+        if entry is None:
+            return
+        emit_detail_event(
+            "worker_finished",
+            generation=entry.foreground_generation or 0,
+            asset_id=entry.key.asset_id,
+            suffix=entry.key.source.suffix.lower(),
+            cache_hit=bool(getattr(worker, "cache_hit", False)),
+        )
+        self.finished.emit(entry.key)
+        self._retire_entry(entry, cancel=False)
+        self._start_next_prefetch()
+
+    def _start_next_prefetch(self) -> None:
+        if self._shutting_down:
+            return
+        while self._prefetch_queue:
+            request = self._prefetch_queue.pop(0)
+            if request.window_generation != self._active_window_generation:
+                continue
+            if self.prefetch(request):
+                return
+
+    def _retire_entry(self, entry: _InflightDecode, *, cancel: bool) -> None:
+        if cancel:
+            cancel_worker = getattr(entry.worker, "cancel", None)
+            if callable(cancel_worker):
+                cancel_worker()
+        if self._inflight_by_key.get(entry.key) is entry:
+            self._inflight_by_key.pop(entry.key, None)
+        self._entry_by_worker_id.pop(id(entry.worker), None)
+        signals = getattr(entry.worker, "signals", None)
+        if signals is not None:
+            signals.deleteLater()
+
+
+__all__ = ["DetailDecodeKey", "DetailStillRequestScheduler"]
+

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -1,0 +1,610 @@
+"""Versioned neutral-surface caches for the Detail still-image pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mmap
+import os
+import shutil
+import struct
+import time
+from collections import OrderedDict
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from dataclasses import replace
+from pathlib import Path
+from threading import RLock
+from typing import Final
+
+from PySide6.QtGui import QColorSpace, QImage
+
+from iPhoto.core.color_resolver import ColorStats, compute_color_statistics
+from iPhoto.gui.detail_decode_backend import (
+    CancellationToken,
+    DecodeCancelledError,
+    DecodedSurface,
+    StillDecodeBackend,
+)
+from iPhoto.gui.detail_pipeline import DetailDecodeKey, DetailRenderRequest
+from iPhoto.gui.detail_profile import emit_detail_event
+from iPhoto.infrastructure.services.thumbnail_runtime_policy import (
+    resolve_physical_memory_bytes,
+)
+
+try:
+    import xxhash
+except ImportError:  # pragma: no cover - declared production dependency
+    xxhash = None  # type: ignore[assignment]
+
+_MIB: Final = 1024 * 1024
+_GIB: Final = 1024 * _MIB
+_MAGIC: Final = b"IPHSURF\0"
+_SCHEMA: Final = 2
+_HEADER_SIZE: Final = 4096
+_PREFIX = struct.Struct("<8sIIIQQ")
+
+
+class SurfaceCacheCorruptError(RuntimeError):
+    """Raised when a disk cache entry cannot be trusted."""
+
+
+class MappedSurfaceOwner:
+    """Keep the file, mmap and exported payload view alive with a QImage."""
+
+    __slots__ = ("file", "mapping", "payload")
+
+    def __init__(self, file, mapping: mmap.mmap, payload: memoryview) -> None:
+        self.file = file
+        self.mapping = mapping
+        self.payload = payload
+
+
+def surface_memory_budget_bytes(physical_memory_bytes: int | None = None) -> int:
+    physical = int(physical_memory_bytes or resolve_physical_memory_bytes())
+    return max(128 * _MIB, min(512 * _MIB, int(max(0, physical) * 0.02)))
+
+
+def _surface_bytes(surface: DecodedSurface) -> int:
+    image = surface.image
+    return max(0, int(image.bytesPerLine()) * int(image.height()))
+
+
+class MappedSurfaceCache:
+    """Thread-safe byte-budgeted LRU for heap and mmap-backed surfaces."""
+
+    def __init__(self, budget_bytes: int | None = None) -> None:
+        self._budget_bytes = max(1, int(budget_bytes or surface_memory_budget_bytes()))
+        self._entries: OrderedDict[DetailDecodeKey, tuple[DecodedSurface, int]] = OrderedDict()
+        self._used_bytes = 0
+        self._lock = RLock()
+
+    @property
+    def budget_bytes(self) -> int:
+        return self._budget_bytes
+
+    @property
+    def used_bytes(self) -> int:
+        with self._lock:
+            return self._used_bytes
+
+    def get(self, key: DetailDecodeKey) -> DecodedSurface | None:
+        if key.source_revision[0] == "legacy":
+            return None
+        with self._lock:
+            value = self._entries.pop(key, None)
+            if value is None:
+                return None
+            self._entries[key] = value
+            surface, _size = value
+            return replace(surface, cache_tier="memory")
+
+    def put(self, surface: DecodedSurface) -> bool:
+        size = _surface_bytes(surface)
+        if (
+            surface.decode_key.source_revision[0] == "legacy"
+            or surface.image.isNull()
+            or size <= 0
+            or size > self._budget_bytes
+        ):
+            return False
+        with self._lock:
+            previous = self._entries.pop(surface.decode_key, None)
+            if previous is not None:
+                self._used_bytes -= previous[1]
+            self._entries[surface.decode_key] = (surface, size)
+            self._used_bytes += size
+            while self._used_bytes > self._budget_bytes and self._entries:
+                _key, (_old, old_size) = self._entries.popitem(last=False)
+                self._used_bytes -= old_size
+        return True
+
+    def discard(self, key: DetailDecodeKey) -> None:
+        with self._lock:
+            previous = self._entries.pop(key, None)
+            if previous is not None:
+                self._used_bytes -= previous[1]
+
+    def invalidate_asset(self, asset_id: str) -> None:
+        with self._lock:
+            for key in tuple(self._entries):
+                if key.asset_id != asset_id:
+                    continue
+                _surface, size = self._entries.pop(key)
+                self._used_bytes -= size
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._used_bytes = 0
+
+
+def _canonical_key(request: DetailRenderRequest) -> bytes:
+    key = DetailDecodeKey.from_request(request)
+    payload = {
+        "asset_id": key.asset_id,
+        "source": str(key.source),
+        "source_revision": list(key.source_revision),
+        "decode_level": key.decode_level,
+        "orientation": request.source_identity.orientation,
+        "pixel_format": "rgba8888",
+        "color_space": "srgb",
+        "contract": 1,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _key_digest(request: DetailRenderRequest) -> str:
+    return hashlib.sha256(_canonical_key(request)).hexdigest()
+
+
+def _checksum(payload: memoryview | bytes) -> int:
+    if xxhash is not None:
+        return int(xxhash.xxh64(payload).intdigest())
+    return int.from_bytes(hashlib.blake2b(payload, digest_size=8).digest(), "little")
+
+
+class NeutralSurfaceStore:
+    """Library-scoped, versioned, mmap-readable disk surface store."""
+
+    def __init__(
+        self,
+        library_root: Path | None = None,
+        *,
+        prune_every_writes: int = 32,
+        prune_after_bytes: int = 256 * _MIB,
+        prune_interval_seconds: float = 60.0,
+    ) -> None:
+        self._root: Path | None = None
+        self._lock = RLock()
+        self._prune_every_writes = max(1, int(prune_every_writes))
+        self._prune_after_bytes = max(1, int(prune_after_bytes))
+        self._prune_interval_seconds = max(0.0, float(prune_interval_seconds))
+        self._writes_since_prune = 0
+        self._bytes_since_prune = 0
+        self._last_prune_at = time.monotonic()
+        self._invalid_paths: set[Path] = set()
+        self.bind_library(library_root)
+
+    @property
+    def root(self) -> Path | None:
+        with self._lock:
+            return self._root
+
+    def bind_library(self, library_root: Path | None) -> None:
+        root = None
+        if library_root is not None:
+            root = Path(library_root).expanduser().absolute() / ".iPhoto" / "cache" / "detail-surfaces" / "v2"
+        with self._lock:
+            self._root = root
+            self._writes_since_prune = 0
+            self._bytes_since_prune = 0
+            self._last_prune_at = time.monotonic()
+            self._invalid_paths.clear()
+
+    def entry_path(self, request: DetailRenderRequest) -> Path | None:
+        root = self.root
+        if root is None or not request.source_identity.has_stable_revision:
+            return None
+        try:
+            library_root = root.parents[3]
+            request.source_identity.path.relative_to(library_root)
+        except (IndexError, ValueError):
+            # A request that outlived a library rebind must never populate the
+            # newly active library's cache namespace.
+            return None
+        digest = _key_digest(request)
+        return root / digest[:2] / f"{digest}.ipsurface"
+
+    def load(self, request: DetailRenderRequest) -> DecodedSurface | None:
+        path = self.entry_path(request)
+        if path is None:
+            return None
+        with self._lock:
+            if path in self._invalid_paths:
+                return None
+        try:
+            file = path.open("rb")
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise SurfaceCacheCorruptError(str(exc)) from exc
+
+        try:
+            mapping = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
+            if len(mapping) < _HEADER_SIZE:
+                raise SurfaceCacheCorruptError("surface cache entry is truncated")
+            magic, schema, header_size, metadata_size, payload_size, _checksum_value = _PREFIX.unpack_from(mapping)
+            if magic != _MAGIC or schema != _SCHEMA or header_size != _HEADER_SIZE:
+                raise SurfaceCacheCorruptError("surface cache header/version mismatch")
+            if metadata_size <= 0 or _PREFIX.size + metadata_size > _HEADER_SIZE:
+                raise SurfaceCacheCorruptError("surface cache metadata size is invalid")
+            if payload_size <= 0 or _HEADER_SIZE + payload_size != len(mapping):
+                raise SurfaceCacheCorruptError("surface cache payload size is invalid")
+            metadata = json.loads(bytes(mapping[_PREFIX.size:_PREFIX.size + metadata_size]))
+            if metadata.get("key_digest") != _key_digest(request):
+                raise SurfaceCacheCorruptError("surface cache key mismatch")
+            width = int(metadata["width"])
+            height = int(metadata["height"])
+            stride = int(metadata["stride"])
+            if width <= 0 or height <= 0 or stride < width * 4 or stride * height != payload_size:
+                raise SurfaceCacheCorruptError("surface cache geometry is invalid")
+            payload = memoryview(mapping)[_HEADER_SIZE:_HEADER_SIZE + payload_size]
+            # Payload validation is deliberately asynchronous.  Header, key,
+            # and geometry checks are enough to construct the mapped surface;
+            # a background verifier evicts a corrupt payload before reuse.
+            try:
+                os.utime(path, None)
+            except OSError:
+                pass
+            owner = MappedSurfaceOwner(file, mapping, payload)
+            image = QImage(payload, width, height, stride, QImage.Format.Format_RGBA8888)
+            if image.isNull():
+                raise SurfaceCacheCorruptError("surface cache QImage mapping failed")
+            image.setColorSpace(QColorSpace(QColorSpace.NamedColorSpace.SRgb))
+            source_size = tuple(int(v) for v in metadata.get("source_size", (width, height)))
+            color_stats = ColorStats.ensure(metadata.get("color_stats"))
+            return DecodedSurface(
+                image=image,
+                decode_key=DetailDecodeKey.from_request(request),
+                source_size=(source_size[0], source_size[1]),
+                decoded_size=(width, height),
+                decode_level=request.with_decode_level().decode_level or "full",
+                backend=str(metadata.get("backend") or "cache"),
+                color_stats=color_stats,
+                fallback=metadata.get("fallback") or None,
+                cache_tier="disk",
+                backing_owner=owner,
+            )
+        except Exception as exc:
+            try:
+                mapping.close()  # type: ignore[possibly-undefined]
+            except (BufferError, NameError, OSError):
+                pass
+            file.close()
+            if isinstance(exc, SurfaceCacheCorruptError):
+                raise
+            raise SurfaceCacheCorruptError(str(exc)) from exc
+
+    def validate(self, request: DetailRenderRequest) -> bool:
+        """Validate a payload away from the disk-hit delivery path."""
+
+        path = self.entry_path(request)
+        if path is None:
+            return False
+        try:
+            with path.open("rb") as file:
+                mapping = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
+                payload = None
+                try:
+                    if len(mapping) < _HEADER_SIZE:
+                        raise SurfaceCacheCorruptError("surface cache entry is truncated")
+                    (
+                        magic,
+                        schema,
+                        header_size,
+                        _metadata_size,
+                        payload_size,
+                        checksum,
+                    ) = _PREFIX.unpack_from(mapping)
+                    if magic != _MAGIC or schema != _SCHEMA or header_size != _HEADER_SIZE:
+                        raise SurfaceCacheCorruptError("surface cache header/version mismatch")
+                    if payload_size <= 0 or _HEADER_SIZE + payload_size != len(mapping):
+                        raise SurfaceCacheCorruptError("surface cache payload size is invalid")
+                    payload = memoryview(mapping)[_HEADER_SIZE:_HEADER_SIZE + payload_size]
+                    if _checksum(payload) != checksum:
+                        raise SurfaceCacheCorruptError("surface cache checksum mismatch")
+                    return True
+                finally:
+                    if payload is not None:
+                        payload.release()
+                    mapping.close()
+        except SurfaceCacheCorruptError:
+            raise
+        except (FileNotFoundError, OSError) as exc:
+            raise SurfaceCacheCorruptError(str(exc)) from exc
+
+    def write(self, request: DetailRenderRequest, surface: DecodedSurface) -> bool:
+        path = self.entry_path(request)
+        if path is None or surface.image.isNull():
+            return False
+        image = surface.image
+        if image.format() != QImage.Format.Format_RGBA8888:
+            image = image.convertToFormat(QImage.Format.Format_RGBA8888)
+        payload = memoryview(image.constBits())[: image.sizeInBytes()]
+        metadata = json.dumps(
+            {
+                "key_digest": _key_digest(request),
+                "width": image.width(),
+                "height": image.height(),
+                "stride": image.bytesPerLine(),
+                "source_size": list(surface.source_size),
+                "backend": surface.backend,
+                "fallback": surface.fallback,
+                "color_stats": {
+                    "saturation_mean": surface.color_stats.saturation_mean,
+                    "saturation_median": surface.color_stats.saturation_median,
+                    "highlight_ratio": surface.color_stats.highlight_ratio,
+                    "dark_ratio": surface.color_stats.dark_ratio,
+                    "skin_ratio": surface.color_stats.skin_ratio,
+                    "cast_magnitude": surface.color_stats.cast_magnitude,
+                    "white_balance_gain_r": surface.color_stats.white_balance_gain[0],
+                    "white_balance_gain_g": surface.color_stats.white_balance_gain[1],
+                    "white_balance_gain_b": surface.color_stats.white_balance_gain[2],
+                },
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        if _PREFIX.size + len(metadata) > _HEADER_SIZE:
+            return False
+        header = bytearray(_HEADER_SIZE)
+        _PREFIX.pack_into(
+            header,
+            0,
+            _MAGIC,
+            _SCHEMA,
+            _HEADER_SIZE,
+            len(metadata),
+            len(payload),
+            _checksum(payload),
+        )
+        header[_PREFIX.size:_PREFIX.size + len(metadata)] = metadata
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+            with temporary.open("wb") as stream:
+                stream.write(header)
+                stream.write(payload)
+            os.replace(temporary, path)
+            with self._lock:
+                self._invalid_paths.discard(path)
+            self._maybe_prune(len(payload))
+            return True
+        except OSError:
+            try:
+                temporary.unlink(missing_ok=True)  # type: ignore[possibly-undefined]
+            except (NameError, OSError):
+                pass
+            return False
+
+    def _maybe_prune(self, written_bytes: int) -> None:
+        now = time.monotonic()
+        with self._lock:
+            self._writes_since_prune += 1
+            self._bytes_since_prune += max(0, int(written_bytes))
+            due = (
+                self._writes_since_prune >= self._prune_every_writes
+                or self._bytes_since_prune >= self._prune_after_bytes
+                or now - self._last_prune_at >= self._prune_interval_seconds
+            )
+            if not due:
+                return
+            self._writes_since_prune = 0
+            self._bytes_since_prune = 0
+            self._last_prune_at = now
+        self.prune()
+
+    def discard(self, request: DetailRenderRequest) -> None:
+        path = self.entry_path(request)
+        if path is not None:
+            with self._lock:
+                self._invalid_paths.add(path)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def prune(self) -> None:
+        root = self.root
+        if root is None or not root.exists():
+            return
+        try:
+            budget = min(2 * _GIB, max(0, int(shutil.disk_usage(root).free * 0.02)))
+            entries = []
+            total = 0
+            for path in root.glob("*/*.ipsurface"):
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                total += int(stat.st_size)
+                entries.append((int(stat.st_mtime_ns), path, int(stat.st_size)))
+            for _mtime, path, size in sorted(entries):
+                if total <= budget:
+                    break
+                try:
+                    path.unlink()
+                    total -= size
+                except OSError:
+                    continue
+        except OSError:
+            return
+
+
+class CachedStillDecodeBackend:
+    """Memory/disk/decode lookup chain with asynchronous persistence."""
+
+    def __init__(
+        self,
+        delegate: StillDecodeBackend,
+        *,
+        memory_cache: MappedSurfaceCache | None = None,
+        store: NeutralSurfaceStore | None = None,
+    ) -> None:
+        self._delegate = delegate
+        self.memory_cache = memory_cache or MappedSurfaceCache()
+        self.store = store or NeutralSurfaceStore()
+        self._io = ThreadPoolExecutor(max_workers=1, thread_name_prefix="iPhoto-surface-cache")
+        self._futures: set[Future] = set()
+        self._lock = RLock()
+        self._shutting_down = False
+        self._color_stats_by_source: OrderedDict[tuple, ColorStats] = OrderedDict()
+
+    def bind_library(self, library_root: Path | None) -> None:
+        self.memory_cache.clear()
+        with self._lock:
+            self._color_stats_by_source.clear()
+        self.store.bind_library(library_root)
+
+    @staticmethod
+    def _source_stats_key(request: DetailRenderRequest) -> tuple:
+        identity = request.source_identity
+        return (identity.path, identity.revision, identity.orientation)
+
+    def _remember_color_stats(
+        self,
+        request: DetailRenderRequest,
+        stats: ColorStats,
+    ) -> ColorStats:
+        key = self._source_stats_key(request)
+        with self._lock:
+            existing = self._color_stats_by_source.pop(key, None)
+            resolved = existing or stats
+            self._color_stats_by_source[key] = resolved
+            while len(self._color_stats_by_source) > 16:
+                self._color_stats_by_source.popitem(last=False)
+            return resolved
+
+    def _cached_color_stats(self, request: DetailRenderRequest) -> ColorStats | None:
+        key = self._source_stats_key(request)
+        with self._lock:
+            stats = self._color_stats_by_source.pop(key, None)
+            if stats is not None:
+                self._color_stats_by_source[key] = stats
+            return stats
+
+    def decode(self, request: DetailRenderRequest, cancellation: CancellationToken) -> DecodedSurface:
+        prepared = request.with_decode_level()
+        repaired_identity = prepared.source_identity.repair_revision_from_stat()
+        if repaired_identity != prepared.source_identity:
+            prepared = replace(prepared, source_identity=repaired_identity)
+        key = DetailDecodeKey.from_request(prepared)
+        if cancellation.is_cancelled():
+            raise DecodeCancelledError("Still-image decode cancelled")
+        if not prepared.source_identity.has_stable_revision:
+            emit_detail_event(
+                "surface_cache_bypass",
+                generation=prepared.generation,
+                asset_id=key.asset_id,
+                reason="unstable_source_revision",
+            )
+            surface = self._delegate.decode(prepared, cancellation)
+            return replace(surface, color_stats=compute_color_statistics(surface.image))
+        surface = self.memory_cache.get(key)
+        if surface is not None:
+            self._remember_color_stats(prepared, surface.color_stats)
+            emit_detail_event("surface_cache_hit", generation=prepared.generation, asset_id=key.asset_id, tier="memory")
+            return surface
+        try:
+            surface = self.store.load(prepared)
+        except SurfaceCacheCorruptError:
+            emit_detail_event("surface_cache_corrupt", generation=prepared.generation, asset_id=key.asset_id)
+            self._submit(self.store.discard, prepared)
+            surface = None
+        if surface is not None:
+            if cancellation.is_cancelled():
+                raise DecodeCancelledError("Still-image decode cancelled")
+            self.memory_cache.put(surface)
+            self._remember_color_stats(prepared, surface.color_stats)
+            self._submit(self._validate_disk_surface, prepared, key)
+            emit_detail_event("surface_cache_hit", generation=prepared.generation, asset_id=key.asset_id, tier="disk")
+            return surface
+        emit_detail_event("surface_cache_miss", generation=prepared.generation, asset_id=key.asset_id)
+        surface = self._delegate.decode(prepared, cancellation)
+        stats = self._cached_color_stats(prepared)
+        if stats is None:
+            started = time.perf_counter()
+            stats = compute_color_statistics(surface.image)
+            emit_detail_event(
+                "color_stats",
+                generation=prepared.generation,
+                asset_id=prepared.asset_id,
+                duration_ms=(time.perf_counter() - started) * 1000.0,
+                width=surface.decoded_size[0],
+                height=surface.decoded_size[1],
+            )
+        stats = self._remember_color_stats(prepared, stats)
+        surface = replace(surface, color_stats=stats)
+        self.memory_cache.put(surface)
+        self._submit(self._write_surface, prepared, surface)
+        return surface
+
+    def _validate_disk_surface(
+        self,
+        request: DetailRenderRequest,
+        key: DetailDecodeKey,
+    ) -> None:
+        try:
+            self.store.validate(request)
+        except SurfaceCacheCorruptError:
+            self.memory_cache.discard(key)
+            self.store.discard(request)
+            emit_detail_event(
+                "surface_cache_corrupt",
+                generation=request.generation,
+                asset_id=key.asset_id,
+                phase="async_validation",
+            )
+
+    def _write_surface(self, request: DetailRenderRequest, surface: DecodedSurface) -> None:
+        if self.store.write(request, surface) and not self._shutting_down:
+            emit_detail_event(
+                "surface_cache_write",
+                generation=request.generation,
+                asset_id=surface.decode_key.asset_id,
+                width=surface.decoded_size[0],
+                height=surface.decoded_size[1],
+            )
+
+    def _submit(self, fn, *args) -> None:
+        with self._lock:
+            if self._shutting_down:
+                return
+            try:
+                future = self._io.submit(fn, *args)
+            except RuntimeError:
+                return
+            self._futures.add(future)
+            future.add_done_callback(self._forget_future)
+
+    def _forget_future(self, future: Future) -> None:
+        with self._lock:
+            self._futures.discard(future)
+
+    def shutdown(self, *, timeout_ms: int = 1000) -> None:
+        with self._lock:
+            self._shutting_down = True
+            futures = tuple(self._futures)
+        if futures:
+            wait(futures, timeout=max(0, int(timeout_ms)) / 1000.0)
+        self._io.shutdown(wait=False, cancel_futures=True)
+
+
+__all__ = [
+    "CachedStillDecodeBackend",
+    "MappedSurfaceCache",
+    "MappedSurfaceOwner",
+    "NeutralSurfaceStore",
+    "SurfaceCacheCorruptError",
+    "surface_memory_budget_bytes",
+]

--- a/tests/gui/test_detail_decode_backend.py
+++ b/tests/gui/test_detail_decode_backend.py
@@ -1,0 +1,662 @@
+from __future__ import annotations
+
+import gc
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QImage
+
+from iPhoto.gui.detail_decode_backend import (
+    DecodeCancelledError,
+    DefaultStillDecodeBackend,
+    QtStillDecodeBackend,
+    RawStillDecodeBackend,
+    StillDecodeBackendRegistry,
+    _qimage_from_array,
+    _qimage_from_raw_thumb,
+    probe_raw_source_identity,
+)
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailGeometryState,
+    DetailRenderRequest,
+)
+
+
+class _Token:
+    def __init__(self, cancelled: bool = False) -> None:
+        self.cancelled = cancelled
+
+    def is_cancelled(self) -> bool:
+        return self.cancelled
+
+
+class _CountingToken:
+    def __init__(self, cancel_at: int) -> None:
+        self.cancel_at = cancel_at
+        self.checks = 0
+
+    def is_cancelled(self) -> bool:
+        self.checks += 1
+        return self.checks >= self.cancel_at
+
+
+def _request(source: Path, *, level: int = 1024) -> DetailRenderRequest:
+    return DetailRenderRequest(
+        generation=1,
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(
+            source,
+            size_bytes=100,
+            source_mtime_ns=1,
+            width=4000,
+            height=3000,
+        ),
+        viewport_physical_size=(800, 600),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="initial",
+        decode_level=level,
+    )
+
+
+def test_qt_backend_returns_scaled_detached_rgba_surface(tmp_path: Path) -> None:
+    source = tmp_path / "alpha.png"
+    image = QImage(2400, 1200, QImage.Format.Format_RGBA8888)
+    image.fill(0x80112233)
+    assert image.save(str(source), "PNG")
+
+    surface = QtStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.decoded_size == (1024, 512)
+    assert surface.image.format() == QImage.Format.Format_RGBA8888
+    assert surface.image.hasAlphaChannel()
+    assert surface.color_space == "srgb"
+    assert surface.backend == "qt"
+
+
+def test_target_surface_is_capped_to_gpu_residency_budget(tmp_path: Path) -> None:
+    source = tmp_path / "large-square.png"
+    request = DetailRenderRequest(
+        generation=1,
+        asset_id="large",
+        source_identity=AssetSourceIdentity.create(
+            source,
+            size_bytes=100,
+            source_mtime_ns=1,
+            width=9000,
+            height=9000,
+        ),
+        viewport_physical_size=(8000, 8000),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="zoom",
+        decode_level="full",
+        texture_limit=8192,
+    )
+    from iPhoto.gui.detail_decode_backend import _target_size
+
+    target = _target_size(request)
+
+    assert target.width() * target.height() * 4 <= 192 * 1024 * 1024
+
+
+def test_qt_backend_checks_cancellation_before_decode(tmp_path: Path) -> None:
+    source = tmp_path / "photo.png"
+    QImage(10, 10, QImage.Format.Format_RGBA8888).save(str(source), "PNG")
+    try:
+        QtStillDecodeBackend().decode(_request(source), _Token(cancelled=True))
+    except DecodeCancelledError:
+        pass
+    else:  # pragma: no cover - explicit failure branch
+        raise AssertionError("cancelled decode should not enter QImageReader")
+
+
+def test_platform_registry_prefers_macos_backend_and_falls_back_to_qt(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "photo.png"
+    image = QImage(64, 32, QImage.Format.Format_RGBA8888)
+    assert image.save(str(source), "PNG")
+
+    class _FailingImageIO:
+        def decode(self, request, cancellation):
+            del request, cancellation
+            raise RuntimeError("native decoder unavailable")
+
+    registry = StillDecodeBackendRegistry(
+        platform="darwin",
+        macos_backend=_FailingImageIO(),
+    )
+    surface = DefaultStillDecodeBackend(registry).decode(_request(source), _Token())
+
+    assert surface.backend == "qt"
+    assert surface.fallback == "imageio_to_qt"
+
+
+def test_platform_registry_keeps_cancellation_terminal() -> None:
+    class _CancelledNative:
+        def decode(self, request, cancellation):
+            del request, cancellation
+            raise DecodeCancelledError("cancelled")
+
+    registry = StillDecodeBackendRegistry(
+        platform="win32",
+        windows_backend=_CancelledNative(),
+    )
+
+    with pytest.raises(DecodeCancelledError):
+        DefaultStillDecodeBackend(registry).decode(
+            _request(Path("photo.jpg")),
+            _Token(),
+        )
+
+
+def test_windows_wic_orientation_mapping_covers_exif_transforms() -> None:
+    from iPhoto.gui.detail_decode_windows import _orientation_transform
+
+    assert [_orientation_transform(value) for value in range(1, 9)] == [
+        0,
+        8,
+        2,
+        10,
+        9,
+        1,
+        11,
+        3,
+    ]
+
+
+def test_windows_wic_hresult_is_a_fixed_signed_32_bit_value() -> None:
+    from ctypes import sizeof
+
+    from iPhoto.gui.detail_decode_windows import _HRESULT, _failed
+
+    assert sizeof(_HRESULT) == 4
+    assert not _failed(0)
+    assert _failed(0x80004005)
+
+
+def test_windows_wic_uses_embedded_profile_for_srgb_output(mocker) -> None:
+    import ctypes
+
+    import iPhoto.gui.detail_decode_windows as wic
+
+    apartment = SimpleNamespace(close=MagicMock())
+    factory = ctypes.c_void_p(1)
+    decoder = ctypes.c_void_p(2)
+    frame = ctypes.c_void_p(3)
+    scaler = ctypes.c_void_p(4)
+    source_color = ctypes.c_void_p(5)
+    target_color = ctypes.c_void_p(6)
+    transform = ctypes.c_void_p(7)
+    image = QImage(800, 600, QImage.Format.Format_RGBA8888)
+    image.fill(0xFF123456)
+    mocker.patch.object(wic._ComApartment, "enter", return_value=apartment)
+    mocker.patch.object(wic, "_create_factory", return_value=factory)
+    mocker.patch.object(wic, "_create_decoder", return_value=decoder)
+    mocker.patch.object(wic, "_first_frame", return_value=frame)
+    mocker.patch.object(wic, "_source_size", return_value=(4000, 3000))
+    mocker.patch.object(wic, "_apply_orientation", return_value=ctypes.c_void_p())
+    mocker.patch.object(wic, "_scale_source", return_value=scaler)
+    mocker.patch.object(wic, "_frame_color_context", return_value=source_color)
+    mocker.patch.object(wic, "_create_srgb_color_context", return_value=target_color)
+    transform_to_srgb = mocker.patch.object(wic, "_transform_to_srgb", return_value=transform)
+    convert_rgba = mocker.patch.object(wic, "_convert_rgba")
+    copy_rgba = mocker.patch.object(wic, "_copy_rgba", return_value=image)
+    mocker.patch.object(wic, "_release")
+
+    surface = wic.WindowsWicStillDecodeBackend().decode(
+        _request(Path("profiled.jpg"), level=1024),
+        _Token(),
+    )
+
+    transform_to_srgb.assert_called_once_with(
+        factory,
+        scaler,
+        source_color,
+        target_color,
+    )
+    convert_rgba.assert_not_called()
+    copy_rgba.assert_called_once_with(transform, 1024, 768)
+    assert surface.image.colorSpace() == image.colorSpace()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows WIC")
+def test_windows_wic_backend_decodes_detached_alpha_surface(tmp_path: Path) -> None:
+    from iPhoto.gui.detail_decode_windows import create_windows_wic_backend
+
+    source = tmp_path / "alpha.png"
+    image = QImage(64, 32, QImage.Format.Format_RGBA8888)
+    image.fill(0x80112233)
+    assert image.save(str(source), "PNG")
+    backend = create_windows_wic_backend()
+    assert backend is not None
+
+    surface = backend.decode(_request(source, level=64), _Token())
+
+    assert surface.backend == "wic"
+    assert surface.decoded_size == (64, 32)
+    assert surface.image.format() == QImage.Format.Format_RGBA8888
+    assert surface.image.hasAlphaChannel()
+
+
+def test_qt_backend_uses_pillow_fallback_after_plugin_failure(tmp_path: Path) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"placeholder")
+    fallback = QImage(800, 600, QImage.Format.Format_RGBA8888)
+
+    class _FailingReader:
+        def __init__(self, _source: str) -> None:
+            pass
+
+        def setCacheEnabled(self, _enabled: bool) -> None:
+            pass
+
+        def setAutoTransform(self, _enabled: bool) -> None:
+            pass
+
+        def size(self) -> QSize:
+            return QSize()
+
+        def read(self) -> QImage:
+            return QImage()
+
+        def errorString(self) -> str:
+            return "plugin failed"
+
+    with patch(
+        "iPhoto.gui.detail_decode_backend.QImageReader",
+        _FailingReader,
+    ), patch(
+        "iPhoto.gui.detail_decode_backend._load_with_pillow",
+        return_value=fallback,
+    ):
+        surface = QtStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.fallback == "pillow"
+    assert surface.decoded_size == (800, 600)
+
+
+def test_qt_backend_marks_plugin_that_ignores_scaled_decode(tmp_path: Path) -> None:
+    source = tmp_path / "ignored-scale.heic"
+    source.write_bytes(b"placeholder")
+    decoded = QImage(4000, 3000, QImage.Format.Format_RGBA8888)
+
+    class _FullReader:
+        def __init__(self, _source: str) -> None:
+            pass
+
+        def setCacheEnabled(self, _enabled: bool) -> None:
+            pass
+
+        def setAutoTransform(self, _enabled: bool) -> None:
+            pass
+
+        def size(self) -> QSize:
+            return QSize(4000, 3000)
+
+        def setScaledSize(self, _size: QSize) -> None:
+            pass
+
+        def read(self) -> QImage:
+            return decoded
+
+    with patch("iPhoto.gui.detail_decode_backend.QImageReader", _FullReader):
+        surface = QtStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.fallback == "qt_full_scale"
+    assert surface.decoded_size == (1024, 768)
+
+
+def test_qt_backend_applies_exif_orientation_once(tmp_path: Path) -> None:
+    source = tmp_path / "rotated.jpg"
+    image = Image.new("RGB", (100, 50), "red")
+    exif = image.getexif()
+    exif[0x0112] = 6
+    image.save(source, exif=exif)
+    request = DetailRenderRequest(
+        generation=1,
+        asset_id="rotated",
+        source_identity=AssetSourceIdentity.create(
+            source,
+            source_mtime_ns=1,
+            width=50,
+            height=100,
+            orientation=6,
+        ),
+        viewport_physical_size=(50, 100),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="initial",
+        decode_level=100,
+    )
+
+    surface = QtStillDecodeBackend().decode(request, _Token())
+
+    assert surface.decoded_size == (50, 100)
+    assert surface.orientation_applied is True
+
+
+def test_raw_backend_prefers_adequate_embedded_preview(tmp_path: Path) -> None:
+    source = tmp_path / "photo.dng"
+    source.write_bytes(b"raw")
+    preview_path = tmp_path / "preview.jpg"
+    preview = QImage(1600, 1200, QImage.Format.Format_RGB32)
+    assert preview.save(str(preview_path), "JPEG")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.extract_thumb.return_value = SimpleNamespace(
+        format="jpeg",
+        data=preview_path.read_bytes(),
+    )
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+
+    with patch(
+        "iPhoto.gui.detail_decode_backend._import_rawpy",
+        return_value=rawpy,
+    ):
+        surface = RawStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.fallback is None
+    assert surface.decoded_size == (1024, 768)
+    raw.postprocess.assert_not_called()
+
+
+def test_raw_embedded_jpeg_is_scaled_during_decode(tmp_path: Path) -> None:
+    source = tmp_path / "photo.nef"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.extract_thumb.return_value = SimpleNamespace(
+        format="jpeg",
+        data=b"embedded-jpeg",
+    )
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+    scaled_sizes: list[QSize] = []
+
+    class _EmbeddedReader:
+        def __init__(self, *_args) -> None:
+            self._scaled = QSize(1600, 1200)
+
+        def setAutoTransform(self, _enabled: bool) -> None:
+            pass
+
+        def size(self) -> QSize:
+            return QSize(1600, 1200)
+
+        def setScaledSize(self, size: QSize) -> None:
+            self._scaled = QSize(size)
+            scaled_sizes.append(QSize(size))
+
+        def read(self) -> QImage:
+            return QImage(
+                self._scaled.width(),
+                self._scaled.height(),
+                QImage.Format.Format_RGB888,
+            )
+
+    with patch(
+        "iPhoto.gui.detail_decode_backend._import_rawpy",
+        return_value=rawpy,
+    ), patch(
+        "iPhoto.gui.detail_decode_backend.QImageReader",
+        _EmbeddedReader,
+    ):
+        surface = RawStillDecodeBackend().decode(_request(source), _Token())
+
+    assert scaled_sizes == [QSize(1024, 768)]
+    assert surface.decoded_size == (1024, 768)
+    raw.postprocess.assert_not_called()
+
+
+def test_raw_backend_falls_back_when_embedded_jpeg_decode_fails(tmp_path: Path) -> None:
+    source = tmp_path / "photo.nef"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.sizes = SimpleNamespace(iwidth=3200, iheight=2400, flip=0)
+    raw.extract_thumb.return_value = SimpleNamespace(
+        format="jpeg",
+        data=b"jpeg-with-readable-header-and-broken-pixels",
+    )
+    raw.postprocess.return_value = np.zeros((1200, 1600, 3), dtype=np.uint8)
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+
+    class _BrokenEmbeddedReader:
+        def __init__(self, *_args) -> None:
+            pass
+
+        def setAutoTransform(self, _enabled: bool) -> None:
+            pass
+
+        def size(self) -> QSize:
+            return QSize(1600, 1200)
+
+        def setScaledSize(self, _size: QSize) -> None:
+            pass
+
+        def read(self) -> QImage:
+            return QImage()
+
+    with patch(
+        "iPhoto.gui.detail_decode_backend._import_rawpy",
+        return_value=rawpy,
+    ), patch(
+        "iPhoto.gui.detail_decode_backend.QImageReader",
+        _BrokenEmbeddedReader,
+    ):
+        surface = RawStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.fallback == "half"
+    assert surface.decoded_size == (1024, 768)
+    assert [call.kwargs["half_size"] for call in raw.postprocess.call_args_list] == [True]
+
+
+def test_raw_embedded_scaled_decode_accounts_for_orientation() -> None:
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+    )
+    thumb = SimpleNamespace(format="jpeg", data=b"embedded-jpeg")
+    scaled_sizes: list[QSize] = []
+
+    class _RotatedReader:
+        def __init__(self, *_args) -> None:
+            pass
+
+        def setAutoTransform(self, _enabled: bool) -> None:
+            pass
+
+        def size(self) -> QSize:
+            return QSize(1600, 1200)
+
+        def setScaledSize(self, size: QSize) -> None:
+            scaled_sizes.append(QSize(size))
+
+        def read(self) -> QImage:
+            return QImage(768, 1024, QImage.Format.Format_RGB888)
+
+    with patch("iPhoto.gui.detail_decode_backend.QImageReader", _RotatedReader):
+        image = _qimage_from_raw_thumb(
+            thumb,
+            rawpy,
+            QSize(768, 1024),
+            orientation=6,
+        )
+
+    assert scaled_sizes == [QSize(1024, 768)]
+    assert image.size() == QSize(768, 1024)
+
+
+def test_raw_backend_checks_cancellation_after_native_preview(tmp_path: Path) -> None:
+    source = tmp_path / "cancelled.dng"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.extract_thumb.return_value = SimpleNamespace(
+        format="bitmap",
+        data=np.zeros((1200, 1600, 3), dtype=np.uint8),
+    )
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+
+    with patch("iPhoto.gui.detail_decode_backend._import_rawpy", return_value=rawpy):
+        with pytest.raises(DecodeCancelledError):
+            RawStillDecodeBackend().decode(_request(source), _CountingToken(cancel_at=3))
+
+    raw.postprocess.assert_not_called()
+
+
+def test_raw_backend_skips_half_when_predicted_size_is_insufficient(tmp_path: Path) -> None:
+    source = tmp_path / "photo.nef"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.sizes = SimpleNamespace(iwidth=1600, iheight=1200, flip=0)
+    raw.extract_thumb.return_value = SimpleNamespace(
+        format="bitmap",
+        data=np.zeros((100, 100, 3), dtype=np.uint8),
+    )
+    raw.postprocess.return_value = np.zeros((1200, 1600, 3), dtype=np.uint8)
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+
+    with patch(
+        "iPhoto.gui.detail_decode_backend._import_rawpy",
+        return_value=rawpy,
+    ):
+        surface = RawStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.fallback == "full"
+    assert [call.kwargs["half_size"] for call in raw.postprocess.call_args_list] == [False]
+    assert surface.decoded_size == (1024, 768)
+
+
+def test_raw_backend_uses_adequate_half_size_demosaic(tmp_path: Path) -> None:
+    source = tmp_path / "photo.cr3"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.sizes = SimpleNamespace(iwidth=3200, iheight=2400, flip=0)
+    raw.extract_thumb.side_effect = RuntimeError("no preview")
+    raw.postprocess.return_value = np.zeros((1200, 1600, 3), dtype=np.uint8)
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+
+    with patch("iPhoto.gui.detail_decode_backend._import_rawpy", return_value=rawpy):
+        surface = RawStillDecodeBackend().decode(_request(source), _Token())
+
+    assert surface.fallback == "half"
+    assert raw.postprocess.call_count == 1
+    assert raw.postprocess.call_args.kwargs["half_size"] is True
+
+
+def test_raw_backend_downgrades_full_decode_when_peak_exceeds_budget(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "budget.nef"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.sizes = SimpleNamespace(iwidth=2000, iheight=1500, flip=0)
+    raw.extract_thumb.side_effect = RuntimeError("no preview")
+    raw.postprocess.return_value = np.zeros((750, 1000, 3), dtype=np.uint8)
+    rawpy = SimpleNamespace(
+        ThumbFormat=SimpleNamespace(JPEG="jpeg", BITMAP="bitmap"),
+        imread=MagicMock(return_value=raw),
+    )
+
+    with patch("iPhoto.gui.detail_decode_backend._import_rawpy", return_value=rawpy):
+        surface = RawStillDecodeBackend(working_memory_budget_bytes=1).decode(
+            _request(source),
+            _Token(),
+        )
+
+    assert surface.fallback == "half_budget"
+    assert raw.postprocess.call_args.kwargs["half_size"] is True
+    assert surface.decoded_size == (1000, 750)
+
+
+def test_raw_array_bridge_scales_from_borrowed_view_without_full_qimage_copy() -> None:
+    array = np.zeros((1200, 1600, 3), dtype=np.uint8)
+    array[0, 0] = (12, 34, 56)
+
+    image = _qimage_from_array(array, target=QSize(400, 300))
+    del array
+    gc.collect()
+
+    assert image.size() == QSize(400, 300)
+    assert image.format() == QImage.Format.Format_RGBA8888
+
+
+def test_raw_array_bridge_is_detached_and_does_not_encode_png() -> None:
+    array = np.zeros((2, 3, 3), dtype=np.uint8)
+    array[0, 0] = (12, 34, 56)
+
+    image = _qimage_from_array(array)
+    del array
+    gc.collect()
+
+    assert image.size() == QSize(3, 2)
+    assert image.pixelColor(0, 0).getRgb()[:3] == (12, 34, 56)
+
+
+def test_probe_raw_source_identity_repairs_geometry_and_orientation(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.nef"
+    source.write_bytes(b"raw")
+    raw = MagicMock()
+    raw.__enter__.return_value = raw
+    raw.__exit__.return_value = False
+    raw.sizes = SimpleNamespace(iwidth=6000, iheight=4000, flip=6)
+    rawpy = SimpleNamespace(imread=MagicMock(return_value=raw))
+    identity = AssetSourceIdentity.create(
+        source,
+        size_bytes=123,
+        source_mtime_ns=456,
+        width=0,
+        height=0,
+    )
+
+    with patch("iPhoto.gui.detail_decode_backend._import_rawpy", return_value=rawpy):
+        repaired = probe_raw_source_identity(identity)
+
+    assert (repaired.width, repaired.height, repaired.orientation) == (4000, 6000, 6)
+    assert repaired.revision == identity.revision
+
+
+def test_raw_backend_reports_corrupt_source_as_decode_failure(tmp_path: Path) -> None:
+    source = tmp_path / "broken.nef"
+    source.write_bytes(b"broken")
+    rawpy = SimpleNamespace(imread=MagicMock(side_effect=RuntimeError("corrupt raw")))
+
+    with patch("iPhoto.gui.detail_decode_backend._import_rawpy", return_value=rawpy):
+        with pytest.raises(RuntimeError, match="corrupt raw"):
+            RawStillDecodeBackend().decode(_request(source), _Token())

--- a/tests/gui/test_detail_pipeline.py
+++ b/tests/gui/test_detail_pipeline.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailGeometryState,
+    DetailRenderRequest,
+    select_detail_decode_level,
+)
+
+
+def _request(
+    tmp_path: Path,
+    *,
+    viewport: tuple[int, int] = (1200, 800),
+    geometry: DetailGeometryState = DetailGeometryState(),
+    texture_limit: int = 8192,
+    zoom_factor: float = 1.0,
+) -> DetailRenderRequest:
+    return DetailRenderRequest(
+        generation=1,
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(
+            tmp_path / "photo.jpg",
+            size_bytes=10,
+            source_mtime_ns=20,
+            index_revision=30,
+            width=6000,
+            height=4000,
+        ),
+        viewport_physical_size=viewport,
+        device_pixel_ratio=2.0,
+        geometry=geometry,
+        reason="initial",
+        texture_limit=texture_limit,
+        zoom_factor=zoom_factor,
+    )
+
+
+def test_source_identity_prefers_mtime_and_falls_back_to_index(tmp_path: Path) -> None:
+    identity = AssetSourceIdentity.create(
+        tmp_path / "photo.jpg",
+        size_bytes=100,
+        source_mtime_ns=200,
+        index_revision=300,
+    )
+    assert identity.revision == ("mtime", 100, 200)
+    legacy = AssetSourceIdentity.create(
+        tmp_path / "photo.jpg",
+        size_bytes=100,
+        index_revision=300,
+    )
+    assert legacy.revision == ("index", 100, 300)
+
+
+def test_source_identity_creation_never_stats_on_the_calling_thread(tmp_path: Path) -> None:
+    with patch.object(Path, "stat", side_effect=AssertionError("unexpected stat")):
+        identity = AssetSourceIdentity.create(
+            tmp_path / "photo.jpg",
+            size_bytes=100,
+            source_mtime_ns=200,
+            width=4000,
+            height=3000,
+        )
+    assert identity.revision == ("mtime", 100, 200)
+
+
+def test_source_identity_exposes_stable_revision_contract(tmp_path: Path) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"source")
+    legacy = AssetSourceIdentity.create(source)
+
+    repaired = legacy.repair_revision_from_stat()
+
+    assert legacy.has_stable_revision is False
+    assert repaired.has_stable_revision is True
+    assert repaired.size_bytes == len(b"source")
+    assert repaired.revision[0] == "mtime"
+
+
+def test_source_identity_remains_unstable_when_stat_fails(tmp_path: Path) -> None:
+    legacy = AssetSourceIdentity.create(tmp_path / "missing.jpg")
+
+    assert legacy.repair_revision_from_stat() is legacy
+    assert legacy.revision[0] == "legacy"
+
+
+def test_decode_key_distinguishes_source_orientation(tmp_path: Path) -> None:
+    first = _request(tmp_path)
+    rotated_identity = AssetSourceIdentity.create(
+        first.source_identity.path,
+        size_bytes=first.source_identity.size_bytes,
+        source_mtime_ns=first.source_identity.source_mtime_ns,
+        width=first.source_identity.height,
+        height=first.source_identity.width,
+        orientation=6,
+    )
+    rotated = DetailRenderRequest(
+        generation=first.generation,
+        asset_id=first.asset_id,
+        source_identity=rotated_identity,
+        viewport_physical_size=first.viewport_physical_size,
+        device_pixel_ratio=first.device_pixel_ratio,
+        geometry=first.geometry,
+        reason=first.reason,
+        texture_limit=first.texture_limit,
+        zoom_factor=first.zoom_factor,
+    )
+
+    assert DetailDecodeKey.from_request(first) != DetailDecodeKey.from_request(rotated)
+
+
+def test_viewport_lod_uses_smallest_satisfying_tier(tmp_path: Path) -> None:
+    assert select_detail_decode_level(_request(tmp_path)) == 2048
+
+
+def test_active_zoom_only_increases_selected_lod(tmp_path: Path) -> None:
+    assert select_detail_decode_level(_request(tmp_path, zoom_factor=2.0)) == 3072
+    assert select_detail_decode_level(_request(tmp_path, zoom_factor=0.25)) == 2048
+
+
+def test_rotation_crop_and_projection_increase_lod(tmp_path: Path) -> None:
+    cropped = DetailGeometryState(
+        crop_width=0.2,
+        crop_height=0.2,
+        rotate90=1,
+        straighten=20.0,
+        perspective_vertical=0.5,
+    )
+    assert select_detail_decode_level(_request(tmp_path, geometry=cropped)) == "full"
+
+
+def test_geometry_state_preserves_extended_perspective_crop() -> None:
+    geometry = DetailGeometryState.from_adjustments(
+        {"Crop_CX": -0.1, "Crop_CY": 1.2, "Crop_W": 1.3, "Crop_H": 0.7}
+    )
+
+    assert geometry.crop_cx == pytest.approx(-0.1)
+    assert geometry.crop_cy == pytest.approx(1.2)
+    assert geometry.crop_width == pytest.approx(1.3)
+
+
+def test_source_smaller_than_tier_is_not_upscaled(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    small_identity = AssetSourceIdentity.create(
+        tmp_path / "small.png",
+        width=640,
+        height=480,
+        source_mtime_ns=1,
+    )
+    small = DetailRenderRequest(
+        generation=request.generation,
+        asset_id=request.asset_id,
+        source_identity=small_identity,
+        viewport_physical_size=request.viewport_physical_size,
+        device_pixel_ratio=request.device_pixel_ratio,
+        geometry=request.geometry,
+        reason=request.reason,
+    )
+    assert select_detail_decode_level(small) == 640
+
+
+def test_missing_indexed_dimensions_uses_full_compatibility_level(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    unknown = DetailRenderRequest(
+        generation=1,
+        asset_id="legacy",
+        source_identity=AssetSourceIdentity.create(tmp_path / "legacy.jpg"),
+        viewport_physical_size=request.viewport_physical_size,
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="initial",
+    )
+    assert select_detail_decode_level(unknown) == "full"

--- a/tests/gui/test_detail_profile.py
+++ b/tests/gui/test_detail_profile.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import current_thread
+from threading import enumerate as enumerate_threads
+
+from iPhoto.gui.detail_profile import emit_detail_event, shutdown_detail_profile
+
+
+def test_profile_jsonl_is_opened_only_by_background_writer(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    shutdown_detail_profile(timeout_ms=100)
+    target = tmp_path / "detail.jsonl"
+    monkeypatch.setenv("IPHOTO_DETAIL_PROFILE", "1")
+    monkeypatch.setenv("IPHOTO_DETAIL_PROFILE_PATH", str(target))
+    original_open = Path.open
+    append_threads: list[str] = []
+    write_threads: list[str] = []
+
+    class TrackedAppendStream:
+        def __init__(self, stream) -> None:
+            self._stream = stream
+
+        def write(self, value: str) -> int:
+            write_threads.append(current_thread().name)
+            return self._stream.write(value)
+
+        def __getattr__(self, name: str):
+            return getattr(self._stream, name)
+
+    def tracked_open(path: Path, *args, **kwargs):
+        mode = args[0] if args else kwargs.get("mode", "r")
+        stream = original_open(path, *args, **kwargs)
+        if mode == "a":
+            append_threads.append(current_thread().name)
+            return TrackedAppendStream(stream)
+        return stream
+
+    monkeypatch.setattr(Path, "open", tracked_open)
+    emit_detail_event(
+        "scheduled",
+        generation=4,
+        source=tmp_path / "private" / "photo.jpg",
+        nested={"absolute_path": str(tmp_path / "secret.jpg")},
+    )
+    shutdown_detail_profile(timeout_ms=1000)
+
+    assert append_threads == ["iPhoto-detail-profile-writer"]
+    assert write_threads == ["iPhoto-detail-profile-writer"]
+    assert not any(
+        thread.name == "iPhoto-detail-profile-writer"
+        for thread in enumerate_threads()
+    )
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["stage"] == "scheduled"
+    assert payload["generation"] == 4
+    serialized = json.dumps(payload)
+    assert str(tmp_path) not in serialized
+    assert "source" not in payload["details"]
+
+
+def test_disabled_profile_creates_neither_writer_nor_file(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    shutdown_detail_profile(timeout_ms=100)
+    target = tmp_path / "disabled.jsonl"
+    monkeypatch.delenv("IPHOTO_DETAIL_PROFILE", raising=False)
+    monkeypatch.setenv("IPHOTO_DETAIL_PROFILE_PATH", str(target))
+
+    emit_detail_event("scheduled", generation=1)
+
+    assert not target.exists()
+    assert not any(
+        thread.name == "iPhoto-detail-profile-writer"
+        for thread in enumerate_threads()
+    )
+

--- a/tests/gui/test_detail_render_coordinator.py
+++ b/tests/gui/test_detail_render_coordinator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailRenderTransaction
+from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator, DetailRenderState
+
+
+def _transaction(generation: int, *, media_kind: str = "image") -> DetailRenderTransaction:
+    return DetailRenderTransaction(
+        generation=generation,
+        asset_id=f"asset-{generation}",
+        media_kind=media_kind,
+        source_identity=AssetSourceIdentity.create(Path(f"/{generation}.jpg")),
+        viewport_physical_size=(1200, 800),
+        device_pixel_ratio=2.0,
+    )
+
+
+def test_transaction_coordinator_allows_exactly_one_presented_terminal(qapp) -> None:
+    coordinator = DetailRenderCoordinator()
+    presented = []
+    coordinator.presented.connect(presented.append)
+
+    assert coordinator.begin(_transaction(1))
+    assert coordinator.mark_routed(1, row=2)
+    assert coordinator.mark_preparing(1)
+    assert coordinator.mark_presented(1)
+    assert not coordinator.mark_presented(1)
+    assert not coordinator.mark_failed(1, "late")
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.state is DetailRenderState.PRESENTED
+    assert len(presented) == 1
+
+
+def test_new_transaction_cancels_old_and_rejects_stale_result(qapp) -> None:
+    coordinator = DetailRenderCoordinator()
+    cancelled = []
+    coordinator.cancelled.connect(cancelled.append)
+
+    coordinator.begin(_transaction(1))
+    coordinator.mark_preparing(1)
+    coordinator.begin(_transaction(2, media_kind="video"))
+
+    assert len(cancelled) == 1
+    assert cancelled[0].transaction.generation == 1
+    assert not coordinator.mark_presented(1)
+    assert coordinator.mark_routed(2, row=3)
+    assert coordinator.mark_presented(2)
+
+
+def test_still_request_is_derived_from_transaction(tmp_path: Path) -> None:
+    from iPhoto.gui.detail_pipeline import DetailGeometryState, DetailRenderRequest
+
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-7",
+        media_kind="image",
+        source_identity=AssetSourceIdentity.create(
+            tmp_path / "photo.jpg",
+            width=4000,
+            height=3000,
+        ),
+        viewport_physical_size=(1600, 1000),
+        device_pixel_ratio=2.0,
+    )
+    request = DetailRenderRequest.from_transaction(
+        transaction,
+        geometry=DetailGeometryState(),
+        reason="initial",
+    )
+
+    assert request.generation == transaction.generation
+    assert request.asset_id == transaction.asset_id
+    assert request.viewport_physical_size == transaction.viewport_physical_size
+

--- a/tests/gui/test_detail_request_scheduler.py
+++ b/tests/gui/test_detail_request_scheduler.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtGui import QImage
+
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailGeometryState,
+    DetailRenderRequest,
+)
+from iPhoto.gui.detail_request_scheduler import DetailStillRequestScheduler
+
+
+class _WorkerSignals(QObject):
+    started = Signal(object)
+    completed = Signal(object)
+    failed = Signal(Path, str)
+    finished = Signal(object)
+
+
+class _FakeWorker:
+    def __init__(self, request: DetailRenderRequest) -> None:
+        self.request = request.with_decode_level()
+        self.source = request.source_identity.path
+        self.signals = _WorkerSignals()
+        self.frame_identity = None
+        self.cache_hit = False
+        self.cancelled = False
+        self.auto_delete = False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+    def update_request(self, request: DetailRenderRequest) -> None:
+        self.request = request.with_decode_level()
+
+    def setAutoDelete(self, enabled: bool) -> None:
+        self.auto_delete = bool(enabled)
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.queued: list[_FakeWorker] = []
+        self.starts: list[tuple[_FakeWorker, int]] = []
+        self.cleared = False
+        self.wait_timeout: int | None = None
+        self.wait_result = True
+
+    def start(self, worker: _FakeWorker, priority: int) -> None:
+        self.starts.append((worker, priority))
+        self.queued.append(worker)
+
+    def tryTake(self, worker: _FakeWorker) -> bool:
+        if worker not in self.queued:
+            return False
+        self.queued.remove(worker)
+        return True
+
+    def mark_running(self, worker: _FakeWorker) -> None:
+        if worker in self.queued:
+            self.queued.remove(worker)
+        worker.signals.started.emit(worker)
+
+    def complete(self, worker: _FakeWorker) -> None:
+        image = QImage(8, 8, QImage.Format.Format_RGBA8888)
+        image.fill(0xFF112233)
+        surface = DecodedSurface(
+            image=image,
+            decode_key=DetailDecodeKey.from_request(worker.request),
+            source_size=(8, 8),
+            decoded_size=(8, 8),
+            decode_level=worker.request.decode_level or "full",
+            backend="fake",
+        )
+        worker.signals.completed.emit(surface)
+        worker.signals.finished.emit(worker)
+
+    def clear(self) -> None:
+        self.cleared = True
+        self.queued.clear()
+
+    def waitForDone(self, timeout_ms: int) -> bool:
+        self.wait_timeout = timeout_ms
+        return self.wait_result
+
+
+def _harness() -> tuple[
+    DetailStillRequestScheduler,
+    _FakePool,
+    list[_FakeWorker],
+]:
+    pool = _FakePool()
+    workers: list[_FakeWorker] = []
+
+    def factory(request: DetailRenderRequest) -> _FakeWorker:
+        worker = _FakeWorker(request)
+        workers.append(worker)
+        return worker
+
+    scheduler = DetailStillRequestScheduler(pool=pool, worker_factory=factory)
+    return scheduler, pool, workers
+
+
+def _request(
+    source: Path,
+    *,
+    asset_id: str,
+    generation: int,
+    level: int = 1024,
+    revision: int = 1,
+    adjustments: dict | None = None,
+    residency_slot: str | None = None,
+    window_generation: int = 0,
+) -> DetailRenderRequest:
+    return DetailRenderRequest(
+        generation=generation,
+        asset_id=asset_id,
+        source_identity=AssetSourceIdentity.create(
+            source,
+            size_bytes=100,
+            source_mtime_ns=revision,
+            width=4000,
+            height=3000,
+        ),
+        viewport_physical_size=(800, 600),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="prefetch" if generation == 0 else "initial",
+        decode_level=level,
+        raw_adjustments=adjustments,
+        residency_slot=residency_slot,  # type: ignore[arg-type]
+        window_generation=window_generation,
+    )
+
+
+def test_queued_prefetch_is_promoted_without_creating_a_second_worker(
+    tmp_path: Path,
+) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "photo.jpg"
+
+    assert scheduler.prefetch(_request(source, asset_id="asset-1", generation=0))
+    assert scheduler.request(_request(source, asset_id="asset-1", generation=7))
+
+    assert len(workers) == 1
+    assert [priority for _, priority in pool.starts] == [-1, 1]
+    assert pool.starts[0][0] is pool.starts[1][0]
+
+
+def test_running_prefetch_is_reused_and_decodes_once(tmp_path: Path) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "photo.heic"
+    presented: list[tuple[int, Path]] = []
+    scheduler.ready.connect(
+        lambda generation, surface, *_args: presented.append(
+            (generation, surface.decode_key.source)
+        )
+    )
+
+    assert scheduler.prefetch(_request(source, asset_id="asset-1", generation=0))
+    pool.mark_running(workers[0])
+    assert scheduler.request(_request(source, asset_id="asset-1", generation=3))
+    pool.complete(workers[0])
+
+    assert len(workers) == 1
+    assert presented == [(3, source)]
+
+
+def test_reused_surface_worker_adopts_latest_adjustments(tmp_path: Path) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "photo.jpg"
+
+    assert scheduler.prefetch(
+        _request(
+            source,
+            asset_id="asset-1",
+            generation=0,
+            adjustments={"Crop_W": 1.0},
+        )
+    )
+    pool.mark_running(workers[0])
+    assert scheduler.request(
+        _request(
+            source,
+            asset_id="asset-1",
+            generation=3,
+            adjustments={"Crop_W": 0.75},
+        )
+    )
+
+    assert len(workers) == 1
+    assert dict(workers[0].request.raw_adjustments or {}) == {"Crop_W": 0.75}
+
+
+def test_new_asset_bypasses_running_stale_decoder_and_stale_never_presents(
+    tmp_path: Path,
+) -> None:
+    scheduler, pool, workers = _harness()
+    source_a = tmp_path / "a.raw"
+    source_b = tmp_path / "b.jpg"
+    presented: list[tuple[int, Path]] = []
+    scheduler.ready.connect(
+        lambda generation, surface, *_args: presented.append(
+            (generation, surface.decode_key.source)
+        )
+    )
+
+    assert scheduler.request(_request(source_a, asset_id="A", generation=1))
+    worker_a = workers[0]
+    pool.mark_running(worker_a)
+    assert scheduler.request(_request(source_b, asset_id="B", generation=2))
+    worker_b = workers[1]
+    pool.mark_running(worker_b)
+
+    # B has started on the second lane before uninterruptible A completes.
+    assert len(pool.starts) == 2
+    pool.complete(worker_a)
+    pool.complete(worker_b)
+
+    assert presented == [(2, source_b)]
+
+
+def test_repeated_click_updates_generation_without_parallel_same_key_decoder(
+    tmp_path: Path,
+) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "photo.png"
+    presented: list[int] = []
+    scheduler.ready.connect(
+        lambda generation, *_args: presented.append(generation)
+    )
+
+    assert scheduler.request(_request(source, asset_id="asset-1", generation=1))
+    pool.mark_running(workers[0])
+    assert scheduler.request(_request(source, asset_id="asset-1", generation=2))
+    pool.complete(workers[0])
+
+    assert len(workers) == 1
+    assert presented == [2]
+
+
+def test_different_decode_levels_do_not_reuse_the_same_worker(tmp_path: Path) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "photo.jpg"
+    assert scheduler.request(
+        _request(source, asset_id="asset-1", generation=1, level=1024)
+    )
+    pool.mark_running(workers[0])
+
+    assert scheduler.request(
+        _request(source, asset_id="asset-1", generation=2, level=2048)
+    )
+
+    assert len(workers) == 2
+    assert workers[0].request.decode_level == 1024
+    assert workers[1].request.decode_level == 2048
+
+
+def test_neighbor_window_runs_one_speculative_decoder_at_a_time_and_warms_both(
+    tmp_path: Path,
+) -> None:
+    scheduler, pool, workers = _harness()
+    warmed: list[tuple[str | None, Path]] = []
+    scheduler.warmed.connect(
+        lambda request, surface: warmed.append(
+            (request.residency_slot, surface.decode_key.source)
+        )
+    )
+    previous = _request(
+        tmp_path / "previous.jpg",
+        asset_id="previous",
+        generation=0,
+        residency_slot="previous",
+        window_generation=4,
+    )
+    following = _request(
+        tmp_path / "next.jpg",
+        asset_id="next",
+        generation=0,
+        residency_slot="next",
+        window_generation=4,
+    )
+
+    assert scheduler.prefetch_window(previous, following)
+    assert len(workers) == 1
+    pool.mark_running(workers[0])
+    pool.complete(workers[0])
+    assert len(workers) == 2
+    pool.mark_running(workers[1])
+    pool.complete(workers[1])
+
+    assert warmed == [
+        ("previous", previous.source_identity.path),
+        ("next", following.source_identity.path),
+    ]
+
+
+def test_old_neighbor_window_result_is_not_published(tmp_path: Path) -> None:
+    scheduler, pool, workers = _harness()
+    warmed: list[Path] = []
+    scheduler.warmed.connect(
+        lambda _request, surface: warmed.append(surface.decode_key.source)
+    )
+    old = _request(
+        tmp_path / "old.jpg",
+        asset_id="old",
+        generation=0,
+        residency_slot="previous",
+        window_generation=1,
+    )
+    new = _request(
+        tmp_path / "new.jpg",
+        asset_id="new",
+        generation=0,
+        residency_slot="next",
+        window_generation=2,
+    )
+    assert scheduler.prefetch(old)
+    pool.mark_running(workers[0])
+    assert scheduler.prefetch(new)
+    pool.complete(workers[0])
+
+    assert warmed == []
+
+
+def test_shutdown_cancels_and_releases_queued_workers(tmp_path: Path) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "photo.jpg"
+    assert scheduler.request(_request(source, asset_id="asset-1", generation=1))
+
+    scheduler.shutdown(timeout_ms=25)
+
+    assert workers[0].cancelled
+    assert not workers[0].auto_delete
+    assert scheduler.inflight_count == 0
+    assert pool.cleared
+    assert pool.wait_timeout == 25
+
+
+def test_shutdown_retains_worker_when_pool_wait_times_out(tmp_path: Path) -> None:
+    scheduler, pool, workers = _harness()
+    source = tmp_path / "slow.raw"
+    assert scheduler.request(_request(source, asset_id="asset-1", generation=1))
+    worker = workers[0]
+    pool.mark_running(worker)
+    pool.wait_result = False
+
+    scheduler.shutdown(timeout_ms=25)
+
+    assert worker.cancelled
+    assert not worker.auto_delete
+    assert scheduler.inflight_count == 1
+
+    pool.complete(worker)
+
+    assert not worker.auto_delete
+    assert scheduler.inflight_count == 0
+

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from PySide6.QtGui import QImage
+
+import iPhoto.gui.detail_surface_cache as surface_cache_module
+from iPhoto.core.color_resolver import ColorStats
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailGeometryState,
+    DetailRenderRequest,
+)
+from iPhoto.gui.detail_surface_cache import (
+    CachedStillDecodeBackend,
+    MappedSurfaceCache,
+    NeutralSurfaceStore,
+    SurfaceCacheCorruptError,
+    surface_memory_budget_bytes,
+)
+
+
+class _Token:
+    def is_cancelled(self) -> bool:
+        return False
+
+
+def _request(source: Path, *, revision: int = 11, level: int = 1024) -> DetailRenderRequest:
+    return DetailRenderRequest(
+        generation=1,
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(
+            source,
+            size_bytes=1234,
+            source_mtime_ns=revision,
+            width=1600,
+            height=1200,
+            orientation=1,
+        ),
+        viewport_physical_size=(800, 600),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="initial",
+        decode_level=level,
+    )
+
+
+def _surface(request: DetailRenderRequest, width: int = 8, height: int = 4) -> DecodedSurface:
+    image = QImage(width, height, QImage.Format.Format_RGBA8888)
+    image.fill(0xFF123456)
+    return DecodedSurface(
+        image=image,
+        decode_key=DetailDecodeKey.from_request(request),
+        source_size=(1600, 1200),
+        decoded_size=(width, height),
+        decode_level=request.decode_level or "full",
+        backend="qt",
+        color_stats=ColorStats(saturation_mean=0.73, cast_magnitude=0.21),
+    )
+
+
+def test_surface_memory_budget_is_two_percent_with_clamps() -> None:
+    assert surface_memory_budget_bytes(1 * 1024**3) == 128 * 1024**2
+    assert surface_memory_budget_bytes(16 * 1024**3) == int(16 * 1024**3 * 0.02)
+    assert surface_memory_budget_bytes(128 * 1024**3) == 512 * 1024**2
+
+
+def test_mapped_surface_lru_accounts_real_stride_and_evicts(tmp_path: Path) -> None:
+    request_a = _request(tmp_path / "a.jpg")
+    request_b = _request(tmp_path / "b.jpg")
+    surface_a = _surface(request_a, 8, 4)
+    surface_b = _surface(request_b, 8, 4)
+    cache = MappedSurfaceCache(budget_bytes=surface_a.image.sizeInBytes())
+
+    assert cache.put(surface_a)
+    assert cache.put(surface_b)
+    assert cache.get(surface_a.decode_key) is None
+    hit = cache.get(surface_b.decode_key)
+    assert hit is not None
+    assert hit.cache_tier == "memory"
+    assert cache.used_bytes == surface_b.image.bytesPerLine() * surface_b.image.height()
+
+
+def test_disk_store_round_trip_returns_mmap_backed_rgba_surface(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    original = _surface(request)
+
+    assert store.write(request, original)
+    loaded = store.load(request)
+
+    assert loaded is not None
+    assert loaded.cache_tier == "disk"
+    assert loaded.backing_owner is not None
+    assert loaded.decode_key == original.decode_key
+    assert loaded.decoded_size == original.decoded_size
+    assert loaded.color_stats == original.color_stats
+    assert bytes(loaded.image.constBits()[:4]) == bytes(original.image.constBits()[:4])
+
+
+def test_disk_store_source_revision_changes_key_but_sidecar_is_not_an_input(tmp_path: Path) -> None:
+    store = NeutralSurfaceStore(tmp_path)
+    request = _request(tmp_path / "photo.jpg", revision=11)
+    changed = _request(tmp_path / "photo.jpg", revision=12)
+    assert store.entry_path(request) != store.entry_path(changed)
+
+    # DetailRenderRequest deliberately has no sidecar revision field. Raw edit
+    # mappings therefore do not affect the neutral cache identity.
+    edited = replace(request, raw_adjustments={"Exposure": 0.5})
+    assert store.entry_path(request) == store.entry_path(edited)
+
+
+def test_disk_store_rejects_truncated_header_synchronously(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    assert path is not None
+    data = bytearray(path.read_bytes())
+    path.write_bytes(data[:64])
+
+    with pytest.raises(SurfaceCacheCorruptError):
+        store.load(request)
+
+
+def test_disk_hit_defers_payload_checksum_to_explicit_validation(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+
+    with patch.object(
+        surface_cache_module,
+        "_checksum",
+        wraps=surface_cache_module._checksum,
+    ) as checksum:
+        loaded = store.load(request)
+        assert loaded is not None
+        assert checksum.call_count == 0
+        assert store.validate(request)
+        assert checksum.call_count == 1
+
+
+def test_async_payload_failure_evicts_and_forces_redecode(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    assert path is not None
+    damaged = bytearray(path.read_bytes())
+    damaged[-1] ^= 0xFF
+    path.write_bytes(damaged)
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    backend = CachedStillDecodeBackend(delegate, store=store)
+
+    disk_hit = backend.decode(request, _Token())
+    backend.shutdown()
+    decoded = backend.decode(request, _Token())
+
+    assert disk_hit.cache_tier == "disk"
+    assert decoded.cache_tier == "decode"
+    assert delegate.decode.call_count == 1
+
+
+def test_unbound_store_is_a_disabled_disk_tier(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(None)
+    assert store.entry_path(request) is None
+    assert store.load(request) is None
+    assert store.write(request, _surface(request)) is False
+
+
+def test_legacy_identity_is_rejected_by_reusable_cache_layers(tmp_path: Path) -> None:
+    request = replace(
+        _request(tmp_path / "photo.jpg"),
+        source_identity=AssetSourceIdentity.create(tmp_path / "photo.jpg"),
+    )
+    surface = _surface(request)
+    store = NeutralSurfaceStore(tmp_path)
+    cache = MappedSurfaceCache()
+
+    assert request.source_identity.has_stable_revision is False
+    assert store.entry_path(request) is None
+    assert store.write(request, surface) is False
+    assert cache.put(surface) is False
+    assert cache.get(surface.decode_key) is None
+
+
+def test_missing_revision_is_repaired_by_stat_before_caching(tmp_path: Path) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"first")
+    request = replace(
+        _request(source),
+        source_identity=AssetSourceIdentity.create(source, width=1600, height=1200),
+    )
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    backend = CachedStillDecodeBackend(delegate, store=NeutralSurfaceStore(None))
+
+    first = backend.decode(request, _Token())
+    second = backend.decode(request, _Token())
+    backend.shutdown()
+
+    assert first.decode_key.source_revision[0] == "mtime"
+    assert second.cache_tier == "memory"
+    assert delegate.decode.call_count == 1
+
+
+def test_in_place_source_replacement_misses_old_memory_and_disk_entries(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"first")
+    initial_stat = source.stat()
+    request = replace(
+        _request(source),
+        source_identity=AssetSourceIdentity.create(source, width=1600, height=1200),
+    )
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    store = NeutralSurfaceStore(tmp_path)
+    backend = CachedStillDecodeBackend(delegate, store=store)
+
+    first = backend.decode(request, _Token())
+    backend.shutdown()
+    source.write_bytes(b"replacement-is-larger")
+    os.utime(
+        source,
+        ns=(initial_stat.st_atime_ns, initial_stat.st_mtime_ns + 1_000_000_000),
+    )
+    second = backend.decode(request, _Token())
+
+    assert first.decode_key.source_revision != second.decode_key.source_revision
+    assert delegate.decode.call_count == 2
+
+
+def test_stat_failure_bypasses_memory_and_disk_cache(tmp_path: Path) -> None:
+    source = tmp_path / "missing.jpg"
+    request = replace(
+        _request(source),
+        source_identity=AssetSourceIdentity.create(source, width=1600, height=1200),
+    )
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    store = Mock()
+    backend = CachedStillDecodeBackend(delegate, store=store)
+
+    backend.decode(request, _Token())
+    backend.decode(request, _Token())
+    backend.shutdown()
+
+    assert delegate.decode.call_count == 2
+    assert backend.memory_cache.used_bytes == 0
+    store.load.assert_not_called()
+    store.write.assert_not_called()
+
+
+def test_surface_write_uses_a_buffer_without_python_bytes_copy(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    synthetic_64_mib = _surface(request, width=4096, height=4096)
+    assert synthetic_64_mib.image.sizeInBytes() == 64 * 1024 * 1024
+
+    with patch.object(
+        surface_cache_module,
+        "bytes",
+        side_effect=AssertionError("payload copied into Python bytes"),
+        create=True,
+    ):
+        assert store.write(request, synthetic_64_mib)
+
+
+def test_prune_is_batched_across_repeated_writes(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(
+        tmp_path,
+        prune_every_writes=25,
+        prune_after_bytes=10**12,
+        prune_interval_seconds=10**6,
+    )
+
+    with patch.object(store, "prune") as prune:
+        for _ in range(100):
+            assert store.write(request, _surface(request))
+
+    assert prune.call_count == 4
+
+
+def test_color_stats_are_computed_once_across_lod_decodes(tmp_path: Path) -> None:
+    first = _request(tmp_path / "photo.jpg", level=1024)
+    second = _request(tmp_path / "photo.jpg", level=2048)
+    delegate = Mock()
+    delegate.decode.side_effect = [_surface(first), _surface(second)]
+    backend = CachedStillDecodeBackend(delegate, store=NeutralSurfaceStore(None))
+    stats = ColorStats(saturation_mean=0.91)
+
+    with patch(
+        "iPhoto.gui.detail_surface_cache.compute_color_statistics",
+        return_value=stats,
+    ) as compute:
+        decoded_first = backend.decode(first, _Token())
+        decoded_second = backend.decode(second, _Token())
+
+    backend.shutdown()
+    assert compute.call_count == 1
+    assert decoded_first.color_stats is stats
+    assert decoded_second.color_stats is stats


### PR DESCRIPTION
## What changed

- Rebuilds only the Detail transaction, request scheduler, platform still decoders, surface cache, and render-state coordinator from #890; no merge commits, Edit, Live Photo, Recognition, or Pets code is included.
- Adds `AssetSourceIdentity.has_stable_revision` and worker-side stat repair. Legacy identities bypass both reusable memory and disk caches.
- Makes disk hits perform header/key/geometry checks synchronously while payload checksums run on the cache worker; failed validation deny-lists/evicts the entry so the next request re-decodes.
- Writes QImage payloads through a buffer view instead of allocating a same-sized Python `bytes` object.
- Batches disk pruning by write count, accumulated bytes, or elapsed time.
- Bridges RAW ndarrays through a target-sized view and predicts peak decode memory; full demosaic downgrades to half when the configured working budget would be exceeded.
- Adds Linux/macOS/Windows Detail core contract jobs.

## Review remediation

Addresses #890 findings 7 and 9, plus the RAW intermediate-memory portion of finding 8. PlayerView-wide surface retention and Edit/Library lifecycle remain intentionally scoped to the later Detail/Edit/Library replacement PR.

## Validation

- Detail core contracts: 64 passed, 1 Windows-only skip locally.
- Full non-GUI regression: 1822 passed, 12 skipped.
- Architecture checks: passed.
- `compileall`, workflow YAML parse, and `git diff --check`: passed.
- Cache contracts include a 64 MiB synthetic write without Python `bytes`, asynchronous disk-hit checksum, 100-write batched pruning, source replacement invalidation, stat-failure bypass, and RAW budget fallback.

## Split context

Replacement PR 3 for draft #890. Depends only on merged #891 and #892. The modules are kept independent of Edit and Live Photo UI lifecycle so those behaviors can be reviewed and rolled back separately.