### PR TITLE
Fix Live Photo motion-to-still presentation lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,3 +135,44 @@ jobs:
           tests/gui/test_detail_decode_backend.py
           tests/gui/test_detail_surface_cache.py
           tests/gui/test_detail_render_coordinator.py
+
+  live-photo-contracts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libegl1 libgl1 libxkbcommon0 libpulse0
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run Live Photo lifecycle contracts
+        env:
+          QT_QPA_PLATFORM: offscreen
+          NUMBA_DISABLE_JIT: "1"
+        run: >-
+          python -m pytest -q
+          tests/gui/test_detail_render_coordinator.py
+          tests/gui/coordinators/test_playback_coordinator.py
+          tests/ui/controllers/test_player_view_controller_adjustments.py
+          tests/ui/controllers/test_player_view_init_cover.py
+          tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
+          tests/ui/widgets/test_video_area.py

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -23,6 +23,8 @@ from iPhoto.infrastructure.repositories.location_assignment_repository import (
     IndexStoreLocationAssignmentRepository,
 )
 from iPhoto.gui.detail_profile import log_detail_profile
+from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailRenderTransaction
+from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator
 from iPhoto.gui.coordinators.view_router import ViewRouter
 from iPhoto.gui.i18n import tr
 from iPhoto.gui.services.location_file_write_queue import (
@@ -168,6 +170,9 @@ class PlaybackCoordinator(QObject):
         self._info_panel: InfoPanel | None = None
         self._active_live_motion: Path | None = None
         self._active_live_still: Path | None = None
+        self._detail_render_lifecycle = DetailRenderCoordinator(self)
+        self._detail_generation = 0
+        self._live_transaction: DetailRenderTransaction | None = None
         self._resume_after_transition = False
         self._trim_in_ms = 0
         self._trim_out_ms = 0
@@ -330,6 +335,12 @@ class PlaybackCoordinator(QObject):
         self._player_view.liveReplayRequested.connect(self.replay_live_photo)
         self._player_view.video_area.playbackStateChanged.connect(self._sync_playback_state)
         self._player_view.video_area.playbackFinished.connect(self._handle_playback_finished)
+        still_presented = getattr(self._player_view, "stillFramePresented", None)
+        if still_presented is not None:
+            still_presented.connect(self._handle_live_still_presented)
+        video_presented = getattr(self._player_view, "videoFramePresented", None)
+        if video_presented is not None:
+            video_presented.connect(self._handle_live_motion_first_frame)
         self._player_view.video_area.durationChanged.connect(self._on_video_duration_changed)
         self._player_view.video_area.positionChanged.connect(self._on_video_position_changed)
 
@@ -578,6 +589,13 @@ class PlaybackCoordinator(QObject):
         source = presentation.path
         self._active_live_motion = None
         self._active_live_still = None
+        live_transaction = (
+            self._begin_or_reuse_live_transaction(presentation)
+            if presentation.is_live and not presentation.is_video
+            else None
+        )
+        if live_transaction is None:
+            self._retire_live_transaction()
 
         self._favorite_button.setEnabled(presentation.can_toggle_favorite)
         self._info_button.setEnabled(True)
@@ -633,7 +651,13 @@ class PlaybackCoordinator(QObject):
                 self._player_view.video_area.stop()
             self._player_view.show_image_surface()
             display_started = time.perf_counter()
-            self._player_view.display_image(source)
+            if live_transaction is None:
+                self._player_view.display_image(source)
+            else:
+                self._player_view.display_image(
+                    source,
+                    transaction=live_transaction,
+                )
             log_detail_profile(
                 "playback",
                 "image.display_image",
@@ -711,6 +735,7 @@ class PlaybackCoordinator(QObject):
         if motion_path is None:
             self._refresh_face_name_overlay_for_presentation(presentation)
             return
+        transaction = self._begin_or_reuse_live_transaction(presentation)
         self._active_live_motion = motion_path
         self._active_live_still = presentation.path
         self._hide_face_name_overlay(clear_annotations=False)
@@ -727,20 +752,106 @@ class PlaybackCoordinator(QObject):
         self._player_view.video_area.play()
         self._player_bar.setEnabled(False)
         self._is_playing = True
+        self._detail_render_lifecycle.mark_preparing(transaction.generation)
 
     def _handle_playback_finished(self) -> None:
         if not self._active_live_motion or not self._active_live_still:
             return
         still = self._active_live_still
         self._active_live_motion = None
+        transaction = getattr(self, "_live_transaction", None)
+        applied_pending = self._player_view.apply_pending_still()
         self._player_view.defer_still_updates(False)
-        if not self._player_view.apply_pending_still():
-            self._player_view.display_image(still)
+        if not applied_pending:
+            if transaction is None:
+                self._player_view.display_image(still)
+            else:
+                self._player_view.display_image(still, transaction=transaction)
         self._player_bar.setEnabled(False)
         self._player_view.show_live_badge()
         self._player_view.set_live_replay_enabled(True)
         self._is_playing = False
+
+    def _begin_or_reuse_live_transaction(
+        self,
+        presentation: DetailPresentation,
+    ) -> DetailRenderTransaction:
+        current = getattr(self, "_live_transaction", None)
+        if (
+            current is not None
+            and current.asset_id == presentation.asset_id
+            and current.source_identity.path == presentation.path
+        ):
+            return current
+        lifecycle = getattr(self, "_detail_render_lifecycle", None)
+        if lifecycle is None:
+            lifecycle = DetailRenderCoordinator()
+            self._detail_render_lifecycle = lifecycle
+        lifecycle.cancel_current()
+        self._detail_generation = max(0, int(getattr(self, "_detail_generation", 0))) + 1
+        transaction = DetailRenderTransaction(
+            generation=self._detail_generation,
+            asset_id=presentation.asset_id or presentation.path.name,
+            media_kind="live_motion",
+            source_identity=AssetSourceIdentity.from_info(
+                presentation.path,
+                presentation.info,
+            ),
+            reason="click",
+        )
+        lifecycle.begin(transaction)
+        lifecycle.mark_routed(transaction.generation, row=presentation.row)
+        self._live_transaction = transaction
+        return transaction
+
+    def _retire_live_transaction(self) -> None:
+        transaction = getattr(self, "_live_transaction", None)
+        if transaction is None:
+            return
+        lifecycle = getattr(self, "_detail_render_lifecycle", None)
+        if lifecycle is not None:
+            lifecycle.cancel_current()
+        self._live_transaction = None
+
+    @Slot(int)
+    def _handle_live_motion_first_frame(self, generation: int) -> None:
+        transaction = getattr(self, "_live_transaction", None)
+        if (
+            transaction is None
+            or transaction.generation != int(generation)
+            or getattr(self, "_active_live_motion", None) is None
+        ):
+            return
+        self._detail_render_lifecycle.mark_surface_presented(
+            transaction.generation,
+            "live_motion_frame",
+        )
+
+    @Slot(Path, int)
+    def _handle_live_still_presented(self, source: Path, generation: int) -> None:
+        transaction = getattr(self, "_live_transaction", None)
+        if (
+            transaction is None
+            or transaction.generation != int(generation)
+            or transaction.source_identity.path != Path(source)
+        ):
+            return
+        if not self._detail_render_lifecycle.mark_surface_presented(
+            transaction.generation,
+            "live_still",
+        ):
+            return
         self._refresh_face_name_overlay_for_current_presentation()
+        self._prefetch_neighbor_rows()
+
+    def _prefetch_neighbor_rows(self) -> None:
+        row = self.current_row()
+        count = self._asset_model.rowCount()
+        if row < 0 or count <= 1:
+            return
+        first = max(0, row - 1)
+        last = min(count - 1, row + 1)
+        self._asset_model.prioritize_rows(first, last)
 
     def _hide_face_name_overlay(self, *, clear_annotations: bool) -> None:
         overlay = getattr(self, "_face_name_overlay", None)
@@ -1098,6 +1209,7 @@ class PlaybackCoordinator(QObject):
 
     def reset_for_gallery(self) -> None:
         self._clear_play_request_state()
+        self._retire_live_transaction()
         self._reset_location_search_service(clear_cache=True)
         video_area = self._player_view.video_area
         has_video = False
@@ -1145,6 +1257,7 @@ class PlaybackCoordinator(QObject):
 
     def shutdown(self) -> None:
         self._clear_play_request_state()
+        self._retire_live_transaction()
         location_search_controller = getattr(self, "_location_search_controller", None)
         if location_search_controller is not None:
             location_search_controller.shutdown()

--- a/src/iPhoto/gui/detail_render_coordinator.py
+++ b/src/iPhoto/gui/detail_render_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Literal
 
 from PySide6.QtCore import QObject, Signal
 
@@ -26,12 +27,15 @@ _TERMINAL_STATES = {
     DetailRenderState.CANCELLED,
 }
 
+DetailSurfaceKind = Literal["still", "video_frame", "live_motion_frame", "live_still"]
+
 
 @dataclass(frozen=True, slots=True)
 class DetailRenderSnapshot:
     transaction: DetailRenderTransaction
     state: DetailRenderState
     message: str = ""
+    presented_surfaces: tuple[DetailSurfaceKind, ...] = ()
 
 
 class DetailRenderCoordinator(QObject):
@@ -41,6 +45,7 @@ class DetailRenderCoordinator(QObject):
     presented = Signal(object)
     failed = Signal(object)
     cancelled = Signal(object)
+    surfacePresented = Signal(object, str)
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -63,17 +68,70 @@ class DetailRenderCoordinator(QObject):
             and snapshot.state not in _TERMINAL_STATES
         )
 
+    def owns_generation(self, generation: int) -> bool:
+        """Return whether the transaction still owns follow-on surface delivery."""
+
+        snapshot = self._snapshot
+        return bool(
+            snapshot is not None
+            and snapshot.transaction.generation == int(generation)
+            and snapshot.state not in {DetailRenderState.FAILED, DetailRenderState.CANCELLED}
+        )
+
     def begin(self, transaction: DetailRenderTransaction) -> bool:
         if transaction.generation <= 0:
             raise ValueError("Detail render transaction generation must be positive")
         current = self._snapshot
         if current is not None:
-            if current.transaction == transaction and current.state not in _TERMINAL_STATES:
+            if current.transaction == transaction:
                 return False
             if current.state not in _TERMINAL_STATES:
                 self._transition(DetailRenderState.CANCELLED)
         self._snapshot = DetailRenderSnapshot(transaction, DetailRenderState.CREATED)
         self.stateChanged.emit(self._snapshot)
+        return True
+
+    def mark_surface_presented(
+        self,
+        generation: int,
+        surface_kind: DetailSurfaceKind,
+    ) -> bool:
+        """Record a visible surface without reopening a completed transaction.
+
+        A Live Photo transaction becomes visible on its motion first frame but
+        continues to own the later still restoration.  That still is a second
+        surface presentation, not a second transaction terminal transition.
+        """
+
+        snapshot = self._snapshot
+        if snapshot is None or snapshot.transaction.generation != int(generation):
+            return False
+        if snapshot.state in {DetailRenderState.FAILED, DetailRenderState.CANCELLED}:
+            return False
+        if snapshot.state is DetailRenderState.PRESENTED:
+            if snapshot.transaction.media_kind != "live_motion" or surface_kind not in {
+                "live_motion_frame",
+                "live_still",
+            }:
+                return False
+        self._snapshot = DetailRenderSnapshot(
+            transaction=snapshot.transaction,
+            state=snapshot.state,
+            message=snapshot.message,
+            presented_surfaces=(*snapshot.presented_surfaces, surface_kind),
+        )
+        emit_detail_event(
+            "surface_presented",
+            generation=int(generation),
+            media_type=snapshot.transaction.media_kind,
+            surface_kind=surface_kind,
+        )
+        if snapshot.state is not DetailRenderState.PRESENTED:
+            if not self.mark_presented(generation):
+                return False
+        current = self._snapshot
+        if current is not None:
+            self.surfacePresented.emit(current, surface_kind)
         return True
 
     def mark_routed(self, generation: int, *, row: int) -> bool:
@@ -153,7 +211,12 @@ class DetailRenderCoordinator(QObject):
         snapshot = self._snapshot
         if snapshot is None:
             return
-        self._snapshot = DetailRenderSnapshot(snapshot.transaction, state, message)
+        self._snapshot = DetailRenderSnapshot(
+            snapshot.transaction,
+            state,
+            message,
+            snapshot.presented_surfaces,
+        )
         emit = {
             DetailRenderState.PRESENTED: self.presented,
             DetailRenderState.FAILED: self.failed,
@@ -170,5 +233,5 @@ __all__ = [
     "DetailRenderCoordinator",
     "DetailRenderSnapshot",
     "DetailRenderState",
+    "DetailSurfaceKind",
 ]
-

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import QLabel, QStackedWidget, QWidget
 
 from ....application.ports import EditServicePort
 from ....core.color_resolver import compute_color_statistics
+from ....gui.detail_pipeline import DetailRenderTransaction
 from ....gui.detail_profile import log_detail_profile
 from ....gui.i18n import tr
 from ....utils import image_loader
@@ -115,6 +116,12 @@ class PlayerViewController(QObject):
     imageLoadingFailed = Signal(Path, str)
     """Emitted when a still image fails to load or post-process."""
 
+    stillFramePresented = Signal(Path, int)
+    """Emitted when a transaction-owned still has actually rendered."""
+
+    videoFramePresented = Signal(int)
+    """Emitted when a transaction-owned video surface renders its first frame."""
+
     def __init__(
         self,
         player_stack: QStackedWidget,
@@ -145,8 +152,14 @@ class PlayerViewController(QObject):
         self._active_workers: Set[_AdjustedImageWorker] = set()
         self._loading_source: Optional[Path] = None
         self._loading_started_at: float | None = None
+        self._active_transaction: DetailRenderTransaction | None = None
+        self._loading_transaction: DetailRenderTransaction | None = None
+        self._current_still_source: Path | None = None
+        self._current_still_generation = 0
         self._defer_still_updates = False
-        self._pending_still: Optional[tuple[Path, QImage, dict]] = None
+        self._pending_still: Optional[
+            tuple[Path, QImage, dict, DetailRenderTransaction | None]
+        ] = None
 
         # Per-widget first-render tracking.  QRhiWidget backing textures are
         # uninitialised (transparent) until the first ``render()`` call fills
@@ -159,7 +172,13 @@ class PlayerViewController(QObject):
         self._video_renderer_rendered = False
 
         self._image_viewer.firstFrameReady.connect(self._on_image_first_render)
+        still_presented = getattr(self._image_viewer, "stillFramePresented", None)
+        if still_presented is not None:
+            still_presented.connect(self._on_still_surface_presented)
         self._video_area.firstFrameReady.connect(self._on_video_first_render)
+        video_presented = getattr(self._video_area, "framePresented", None)
+        if video_presented is not None:
+            video_presented.connect(self._on_video_surface_presented)
 
     # ------------------------------------------------------------------
     # High-level surface selection helpers
@@ -175,11 +194,27 @@ class PlayerViewController(QObject):
         if self._player_stack.currentWidget() is self._image_viewer:
             self._hide_detail_init_cover()
 
+    def _on_still_surface_presented(self, source: object) -> None:
+        if self._current_still_generation <= 0:
+            return
+        presented_source = Path(source)
+        if self._current_still_source != presented_source:
+            return
+        self.stillFramePresented.emit(
+            presented_source,
+            self._current_still_generation,
+        )
+
     def _on_video_first_render(self) -> None:
         """Mark video renderer as initialised; hide cover if it is visible."""
         self._video_renderer_rendered = True
         if self._player_stack.currentWidget() is self._video_area:
             self._hide_detail_init_cover()
+
+    def _on_video_surface_presented(self, _source: Path) -> None:
+        transaction = self._active_transaction
+        if transaction is not None and transaction.media_kind == "live_motion":
+            self.videoFramePresented.emit(transaction.generation)
 
     def _hide_detail_init_cover(self) -> None:
         """Walk up to ``DetailPageWidget`` and hide the init cover."""
@@ -281,10 +316,18 @@ class PlayerViewController(QObject):
     # ------------------------------------------------------------------
     # Content helpers
     # ------------------------------------------------------------------
-    def display_image(self, source: Path, *, placeholder: Optional[QPixmap] = None) -> bool:
+    def display_image(
+        self,
+        source: Path,
+        *,
+        placeholder: Optional[QPixmap] = None,
+        transaction: DetailRenderTransaction | None = None,
+    ) -> bool:
         """Begin loading ``source`` asynchronously, returning scheduling success."""
         self._loading_source = source
         self._loading_started_at = time.perf_counter()
+        self._active_transaction = transaction
+        self._loading_transaction = transaction
 
         # 1) 先切到 GL 视图，保证有有效的 GL 上下文
         self.show_image_surface()
@@ -320,6 +363,7 @@ class PlayerViewController(QObject):
             self._release_worker(worker)
             self._loading_source = None
             self._loading_started_at = None
+            self._loading_transaction = None
             self.imageLoadingFailed.emit(source, str(exc))
             return False
         return True
@@ -334,9 +378,9 @@ class PlayerViewController(QObject):
         """Apply any deferred still frame if available."""
         if self._pending_still is None:
             return False
-        source, image, adjustments = self._pending_still
+        source, image, adjustments, transaction = self._pending_still
         self._pending_still = None
-        self._apply_still_frame(source, image, adjustments)
+        self._apply_still_frame(source, image, adjustments, transaction=transaction)
         return True
 
     def clear_image(self) -> None:
@@ -419,18 +463,30 @@ class PlayerViewController(QObject):
             if self._loading_source == source:
                 self._loading_source = None
                 self._loading_started_at = None
+                self._loading_transaction = None
             self._image_viewer.set_image(None, {})
             self.imageLoadingFailed.emit(source, "Image decoder returned an empty frame")
             return
 
         if self._defer_still_updates and self._player_stack.currentWidget() is self._video_area:
-            self._pending_still = (source, image, adjustments)
+            self._pending_still = (
+                source,
+                image,
+                adjustments,
+                self._loading_transaction,
+            )
         else:
-            self._apply_still_frame(source, image, adjustments)
+            self._apply_still_frame(
+                source,
+                image,
+                adjustments,
+                transaction=self._loading_transaction,
+            )
 
         if self._loading_source == source:
             self._loading_source = None
             self._loading_started_at = None
+            self._loading_transaction = None
 
     def _on_adjusted_image_failed(self, source: Path, message: str) -> None:
         """Propagate worker failures while ensuring stale results are ignored."""
@@ -441,12 +497,25 @@ class PlayerViewController(QObject):
         if self._loading_source == source:
             self._loading_source = None
             self._loading_started_at = None
+            self._loading_transaction = None
         self._image_viewer.set_image(None)
         self.imageLoadingFailed.emit(source, message)
 
-    def _apply_still_frame(self, source: Path, image: QImage, adjustments: dict) -> None:
+    def _apply_still_frame(
+        self,
+        source: Path,
+        image: QImage,
+        adjustments: dict,
+        *,
+        transaction: DetailRenderTransaction | None = None,
+    ) -> None:
         """Render the still image on the GL viewer."""
         apply_started = time.perf_counter()
+        self._active_transaction = transaction
+        self._current_still_source = source
+        self._current_still_generation = (
+            transaction.generation if transaction is not None else 0
+        )
         self.show_image_surface()
         self._image_viewer.set_image(
             image,

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -99,6 +99,8 @@ class GLImageViewer(QRhiWidget):
     colorPicked = Signal(float, float, float)
     firstFrameReady = Signal()
     """Emitted once after the first opaque frame has been rendered."""
+    stillFramePresented = Signal(object)
+    """Emitted after each newly uploaded still texture is drawn."""
 
     def __init__(self, parent: QRhiWidget | None = None) -> None:
         super().__init__(parent)
@@ -1289,6 +1291,7 @@ class GLImageViewer(QRhiWidget):
         cb.endPass()
         self._emit_first_frame_ready()
         if uploaded_new_still_texture:
+            self._emit_still_frame_presented()
             self._schedule_post_load_view_transform()
 
     def _render_rhi(self, cb) -> None:
@@ -1393,7 +1396,13 @@ class GLImageViewer(QRhiWidget):
 
         self._emit_first_frame_ready()
         if uploaded_new_still_texture:
+            self._emit_still_frame_presented()
             self._schedule_post_load_view_transform()
+
+    def _emit_still_frame_presented(self) -> None:
+        source = self.current_image_source()
+        if source is not None:
+            self.stillFramePresented.emit(source)
 
     def _emit_first_frame_ready(self) -> None:
         """Notify listeners that the first opaque frame has been rendered."""

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -99,6 +99,8 @@ class VideoArea(QWidget):
     cropInteractionFinished = Signal()
     colorPicked = Signal(float, float, float)
     firstFrameReady = Signal()
+    framePresented = Signal(Path)
+    """Emitted once per load when the first decoded frame reaches the GPU surface."""
     displaySizeChanged = Signal(QSizeF)
     SHORTCUT_VOLUME_STEP = 5
 
@@ -166,6 +168,7 @@ class VideoArea(QWidget):
         self._profile_load_started_at: float | None = None
         self._profile_load_source: Path | None = None
         self._profile_first_frame_logged = False
+        self._surface_first_frame_pending = False
         self._resize_refit_pending = False
         self._resize_refit_timer = QTimer(self)
         self._resize_refit_timer.setSingleShot(True)
@@ -655,6 +658,7 @@ class VideoArea(QWidget):
         self._profile_load_started_at = load_started
         self._profile_load_source = path
         self._profile_first_frame_logged = False
+        self._surface_first_frame_pending = True
         self._current_source = path
         self._current_adjustments = dict(adjustments or {})
         self._pending_video_frame = None
@@ -1298,6 +1302,15 @@ class VideoArea(QWidget):
         self._edit_viewer.colorPicked.connect(self.colorPicked.emit)
         self._edit_viewer.firstFrameReady.connect(self.firstFrameReady.emit)
         self._renderer.firstFrameReady.connect(self.firstFrameReady.emit)
+        self._renderer.framePresented.connect(self._on_renderer_frame_presented)
+
+    def _on_renderer_frame_presented(self) -> None:
+        """Publish the first GPU-presented frame for the current media load."""
+
+        if not self._surface_first_frame_pending or self._current_source is None:
+            return
+        self._surface_first_frame_pending = False
+        self.framePresented.emit(self._current_source)
 
     def _on_edit_viewer_zoom_changed(self, factor: float) -> None:
         """Forward zoom changes from _edit_viewer only when it is the active surface."""

--- a/src/iPhoto/gui/ui/widgets/video_renderer_widget.py
+++ b/src/iPhoto/gui/ui/widgets/video_renderer_widget.py
@@ -271,6 +271,8 @@ class VideoRendererWidget(QRhiWidget):
 
     nativeSizeChanged = Signal(QSizeF)
     firstFrameReady = Signal()
+    framePresented = Signal()
+    """Emitted after a decoded frame has completed a GPU render pass."""
     zoomChanged = Signal(float)
 
     _ZOOM_MIN = 0.1
@@ -770,6 +772,7 @@ class VideoRendererWidget(QRhiWidget):
         cb.setVertexInput(0, vbuf_binding)
         cb.draw(6)  # 6 vertices = 2 triangles
         cb.endPass()
+        self.framePresented.emit()
         self._emit_first_frame_ready()
 
     def _emit_first_frame_ready(self) -> None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -12,6 +12,7 @@ pytest.importorskip("PySide6", reason="PySide6 is required for playback coordina
 from iPhoto.application.ports import LocationWriteJobRecord
 from iPhoto.gui.coordinators import playback_coordinator as playback_coordinator_module
 from iPhoto.gui.coordinators.playback_coordinator import PlaybackCoordinator
+from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator, DetailRenderState
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
 from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
 from iPhoto.gui.ui.widgets.recognition_annotations import RecognitionAnnotation
@@ -410,6 +411,133 @@ def test_render_presentation_stops_video_area_before_showing_still() -> None:
     assert parent.mock_calls[:2] == [call.stop(), call.show_image_surface()]
     player_view.display_image.assert_called_once_with(Path("/fake/photo.heic"))
     coordinator._player_bar.setEnabled.assert_called_once_with(False)
+
+
+def _live_lifecycle_coordinator(
+    tmp_path: Path,
+) -> tuple[PlaybackCoordinator, DetailPresentation, Path, Path]:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = tmp_path / "photo.heic"
+    motion = tmp_path / "motion.mov"
+    still.write_bytes(b"still")
+    motion.write_bytes(b"motion")
+    presentation = replace(
+        _make_presentation(
+            path=str(still),
+            is_video=False,
+            is_live=True,
+        ),
+        live_motion_rel=Path("motion.mov"),
+        live_motion_abs=motion,
+    )
+    coordinator._detail_render_lifecycle = DetailRenderCoordinator()
+    coordinator._detail_generation = 0
+    coordinator._live_transaction = None
+    coordinator._current_presentation = presentation
+    coordinator._active_live_motion = motion
+    coordinator._active_live_still = still
+    coordinator._detail_vm = SimpleNamespace(current_row=SimpleNamespace(value=1))
+    coordinator._asset_model = Mock(rowCount=Mock(return_value=3), prioritize_rows=Mock())
+    coordinator._refresh_face_name_overlay_for_current_presentation = Mock()
+    coordinator._player_view = Mock(
+        apply_pending_still=Mock(),
+        defer_still_updates=Mock(),
+        display_image=Mock(),
+        show_live_badge=Mock(),
+        set_live_replay_enabled=Mock(),
+    )
+    coordinator._player_bar = Mock(setEnabled=Mock())
+    coordinator._is_playing = True
+    return coordinator, presentation, still, motion
+
+
+def test_live_pending_still_completes_same_transaction_before_overlay_and_prefetch(
+    tmp_path: Path,
+) -> None:
+    coordinator, presentation, still, _motion = _live_lifecycle_coordinator(tmp_path)
+    transaction = PlaybackCoordinator._begin_or_reuse_live_transaction(
+        coordinator,
+        presentation,
+    )
+    PlaybackCoordinator._handle_live_motion_first_frame(
+        coordinator,
+        transaction.generation,
+    )
+    coordinator._player_view.apply_pending_still.return_value = True
+    order = Mock()
+    order.attach_mock(
+        coordinator._refresh_face_name_overlay_for_current_presentation,
+        "overlay",
+    )
+    order.attach_mock(coordinator._asset_model.prioritize_rows, "prefetch")
+
+    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._handle_live_still_presented(
+        coordinator,
+        still,
+        transaction.generation,
+    )
+    reused = PlaybackCoordinator._begin_or_reuse_live_transaction(
+        coordinator,
+        presentation,
+    )
+
+    assert reused is transaction
+    assert coordinator._detail_generation == transaction.generation
+    assert coordinator._detail_render_lifecycle.snapshot is not None
+    assert coordinator._detail_render_lifecycle.snapshot.state is DetailRenderState.PRESENTED
+    assert coordinator._detail_render_lifecycle.snapshot.presented_surfaces == (
+        "live_motion_frame",
+        "live_still",
+    )
+    coordinator._player_view.display_image.assert_not_called()
+    assert order.mock_calls == [call.overlay(), call.prefetch(0, 2)]
+
+
+def test_live_redecode_restores_still_with_original_transaction(
+    tmp_path: Path,
+) -> None:
+    coordinator, presentation, still, _motion = _live_lifecycle_coordinator(tmp_path)
+    transaction = PlaybackCoordinator._begin_or_reuse_live_transaction(
+        coordinator,
+        presentation,
+    )
+    PlaybackCoordinator._handle_live_motion_first_frame(
+        coordinator,
+        transaction.generation,
+    )
+    coordinator._player_view.apply_pending_still.return_value = False
+
+    PlaybackCoordinator._handle_playback_finished(coordinator)
+
+    coordinator._player_view.display_image.assert_called_once_with(
+        still,
+        transaction=transaction,
+    )
+    PlaybackCoordinator._handle_live_still_presented(
+        coordinator,
+        still,
+        transaction.generation,
+    )
+    coordinator._refresh_face_name_overlay_for_current_presentation.assert_called_once_with()
+    coordinator._asset_model.prioritize_rows.assert_called_once_with(0, 2)
+
+
+def test_live_still_rejects_previous_generation(tmp_path: Path) -> None:
+    coordinator, presentation, still, _motion = _live_lifecycle_coordinator(tmp_path)
+    transaction = PlaybackCoordinator._begin_or_reuse_live_transaction(
+        coordinator,
+        presentation,
+    )
+
+    PlaybackCoordinator._handle_live_still_presented(
+        coordinator,
+        still,
+        transaction.generation - 1,
+    )
+
+    coordinator._refresh_face_name_overlay_for_current_presentation.assert_not_called()
+    coordinator._asset_model.prioritize_rows.assert_not_called()
 
 
 def test_reset_for_gallery_closes_info_panel_and_clears_viewmodel_state() -> None:

--- a/tests/gui/test_detail_render_coordinator.py
+++ b/tests/gui/test_detail_render_coordinator.py
@@ -49,6 +49,44 @@ def test_new_transaction_cancels_old_and_rejects_stale_result(qapp) -> None:
     assert coordinator.mark_presented(2)
 
 
+def test_live_motion_and_restored_still_share_one_completed_transaction(qapp) -> None:
+    coordinator = DetailRenderCoordinator()
+    terminal_presentations = []
+    surfaces = []
+    coordinator.presented.connect(terminal_presentations.append)
+    coordinator.surfacePresented.connect(
+        lambda snapshot, kind: surfaces.append((snapshot.transaction.generation, kind))
+    )
+    transaction = _transaction(7, media_kind="live_motion")
+
+    assert coordinator.begin(transaction)
+    assert coordinator.mark_preparing(7)
+    assert coordinator.mark_surface_presented(7, "live_motion_frame")
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.state is DetailRenderState.PRESENTED
+    assert coordinator.owns_generation(7)
+    assert coordinator.mark_surface_presented(7, "live_still")
+    assert not coordinator.begin(transaction)
+
+    assert len(terminal_presentations) == 1
+    assert surfaces == [(7, "live_motion_frame"), (7, "live_still")]
+    assert coordinator.snapshot.presented_surfaces == (
+        "live_motion_frame",
+        "live_still",
+    )
+
+
+def test_live_still_surface_rejects_stale_generation(qapp) -> None:
+    coordinator = DetailRenderCoordinator()
+    coordinator.begin(_transaction(1, media_kind="live_motion"))
+    coordinator.mark_surface_presented(1, "live_motion_frame")
+    coordinator.begin(_transaction(2, media_kind="live_motion"))
+
+    assert not coordinator.mark_surface_presented(1, "live_still")
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.transaction.generation == 2
+
+
 def test_still_request_is_derived_from_transaction(tmp_path: Path) -> None:
     from iPhoto.gui.detail_pipeline import DetailGeometryState, DetailRenderRequest
 
@@ -73,4 +111,3 @@ def test_still_request_is_derived_from_transaction(tmp_path: Path) -> None:
     assert request.generation == transaction.generation
     assert request.asset_id == transaction.asset_id
     assert request.viewport_physical_size == transaction.viewport_physical_size
-

--- a/tests/ui/controllers/test_player_view_controller_adjustments.py
+++ b/tests/ui/controllers/test_player_view_controller_adjustments.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,7 +11,11 @@ pytest.importorskip("PySide6.QtGui", reason="QtGui is required for GUI tests", e
 
 from PySide6.QtGui import QImage
 
-from iPhoto.gui.ui.controllers.player_view_controller import _AdjustedImageWorker
+from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailRenderTransaction
+from iPhoto.gui.ui.controllers.player_view_controller import (
+    PlayerViewController,
+    _AdjustedImageWorker,
+)
 
 
 def test_adjusted_image_worker_skips_color_stats_without_sidecar() -> None:
@@ -57,3 +62,39 @@ def test_adjusted_image_worker_resolves_adjustments_when_sidecar_exists() -> Non
     compute_stats.assert_called_once_with(image)
     edit_service.describe_adjustments.assert_called_once_with(source, color_stats="stats")
     signals.completed.emit.assert_called_once_with(source, image, {"Exposure": 0.5})
+
+
+def test_deferred_still_keeps_original_live_transaction_until_applied() -> None:
+    source = Path("/tmp/live.heic")
+    transaction = DetailRenderTransaction(
+        generation=9,
+        asset_id="live-asset",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(source, source_mtime_ns=1),
+    )
+    video_surface = object()
+    controller = SimpleNamespace(
+        _loading_source=source,
+        _loading_started_at=None,
+        _loading_transaction=transaction,
+        _defer_still_updates=True,
+        _player_stack=Mock(currentWidget=Mock(return_value=video_surface)),
+        _video_area=video_surface,
+        _pending_still=None,
+        _apply_still_frame=Mock(),
+        _image_viewer=Mock(),
+        imageLoadingFailed=Mock(),
+    )
+    image = QImage(8, 8, QImage.Format.Format_RGBA8888)
+
+    PlayerViewController._on_adjusted_image_ready(controller, source, image, {})
+    assert controller._pending_still is not None
+    assert controller._pending_still[3] is transaction
+
+    assert PlayerViewController.apply_pending_still(controller)
+    controller._apply_still_frame.assert_called_once_with(
+        source,
+        image,
+        {},
+        transaction=transaction,
+    )

--- a/tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
+++ b/tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip("PySide6", reason="PySide6 is required for GL image viewer tests")
 
 import os
+from pathlib import Path
 
 from PySide6.QtCore import QPointF
 from PySide6.QtGui import QImage
@@ -69,3 +70,15 @@ def test_gl_image_viewer_maps_image_geometry_before_texture_upload(qapp) -> None
     )
     assert image_point.x() == pytest.approx(210.0)
     assert image_point.y() == pytest.approx(160.0)
+
+
+def test_gl_image_viewer_reports_each_presented_still_source(qapp) -> None:
+    viewer = GLImageViewer()
+    image = QImage(16, 16, QImage.Format.Format_RGBA8888)
+    viewer.set_image(image, {}, image_source=Path("/tmp/live.heic"))
+    presented = []
+    viewer.stillFramePresented.connect(presented.append)
+
+    viewer._emit_still_frame_presented()
+
+    assert presented == [Path("/tmp/live.heic")]

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -67,6 +67,27 @@ def _set_rotation_180(fmt: QVideoFrameFormat) -> None:
     raise RuntimeError("Could not resolve a Qt-compatible 180° rotation enum")
 
 
+def test_video_area_reports_first_presented_frame_for_each_load(qapp) -> None:
+    area = VideoArea()
+    source = Path("/tmp/live.mov")
+    area._current_source = source
+    area._surface_first_frame_pending = True
+    area._profile_load_started_at = None
+    area._adjusted_preview_enabled = False
+    area._renderer.update_frame = Mock()
+    presented = []
+    area.framePresented.connect(presented.append)
+    frame = QVideoFrame(QImage(4, 4, QImage.Format.Format_RGBA8888))
+
+    area._present_video_frame(frame)
+    area._present_video_frame(frame)
+    assert presented == []
+    area._renderer.framePresented.emit()
+    area._renderer.framePresented.emit()
+
+    assert presented == [source]
+
+
 @pytest.fixture
 def qapp():
     """Create QApplication instance for Qt tests."""


### PR DESCRIPTION
## Summary

Fourth replacement PR for #890. This isolates and fixes review finding 2 without bringing in Edit, Recognition, Pets, or broad merge commits.

- separate the transaction's first visible surface from later legal surface presentations
- keep Live Photo motion and restored still on the same transaction and generation
- preserve that transaction through both pending-still and re-decode restoration paths
- trigger overlay refresh and neighbor prefetch only after the still surface is actually rendered
- report real still texture and video GPU presentation events
- add Linux/macOS/Windows Live Photo lifecycle contracts

## Contracts

- motion first frame may complete the transaction once
- a later `live_still` surface remains valid for that completed Live Photo transaction
- terminal presentation emits once; surface presentation records motion then still
- stale generations cannot refresh overlays or prefetch neighbors
- replay/restoration does not fork the generation

## Validation

- `185 passed` in the focused lifecycle/UI suite
- `2313 passed, 13 skipped` in the non-UI regression suite
- architecture checks, compile checks, workflow YAML, and `git diff --check` passed

Supersedes the Live Photo lifecycle portion of #890.