### PR TITLE
Harden Detail Edit and Library session lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,3 +176,50 @@ jobs:
           tests/ui/controllers/test_player_view_init_cover.py
           tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
           tests/ui/widgets/test_video_area.py
+
+  detail-edit-library-contracts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libegl1 libgl1 libxkbcommon0 libpulse0
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run Detail/Edit/Library lifecycle contracts
+        env:
+          QT_QPA_PLATFORM: offscreen
+          NUMBA_DISABLE_JIT: "1"
+        run: >-
+          python -m pytest -q
+          tests/gui/test_detail_render_session.py
+          tests/gui/test_detail_pipeline.py
+          tests/application/test_dialog_controller_runtime_binding.py
+          tests/application/test_appctx_runtime_context.py
+          tests/application/test_runtime_context.py
+          tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
+          tests/gui/coordinators/test_main_coordinator_pending_moves.py
+          tests/gui/coordinators/test_edit_coordinator.py
+          tests/gui/coordinators/test_playback_coordinator.py
+          tests/ui/controllers/test_player_view_controller_adjustments.py
+          tests/ui/controllers/test_player_view_init_cover.py
+          tests/ui/test_window_manager_geometry.py

--- a/src/iPhoto/application/contracts/runtime_entry_contract.py
+++ b/src/iPhoto/application/contracts/runtime_entry_contract.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from ...library.runtime_controller import LibraryRuntimeController
     from ...settings.manager import SettingsManager
     from ...bootstrap.library_session import LibrarySession
+    from ...bootstrap.runtime_context import LibraryBindingToken
 
 
 @runtime_checkable
@@ -30,6 +31,7 @@ class RuntimeEntryContract(Protocol):
     container: "DependencyContainer"
     asset_runtime: "LibraryAssetRuntime"
     library_session: "LibrarySession | None"
+    library_binding_token: "LibraryBindingToken"
     recent_albums: list[Path]
     defer_startup_tasks: bool
 

--- a/src/iPhoto/bootstrap/runtime_context.py
+++ b/src/iPhoto/bootstrap/runtime_context.py
@@ -335,6 +335,9 @@ class RuntimeContext:
                 asset_runtime=self.asset_runtime,
                 bind_asset_runtime=False,
             )
+        # Advance before publishing the new session: synchronous treeUpdated
+        # consumers must observe the new epoch, never the previous binding.
+        self._library_epoch += 1
         bind_library_session = getattr(self.library, "bind_library_session", None)
         used_session_binding = callable(bind_library_session)
         if used_session_binding:
@@ -419,12 +422,16 @@ class RuntimeContext:
             )
             if callable(bind_map_interaction_service):
                 bind_map_interaction_service(self.library_session.map_interactions)
-        self._library_epoch += 1
         return self.library_session
 
     def close_library(self) -> None:
         """Close the active library-scoped session if one exists."""
 
+        session = getattr(self, "library_session", None)
+        if session is not None:
+            # Publish the closed binding before synchronous unbind callbacks.
+            self.library_session = None
+            self._library_epoch += 1
         bind_library_session = getattr(self.library, "bind_library_session", None)
         if callable(bind_library_session):
             bind_library_session(None)
@@ -500,12 +507,9 @@ class RuntimeContext:
             if callable(bind_scan_service):
                 bind_scan_service(None)
 
-        session = getattr(self, "library_session", None)
         if session is None:
             return
         session.shutdown()
-        self.library_session = None
-        self._library_epoch += 1
 
     def remember_album(self, root: Path) -> None:
         """Track *root* in the recent albums list, keeping the most recent first."""

--- a/src/iPhoto/gui/coordinators/edit_coordinator.py
+++ b/src/iPhoto/gui/coordinators/edit_coordinator.py
@@ -81,6 +81,7 @@ class EditCoordinator(QObject):
         media_session: "MediaSelectionSession | None" = None,
         adjustment_committer: "MediaAdjustmentCommitter | None" = None,
         edit_service_getter: Callable[[], EditServicePort | None] | None = None,
+        render_session_controller: object | None = None,
     ):
         super().__init__()
         # We need access to specific UI elements within edit_page (which is likely MainWindow.ui)
@@ -93,6 +94,8 @@ class EditCoordinator(QObject):
         self._media_session = media_session
         self._adjustment_committer = adjustment_committer
         self._edit_service_getter = edit_service_getter
+        self._render_session_controller = render_session_controller
+        self._render_session_handle = None
 
         self._transition_manager = EditViewTransitionManager(
             self._ui,
@@ -299,6 +302,28 @@ class EditCoordinator(QObject):
 
         return self._session is not None
 
+    def preflight_library_rebind(self) -> bool:
+        """Refuse a user-initiated library switch while edits are unresolved."""
+
+        return self._session is None
+
+    def invalidate_library_binding(self) -> None:
+        """Safely abandon an edit after an unexpected external session switch."""
+
+        handle = getattr(self, "_render_session_handle", None)
+        if handle is not None:
+            invalidate = getattr(handle, "invalidate", None)
+            if callable(invalidate):
+                invalidate()
+        if self._session is not None:
+            self.leave_edit_mode(restore_reason="library_invalidated", restore_detail=False)
+
+    def cancel_edit_mode(self) -> None:
+        """Discard the active in-memory session without writing its adjustments."""
+
+        if self._session is not None:
+            self.leave_edit_mode(restore_reason="edit_cancel")
+
     # ------------------------------------------------------------------
     # Public transport API (used by AppShortcutManager)
     # ------------------------------------------------------------------
@@ -359,17 +384,34 @@ class EditCoordinator(QObject):
             is_video=asset_path.suffix.lower() in VIDEO_EXTENSIONS,
         )
 
-        # Load Adjustments
-        edit_service = self._edit_service()
-        adjustments = (
-            edit_service.read_adjustments(asset_path)
-            if edit_service is not None
-            else {}
-        )
+        render_handle = None
+        if asset_path.suffix.lower() not in VIDEO_EXTENSIONS:
+            acquire = getattr(
+                getattr(self, "_render_session_controller", None),
+                "acquire_render_session",
+                None,
+            )
+            if callable(acquire):
+                render_handle = acquire(asset_path)
+        self._render_session_handle = render_handle
+
+        # Prefer the exact state already displayed by Detail.  Falling back to
+        # the library edit service keeps direct Edit entry compatible.
+        if render_handle is not None:
+            adjustments = dict(render_handle.edit_state.raw_adjustments)
+        else:
+            edit_service = self._edit_service()
+            adjustments = (
+                edit_service.read_adjustments(asset_path)
+                if edit_service is not None
+                else {}
+            )
 
         # Setup Session
         session = EditSession(self)
         session.set_values(adjustments, emit_individual=False)
+        if render_handle is not None:
+            session.set_color_stats(render_handle.edit_state.color_stats)
         session.valuesChanged.connect(self._handle_session_changed)
         self._session = session
         self._history_manager.set_session(session)
@@ -419,7 +461,22 @@ class EditCoordinator(QObject):
 
         # Start Loading High-Res Image / Video
         if not self._is_video_source():
-            self._start_async_edit_load(asset_path)
+            sidebar_input = getattr(
+                getattr(self, "_render_session_controller", None),
+                "render_session_sidebar_input",
+                None,
+            )
+            shared = (
+                sidebar_input(render_handle)
+                if render_handle is not None and callable(sidebar_input)
+                else None
+            )
+            if shared is None:
+                self._start_async_edit_load(asset_path)
+            else:
+                image, color_stats = shared
+                session.set_color_stats(color_stats)
+                self._install_edit_image(asset_path, image)
 
     def _start_async_edit_load(self, source: Path):
         if self._session is None: return
@@ -475,6 +532,14 @@ class EditCoordinator(QObject):
     def _on_edit_image_loaded(self, path: Path, image: QImage):
         if self._session is None or self._current_source != path: return
 
+        self._install_edit_image(path, image)
+
+    def _install_edit_image(self, path: Path, image: QImage) -> None:
+        """Install either a shared Detail surface or a fallback Edit decode."""
+
+        if self._session is None or self._current_source != path:
+            return
+
         try:
             self._preview_manager.start_session(image, self._session.values())
         except Exception:
@@ -509,7 +574,12 @@ class EditCoordinator(QObject):
             self._ui.edit_sidebar.set_light_preview_image(result.image, color_stats=result.stats)
             self._ui.edit_sidebar.refresh()
 
-    def leave_edit_mode(self, *, restore_reason: str = "edit_exit"):
+    def leave_edit_mode(
+        self,
+        *,
+        restore_reason: str = "edit_exit",
+        restore_detail: bool = True,
+    ):
         """Returns to detail view."""
         source = self._current_source
         is_video_source = (
@@ -517,7 +587,8 @@ class EditCoordinator(QObject):
             and source.suffix.lower() in VIDEO_EXTENSIONS
         )
         should_restore_detail = (
-            source is not None
+            restore_detail
+            and source is not None
             and self._media_session is not None
         )
         _LOGGER.debug(
@@ -540,6 +611,18 @@ class EditCoordinator(QObject):
         self._active_edit_viewport().set_eyedropper_mode(False)
         self._current_source = None
         self._session = None
+        render_handle = getattr(self, "_render_session_handle", None)
+        self._render_session_handle = None
+        finish_render_session = getattr(
+            getattr(self, "_render_session_controller", None),
+            "finish_render_session",
+            None,
+        )
+        if render_handle is not None and callable(finish_render_session):
+            finish_render_session(
+                render_handle,
+                committed=restore_reason == "edit_done",
+            )
         self._preview_manager.stop_session()
         self._zoom_handler.disconnect_controls()
         self._header_controller.restore_detail_mode()
@@ -605,6 +688,7 @@ class EditCoordinator(QObject):
             self._active_edit_viewport().crop_values(),
             emit_individual=False,
         )
+        self._flush_render_session_state()
         if self._adjustment_committer is None:
             navigation = self._navigation
             if navigation:
@@ -627,6 +711,18 @@ class EditCoordinator(QObject):
         if self._session:
             self.push_undo_state()
             self._session.reset()
+
+    def _flush_render_session_state(self) -> None:
+        session = self._session
+        handle = getattr(self, "_render_session_handle", None)
+        update = getattr(
+            getattr(self, "_render_session_controller", None),
+            "update_render_session",
+            None,
+        )
+        if session is not None and handle is not None and callable(update):
+            update(handle, session.values())
+        self._pending_session_values = None
 
     def _handle_rotate_left_clicked(self):
         if self._session:
@@ -683,7 +779,23 @@ class EditCoordinator(QObject):
 
     def _apply_session_adjustments_to_viewer(self):
         if self._session and not self._compare_active:
-            adj = self._resolve_session_adjustments()
+            state = None
+            update_render_session = getattr(
+                getattr(self, "_render_session_controller", None),
+                "update_render_session",
+                None,
+            )
+            render_handle = getattr(self, "_render_session_handle", None)
+            if render_handle is not None and callable(update_render_session):
+                state = update_render_session(
+                    render_handle,
+                    self._session.values(),
+                )
+            adj = (
+                dict(state.shader_adjustments)
+                if state is not None
+                else self._resolve_session_adjustments()
+            )
             self._active_adjustments = adj
             self._active_edit_viewport().set_adjustments(adj)
             if self._is_video_source():

--- a/src/iPhoto/gui/coordinators/main_coordinator.py
+++ b/src/iPhoto/gui/coordinators/main_coordinator.py
@@ -74,6 +74,7 @@ class MainCoordinator(QObject):
         super().__init__(window)
         self._window = window
         self._context = context
+        self._library_binding_token = getattr(context, "library_binding_token", None)
         self._is_shutting_down = False
         self._shutdown_complete = False
         # facade reference kept for signal wiring as some systems still emit through it
@@ -237,6 +238,11 @@ class MainCoordinator(QObject):
             map_runtime=self._map_runtime(),
             event_bus=self._event_bus,
             location_write_queue=self._location_write_queue,
+            library_binding_token_getter=lambda: getattr(
+                self._context,
+                "library_binding_token",
+                None,
+            ),
         )
 
         # Inject optional dependencies into Playback
@@ -268,7 +274,12 @@ class MainCoordinator(QObject):
         self._edit: "EditCoordinator | None" = None
 
         # --- Legacy Controllers ---
-        self._dialog = DialogController(window, context, window.ui.status_bar)
+        self._dialog = DialogController(
+            window,
+            context,
+            window.ui.status_bar,
+            library_rebind_preflight=self._library_rebind_preflight,
+        )
         self._facade.register_restore_prompt(self._dialog.prompt_restore_to_root)
         self._status_bar = StatusBarController(
             window.ui.status_bar,
@@ -410,6 +421,7 @@ class MainCoordinator(QObject):
             self._media_session,
             self._adjustment_committer,
             self._edit_service_getter,
+            self._player_view_controller,
         )
         self._shortcut_manager.set_edit_coordinator(self._edit)
         return self._edit
@@ -770,6 +782,7 @@ class MainCoordinator(QObject):
     def _on_library_tree_updated(self) -> None:
         root = self._library_root()
         self._logger.debug("_on_library_tree_updated: root=%s", root)
+        MainCoordinator._synchronize_library_binding(self)
         self._context.asset_runtime.bind_library_root(root)
         location_queue = getattr(self, "_location_write_queue", None)
         if location_queue is not None:
@@ -820,6 +833,28 @@ class MainCoordinator(QObject):
                 playback.set_people_library_root(root)
             if bound_pet_service is not None and hasattr(playback, "set_pet_service"):
                 playback.set_pet_service(bound_pet_service)
+
+    def _synchronize_library_binding(self) -> bool:
+        """Differentiate a same-session tree refresh from an actual rebind."""
+
+        binding_token = getattr(self._context, "library_binding_token", None)
+        previous_token = getattr(self, "_library_binding_token", None)
+        session_changed = (
+            previous_token is not None
+            and binding_token is not None
+            and binding_token != previous_token
+        )
+        if session_changed:
+            edit = getattr(self, "_edit", None)
+            if edit is not None and edit.is_editing():
+                edit.invalidate_library_binding()
+        if binding_token is not None:
+            self._library_binding_token = binding_token
+        playback = getattr(self, "_playback", None)
+        rebind_playback = getattr(playback, "rebind_library", None)
+        if callable(rebind_playback):
+            rebind_playback(binding_token, session_change=session_changed)
+        return session_changed
 
     def _active_session(self):
         return getattr(self._context, "library_session", None)
@@ -1142,6 +1177,12 @@ class MainCoordinator(QObject):
         open_library = getattr(self._context, "open_library", None)
         if not callable(open_library):
             return True
+        if not self._library_rebind_preflight():
+            self._facade.errorRaised.emit(
+                "Finish the current edit with Done, or press Escape to cancel it, "
+                "before switching libraries."
+            )
+            return False
 
         try:
             open_library(path)
@@ -1151,6 +1192,13 @@ class MainCoordinator(QObject):
 
         self._on_library_tree_updated()
         return True
+
+    def _library_rebind_preflight(self) -> bool:
+        edit = getattr(self, "_edit", None)
+        if edit is None:
+            return True
+        preflight = getattr(edit, "preflight_library_rebind", None)
+        return bool(preflight()) if callable(preflight) else not edit.is_editing()
 
     @staticmethod
     def _path_is_descendant(path: Path, root: Path) -> bool:

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -23,7 +23,11 @@ from iPhoto.infrastructure.repositories.location_assignment_repository import (
     IndexStoreLocationAssignmentRepository,
 )
 from iPhoto.gui.detail_profile import log_detail_profile
-from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailRenderTransaction
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailRenderTransaction,
+    PlaybackAsyncToken,
+)
 from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator
 from iPhoto.gui.coordinators.view_router import ViewRouter
 from iPhoto.gui.i18n import tr
@@ -131,6 +135,7 @@ class PlaybackCoordinator(QObject):
         map_runtime: MapRuntimePort | None = None,
         event_bus: EventBus | None = None,
         location_write_queue: LocationFileWriteQueue | None = None,
+        library_binding_token_getter: Callable[[], object | None] | None = None,
     ) -> None:
         super().__init__()
         self._player_bar = player_bar
@@ -164,6 +169,16 @@ class PlaybackCoordinator(QObject):
         self._map_runtime = map_runtime or getattr(library_manager, "map_runtime", None)
         self._event_bus = event_bus
         self._location_write_queue = location_write_queue
+        self._library_binding_token_getter = library_binding_token_getter
+        self._library_binding_token = (
+            library_binding_token_getter()
+            if library_binding_token_getter is not None
+            else None
+        )
+        self._asset_generation = 0
+        self._active_async_token: PlaybackAsyncToken | None = None
+        self._location_search_async_tokens: dict[int, PlaybackAsyncToken] = {}
+        self._location_search_dispatch_token: PlaybackAsyncToken | None = None
 
         self._is_playing = False
         self._navigation: NavigationCoordinator | None = None
@@ -202,6 +217,7 @@ class PlaybackCoordinator(QObject):
         self._location_released_video_position_ms: int | None = None
         self._location_video_write_inflight_paths: set[Path] = set()
         self._location_write_jobs_by_path: dict[Path, str] = {}
+        self._location_write_tokens_by_job: dict[str, PlaybackAsyncToken] = {}
         if self._location_write_queue is not None:
             self._location_write_queue.writeStarted.connect(
                 self._handle_location_file_write_started
@@ -221,6 +237,54 @@ class PlaybackCoordinator(QObject):
         self._play_debounce.timeout.connect(self._execute_pending_play)
 
         self._connect_signals()
+
+    def rebind_library(
+        self,
+        binding_token: object | None,
+        *,
+        session_change: bool,
+    ) -> None:
+        """Invalidate library-scoped playback only for a real session change."""
+
+        if not session_change:
+            return
+        self._library_binding_token = binding_token
+        self._asset_generation += 1
+        self._active_async_token = None
+        self._location_search_async_tokens.clear()
+        self._location_search_dispatch_token = None
+        getattr(self, "_location_write_tokens_by_job", {}).clear()
+        getattr(self, "_location_write_jobs_by_path", {}).clear()
+        getattr(self, "_location_video_write_inflight_paths", set()).clear()
+        self._location_assign_inflight = False
+        self._location_assign_path = None
+        self._manual_face_add_inflight = False
+        self._manual_face_inflight_asset_id = None
+        self._manual_face_pending_merge_target = None
+        getattr(self, "_pending_manual_face_annotations", {}).clear()
+        self._retire_live_transaction()
+        self._reset_location_search_service(clear_cache=True)
+        self._player_view.invalidate_async_work()
+        self._player_view.video_area.stop()
+        self._player_view.show_placeholder()
+        self._hide_face_name_overlay(clear_annotations=True)
+        self._is_playing = False
+        self._current_presentation = None
+        self._clear_info_panel_metadata_state()
+        self._clear_confirmed_location_metadata()
+
+    def _current_library_epoch(self) -> int:
+        getter = getattr(self, "_library_binding_token_getter", None)
+        binding = getter() if callable(getter) else getattr(self, "_library_binding_token", None)
+        return max(0, int(getattr(binding, "epoch", 0) or 0))
+
+    def _is_async_token_current(self, token: PlaybackAsyncToken | None) -> bool:
+        if token is None:
+            return True
+        return (
+            token == getattr(self, "_active_async_token", None)
+            and token.library_epoch == self._current_library_epoch()
+        )
         self._setup_zoom_handler()
         self._restore_filmstrip_preference()
 
@@ -467,6 +531,15 @@ class PlaybackCoordinator(QObject):
     def _clear_play_request_state(self) -> None:
         self._pending_play_row = None
         self._clear_play_profile()
+        self._asset_generation = max(0, int(getattr(self, "_asset_generation", 0))) + 1
+        self._active_async_token = None
+        tokens = getattr(self, "_location_search_async_tokens", None)
+        if isinstance(tokens, dict):
+            tokens.clear()
+        player_view = getattr(self, "_player_view", None)
+        invalidate_async_work = getattr(player_view, "invalidate_async_work", None)
+        if callable(invalidate_async_work):
+            invalidate_async_work()
         play_debounce = getattr(self, "_play_debounce", None)
         if play_debounce is not None:
             play_debounce.stop()
@@ -545,6 +618,16 @@ class PlaybackCoordinator(QObject):
                 self._info_panel.close()
             self._clear_play_profile(presentation.row)
             return
+        self._asset_generation = max(0, int(getattr(self, "_asset_generation", 0))) + 1
+        self._active_async_token = PlaybackAsyncToken.create(
+            library_epoch=self._current_library_epoch(),
+            asset_generation=self._asset_generation,
+            asset_id=presentation.asset_id or presentation.path.name,
+            source_identity=AssetSourceIdentity.from_info(
+                presentation.path,
+                presentation.info,
+            ),
+        )
         self._render_presentation(presentation)
 
     def _preserve_live_presentation(
@@ -651,13 +734,17 @@ class PlaybackCoordinator(QObject):
                 self._player_view.video_area.stop()
             self._player_view.show_image_surface()
             display_started = time.perf_counter()
+            async_token = getattr(self, "_active_async_token", None)
             if live_transaction is None:
-                self._player_view.display_image(source)
+                if async_token is None:
+                    self._player_view.display_image(source)
+                else:
+                    self._player_view.display_image(source, async_token=async_token)
             else:
-                self._player_view.display_image(
-                    source,
-                    transaction=live_transaction,
-                )
+                kwargs = {"transaction": live_transaction}
+                if async_token is not None:
+                    kwargs["async_token"] = async_token
+                self._player_view.display_image(source, **kwargs)
             log_detail_profile(
                 "playback",
                 "image.display_image",
@@ -763,10 +850,17 @@ class PlaybackCoordinator(QObject):
         applied_pending = self._player_view.apply_pending_still()
         self._player_view.defer_still_updates(False)
         if not applied_pending:
+            async_token = getattr(self, "_active_async_token", None)
             if transaction is None:
-                self._player_view.display_image(still)
+                if async_token is None:
+                    self._player_view.display_image(still)
+                else:
+                    self._player_view.display_image(still, async_token=async_token)
             else:
-                self._player_view.display_image(still, transaction=transaction)
+                kwargs = {"transaction": transaction}
+                if async_token is not None:
+                    kwargs["async_token"] = async_token
+                self._player_view.display_image(still, **kwargs)
         self._player_bar.setEnabled(False)
         self._player_view.show_live_badge()
         self._player_view.set_live_replay_enabled(True)
@@ -1444,6 +1538,10 @@ class PlaybackCoordinator(QObject):
         return fallback_runtime
 
     def _reset_location_search_service(self, *, clear_cache: bool = False) -> None:
+        tokens = getattr(self, "_location_search_async_tokens", None)
+        if isinstance(tokens, dict):
+            tokens.clear()
+        self._location_search_dispatch_token = None
         controller = getattr(self, "_location_search_controller", None)
         if controller is not None:
             controller.reset()
@@ -1483,12 +1581,20 @@ class PlaybackCoordinator(QObject):
             return
 
         locale = QLocale.system().bcp47Name()
-        self._location_search_controller.search(
+        async_token = getattr(self, "_active_async_token", None)
+        self._location_search_dispatch_token = async_token
+        search_token = self._location_search_controller.search(
             query,
             target_path=presentation.path,
             package_root=self._map_runtime_package_root(),
             locale=locale,
         )
+        if async_token is not None:
+            self._location_search_async_tokens[int(search_token)] = async_token
+            while len(self._location_search_async_tokens) > 128:
+                oldest = next(iter(self._location_search_async_tokens))
+                self._location_search_async_tokens.pop(oldest, None)
+        self._location_search_dispatch_token = None
 
     @Slot(int, object, str, object)
     def _handle_location_suggestions_ready(
@@ -1500,9 +1606,16 @@ class PlaybackCoordinator(QObject):
     ) -> None:
         info_panel = getattr(self, "_info_panel", None)
         current_presentation = getattr(self, "_current_presentation", None)
+        async_token = self._location_search_async_tokens.get(
+            int(_token),
+            getattr(self, "_location_search_dispatch_token", None),
+        )
+        if async_token is None and getattr(self, "_active_async_token", None) is not None:
+            return
         if (
             info_panel is None
             or current_presentation is None
+            or not self._is_async_token_current(async_token)
             or current_presentation.path != Path(target_path)
             or self._location_assign_inflight
         ):
@@ -1520,9 +1633,16 @@ class PlaybackCoordinator(QObject):
     ) -> None:
         info_panel = getattr(self, "_info_panel", None)
         current_presentation = getattr(self, "_current_presentation", None)
+        async_token = self._location_search_async_tokens.get(
+            int(_token),
+            getattr(self, "_location_search_dispatch_token", None),
+        )
+        if async_token is None and getattr(self, "_active_async_token", None) is not None:
+            return
         if (
             info_panel is None
             or current_presentation is None
+            or not self._is_async_token_current(async_token)
             or current_presentation.path != Path(target_path)
         ):
             return
@@ -1605,6 +1725,13 @@ class PlaybackCoordinator(QObject):
             if queue is None:
                 raise RuntimeError("write-back queue unavailable")
             self._location_write_jobs_by_path[presentation.path] = assignment.write_job.job_id
+            async_token = getattr(self, "_active_async_token", None)
+            if async_token is not None:
+                token_map = getattr(self, "_location_write_tokens_by_job", None)
+                if not isinstance(token_map, dict):
+                    token_map = {}
+                    self._location_write_tokens_by_job = token_map
+                token_map[assignment.write_job.job_id] = async_token
             queue.enqueue(assignment.write_job)
         except Exception as exc:  # noqa: BLE001
             message = str(exc)
@@ -1617,6 +1744,10 @@ class PlaybackCoordinator(QObject):
             if presentation.is_video:
                 self._allow_location_video_loading(presentation.path)
                 self._restore_video_released_for_location_write()
+            getattr(self, "_location_write_tokens_by_job", {}).pop(
+                assignment.write_job.job_id,
+                None,
+            )
         finally:
             self._location_assign_inflight = False
             self._location_assign_path = None
@@ -1863,6 +1994,8 @@ class PlaybackCoordinator(QObject):
     def _handle_location_file_write_started(self, job: object) -> None:
         if not isinstance(job, LocationWriteJobRecord) or not job.is_video:
             return
+        if not self._location_write_result_is_current(job.job_id):
+            return
         path = Path(job.asset_path)
         self._location_write_jobs_by_path[path] = job.job_id
         already_inflight = self._is_location_video_write_inflight(path)
@@ -1881,6 +2014,10 @@ class PlaybackCoordinator(QObject):
     def _handle_location_file_write_verified(self, result: object) -> None:
         if not isinstance(result, LocationFileWriteResult):
             return
+        if not self._location_write_result_is_current(result.job_id):
+            getattr(self, "_location_write_tokens_by_job", {}).pop(result.job_id, None)
+            return
+        getattr(self, "_location_write_tokens_by_job", {}).pop(result.job_id, None)
         self._location_write_jobs_by_path.pop(result.asset_path, None)
         self._complete_location_video_file_write(result.asset_path)
 
@@ -1888,6 +2025,10 @@ class PlaybackCoordinator(QObject):
     def _handle_location_file_write_failed(self, result: object) -> None:
         if not isinstance(result, LocationFileWriteResult):
             return
+        if not self._location_write_result_is_current(result.job_id):
+            getattr(self, "_location_write_tokens_by_job", {}).pop(result.job_id, None)
+            return
+        getattr(self, "_location_write_tokens_by_job", {}).pop(result.job_id, None)
         message = result.error or "unknown error"
         LOGGER.warning(
             "Location saved in the library, but GPS metadata was not written to %s: %s",
@@ -1900,6 +2041,13 @@ class PlaybackCoordinator(QObject):
         else:
             self._queue_location_file_write_warning(message)
         self._complete_location_video_file_write(result.asset_path)
+
+    def _location_write_result_is_current(self, job_id: str) -> bool:
+        active = getattr(self, "_active_async_token", None)
+        if active is None:
+            return True
+        token = getattr(self, "_location_write_tokens_by_job", {}).get(str(job_id))
+        return token is not None and self._is_async_token_current(token)
 
     @Slot(str)
     def _handle_location_assignment_error(self, message: str) -> None:
@@ -2029,11 +2177,28 @@ class PlaybackCoordinator(QObject):
         if path_key in self._info_panel_metadata_inflight:
             return
         self._info_panel_metadata_inflight.add(path_key)
+        async_token = getattr(self, "_active_async_token", None)
 
         worker = InfoPanelMetadataWorker(path, is_video=is_video)
-        worker.signals.ready.connect(self._handle_info_panel_metadata_ready)
-        worker.signals.error.connect(self._handle_info_panel_metadata_error)
-        worker.signals.finished.connect(self._handle_info_panel_metadata_finished)
+        worker.signals.ready.connect(
+            lambda result, token=async_token: self._handle_info_panel_metadata_ready(
+                result,
+                async_token=token,
+            )
+        )
+        worker.signals.error.connect(
+            lambda key, message, token=async_token: self._handle_info_panel_metadata_error(
+                key,
+                message,
+                async_token=token,
+            )
+        )
+        worker.signals.finished.connect(
+            lambda key, token=async_token: self._handle_info_panel_metadata_finished(
+                key,
+                async_token=token,
+            )
+        )
         try:
             QThreadPool.globalInstance().start(worker, -1)
         except Exception:  # noqa: BLE001
@@ -2041,8 +2206,14 @@ class PlaybackCoordinator(QObject):
             self._info_panel_metadata_inflight.discard(path_key)
             self._info_panel_metadata_attempted.discard(path_key)
 
-    @Slot(object)
-    def _handle_info_panel_metadata_ready(self, result: InfoPanelMetadataResult) -> None:
+    def _handle_info_panel_metadata_ready(
+        self,
+        result: InfoPanelMetadataResult,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
+        if not self._is_async_token_current(async_token):
+            return
         self._ensure_info_panel_metadata_state()
         path_key = str(result.path)
         # Evict oldest entry (insertion-order FIFO, Python 3.7+) before inserting
@@ -2072,16 +2243,29 @@ class PlaybackCoordinator(QObject):
                 return context
         return nullcontext()
 
-    @Slot(str, str)
-    def _handle_info_panel_metadata_error(self, path_key: str, message: str) -> None:
+    def _handle_info_panel_metadata_error(
+        self,
+        path_key: str,
+        message: str,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
+        if not self._is_async_token_current(async_token):
+            return
         LOGGER.debug(
             "Failed to enrich info-panel metadata for %s: %s",
             path_key,
             message,
         )
 
-    @Slot(str)
-    def _handle_info_panel_metadata_finished(self, path_key: str) -> None:
+    def _handle_info_panel_metadata_finished(
+        self,
+        path_key: str,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
+        if not self._is_async_token_current(async_token):
+            return
         self._ensure_info_panel_metadata_state()
         self._info_panel_metadata_inflight.discard(path_key)
         self._info_panel_metadata_attempted.add(path_key)
@@ -2142,13 +2326,34 @@ class PlaybackCoordinator(QObject):
             person_id=worker_person_id,
             people_service=self._people_service,
         )
-        worker.signals.ready.connect(self._handle_manual_face_ready)
-        worker.signals.error.connect(self._handle_manual_face_error)
-        worker.signals.finished.connect(self._handle_manual_face_finished)
+        async_token = getattr(self, "_active_async_token", None)
+        worker.signals.ready.connect(
+            lambda result, token=async_token: self._handle_manual_face_ready(
+                result,
+                async_token=token,
+            )
+        )
+        worker.signals.error.connect(
+            lambda message, token=async_token: self._handle_manual_face_error(
+                message,
+                async_token=token,
+            )
+        )
+        worker.signals.finished.connect(
+            lambda token=async_token: self._handle_manual_face_finished(
+                async_token=token,
+            )
+        )
         QThreadPool.globalInstance().start(worker, -1)
 
-    @Slot(object)
-    def _handle_manual_face_ready(self, result: object) -> None:
+    def _handle_manual_face_ready(
+        self,
+        result: object,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
+        if not self._is_async_token_current(async_token):
+            return
         submitted_asset_id = self._manual_face_inflight_asset_id
         if submitted_asset_id:
             self._clear_pending_manual_faces(submitted_asset_id)
@@ -2186,8 +2391,14 @@ class PlaybackCoordinator(QObject):
         if callable(refresh_callback):
             refresh_callback()
 
-    @Slot(str)
-    def _handle_manual_face_error(self, message: str) -> None:
+    def _handle_manual_face_error(
+        self,
+        message: str,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
+        if not self._is_async_token_current(async_token):
+            return
         self._manual_face_pending_merge_target = None
         submitted_asset_id = getattr(self, "_manual_face_inflight_asset_id", None)
         if not submitted_asset_id:
@@ -2207,8 +2418,13 @@ class PlaybackCoordinator(QObject):
             overlay.set_manual_face_busy(False)
             overlay.show_manual_error(message)
 
-    @Slot()
-    def _handle_manual_face_finished(self) -> None:
+    def _handle_manual_face_finished(
+        self,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
+        if not self._is_async_token_current(async_token):
+            return
         self._manual_face_add_inflight = False
         self._manual_face_inflight_asset_id = None
         self._manual_face_pending_merge_target = None

--- a/src/iPhoto/gui/detail_pipeline.py
+++ b/src/iPhoto/gui/detail_pipeline.py
@@ -106,6 +106,49 @@ class AssetSourceIdentity:
 
 
 @dataclass(frozen=True, slots=True)
+class PlaybackAsyncToken:
+    """Complete delivery identity for library-scoped playback work."""
+
+    library_epoch: int
+    asset_generation: int
+    asset_id: str
+    source_path: Path
+    source_revision: tuple[str, int, int]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        library_epoch: int,
+        asset_generation: int,
+        asset_id: str,
+        source_identity: AssetSourceIdentity,
+    ) -> "PlaybackAsyncToken":
+        return cls(
+            library_epoch=max(0, int(library_epoch)),
+            asset_generation=max(0, int(asset_generation)),
+            asset_id=str(asset_id).strip() or source_identity.path.name,
+            source_path=source_identity.path,
+            source_revision=source_identity.revision,
+        )
+
+    def matches(
+        self,
+        *,
+        library_epoch: int,
+        asset_generation: int,
+        asset_id: str,
+        source_identity: AssetSourceIdentity,
+    ) -> bool:
+        return self == PlaybackAsyncToken.create(
+            library_epoch=library_epoch,
+            asset_generation=asset_generation,
+            asset_id=asset_id,
+            source_identity=source_identity,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class DetailRenderTransaction:
     """Immutable identity shared by still and video Detail render work."""
 
@@ -419,6 +462,7 @@ __all__ = [
     "DetailMediaPreparation",
     "DetailOpenTrace",
     "DetailPrefetchDescriptor",
+    "PlaybackAsyncToken",
     "DetailRenderTransaction",
     "DetailRenderRequest",
     "DetailResidencySlot",

--- a/src/iPhoto/gui/detail_render_session.py
+++ b/src/iPhoto/gui/detail_render_session.py
@@ -1,0 +1,195 @@
+"""Budgeted render-session state shared by Detail and Edit."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Literal
+
+from iPhoto.core.adjustment_mapping import resolve_adjustment_mapping
+from iPhoto.core.color_resolver import ColorStats
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailDecodeKey
+
+
+EditRevisionKind = Literal["index", "session", "commit"]
+
+
+@dataclass(frozen=True, slots=True)
+class EditRenderState:
+    """One immutable raw/resolved adjustment snapshot."""
+
+    revision: tuple[EditRevisionKind, int]
+    raw_adjustments: Mapping[str, Any]
+    shader_adjustments: Mapping[str, Any]
+    color_stats: ColorStats
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "raw_adjustments", MappingProxyType(dict(self.raw_adjustments)))
+        object.__setattr__(
+            self,
+            "shader_adjustments",
+            MappingProxyType(dict(self.shader_adjustments)),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        raw_adjustments: Mapping[str, Any] | None,
+        *,
+        color_stats: ColorStats,
+        revision: tuple[EditRevisionKind, int],
+    ) -> "EditRenderState":
+        raw = dict(raw_adjustments or {})
+        return cls(
+            revision=revision,
+            raw_adjustments=raw,
+            shader_adjustments=resolve_adjustment_mapping(
+                raw,
+                stats=color_stats,
+                bool_as_float=True,
+                normalize_bw_for_render=True,
+            ),
+            color_stats=color_stats,
+        )
+
+
+class SurfaceRetentionBudget:
+    """Account strong CPU-surface references owned by PlayerView sessions."""
+
+    def __init__(self, max_bytes: int) -> None:
+        self.max_bytes = max(0, int(max_bytes))
+        self._bytes_by_session: dict[int, int] = {}
+
+    @property
+    def retained_bytes(self) -> int:
+        return sum(self._bytes_by_session.values())
+
+    def can_replace(self, session_id: int, byte_count: int) -> bool:
+        previous = self._bytes_by_session.get(int(session_id), 0)
+        return self.retained_bytes - previous + max(0, int(byte_count)) <= self.max_bytes
+
+    def replace(self, session_id: int, byte_count: int) -> bool:
+        if not self.can_replace(session_id, byte_count):
+            return False
+        self._bytes_by_session[int(session_id)] = max(0, int(byte_count))
+        return True
+
+    def release(self, session_id: int) -> None:
+        self._bytes_by_session.pop(int(session_id), None)
+
+    def clear(self) -> None:
+        self._bytes_by_session.clear()
+
+    @staticmethod
+    def surface_bytes(surface: DecodedSurface | None) -> int:
+        if surface is None or surface.image.isNull():
+            return 0
+        return max(0, int(surface.image.sizeInBytes()))
+
+
+@dataclass(slots=True)
+class PhotoRenderSessionHandle:
+    """GUI-owned, safely invalidatable handle for one still asset.
+
+    A session deliberately retains only the current surface and, while an
+    upload is in flight, one fallback.  It never accumulates every visited LOD.
+    """
+
+    session_id: int
+    asset_id: str
+    source_identity: AssetSourceIdentity
+    current_surface: DecodedSurface | None
+    edit_state: EditRenderState
+    baseline_state: EditRenderState
+    upload_fallback: DecodedSurface | None = None
+    edit_references: int = 0
+    valid: bool = True
+    _revision_counter: int = 0
+
+    def __post_init__(self) -> None:
+        self._revision_counter = max(
+            int(self.source_identity.index_revision),
+            int(self.edit_state.revision[1]),
+        )
+
+    @property
+    def source(self) -> Path:
+        return self.source_identity.path
+
+    @property
+    def current_texture_key(self) -> DetailDecodeKey | None:
+        surface = self.current_surface
+        return surface.decode_key if surface is not None else None
+
+    @property
+    def retained_bytes(self) -> int:
+        current = SurfaceRetentionBudget.surface_bytes(self.current_surface)
+        fallback = self.upload_fallback
+        if fallback is self.current_surface:
+            return current
+        return current + SurfaceRetentionBudget.surface_bytes(fallback)
+
+    def replace_surface(
+        self,
+        surface: DecodedSurface,
+        *,
+        retain_upload_fallback: bool = False,
+    ) -> bool:
+        if not self.valid:
+            return False
+        previous = self.current_surface
+        self.current_surface = surface
+        self.upload_fallback = previous if retain_upload_fallback else None
+        return True
+
+    def finish_upload(self) -> None:
+        self.upload_fallback = None
+
+    def surface_for_key(self, key: DetailDecodeKey) -> DecodedSurface | None:
+        if not self.valid:
+            return None
+        for surface in (self.current_surface, self.upload_fallback):
+            if surface is not None and surface.decode_key == key:
+                return surface
+        return None
+
+    def next_state(
+        self,
+        raw_adjustments: Mapping[str, Any],
+        *,
+        kind: EditRevisionKind = "session",
+    ) -> EditRenderState | None:
+        if not self.valid:
+            return None
+        self._revision_counter += 1
+        state = EditRenderState.create(
+            raw_adjustments,
+            color_stats=self.edit_state.color_stats,
+            revision=(kind, self._revision_counter),
+        )
+        self.edit_state = state
+        return state
+
+    def restore_baseline(self) -> EditRenderState | None:
+        if not self.valid:
+            return None
+        self.edit_state = self.baseline_state
+        return self.edit_state
+
+    def invalidate(self) -> None:
+        """Make all late consumers harmless and release strong surfaces."""
+
+        self.valid = False
+        self.edit_references = 0
+        self.current_surface = None
+        self.upload_fallback = None
+
+
+__all__ = [
+    "EditRenderState",
+    "PhotoRenderSessionHandle",
+    "SurfaceRetentionBudget",
+]

--- a/src/iPhoto/gui/ui/controllers/dialog_controller.py
+++ b/src/iPhoto/gui/ui/controllers/dialog_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,10 +29,12 @@ class DialogController:
         parent: QWidget,
         context: RuntimeEntryContract,
         status_bar: ChromeStatusBar,
+        library_rebind_preflight: Callable[[], bool] | None = None,
     ) -> None:
         self._parent = parent
         self._context = context
         self._status = status_bar
+        self._library_rebind_preflight = library_rebind_preflight
 
     # ------------------------------------------------------------------
     # Public API
@@ -43,6 +46,19 @@ class DialogController:
         )
 
     def bind_library_dialog(self) -> Path | None:
+        if (
+            self._library_rebind_preflight is not None
+            and not self._library_rebind_preflight()
+        ):
+            dialogs.show_error(
+                self._parent,
+                QCoreApplication.translate(
+                    "DialogController",
+                    "Finish the current edit with Done, or press Escape to cancel it, before switching libraries.",
+                    None,
+                ),
+            )
+            return None
         root = dialogs.select_directory(
             self._parent,
             QCoreApplication.translate("DialogController", "Select Basic Library", None),

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections import OrderedDict
 from pathlib import Path
 from typing import Callable, Optional, Set
 
@@ -11,9 +12,20 @@ from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import QLabel, QStackedWidget, QWidget
 
 from ....application.ports import EditServicePort
-from ....core.color_resolver import compute_color_statistics
-from ....gui.detail_pipeline import DetailRenderTransaction
+from ....core.color_resolver import ColorStats, compute_color_statistics
+from ....gui.detail_decode_backend import DecodedSurface
+from ....gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailRenderTransaction,
+    PlaybackAsyncToken,
+)
 from ....gui.detail_profile import log_detail_profile
+from ....gui.detail_render_session import (
+    EditRenderState,
+    PhotoRenderSessionHandle,
+    SurfaceRetentionBudget,
+)
 from ....gui.i18n import tr
 from ....utils import image_loader
 from ..widgets.gl_image_viewer import GLImageViewer
@@ -45,6 +57,8 @@ class _AdjustedImageWorker(QRunnable):
         self._source = source
         self._signals = signals
         self._edit_service = edit_service
+        self.color_stats = ColorStats()
+        self.source_identity = AssetSourceIdentity.create(source)
         # The worker always decodes the original frame at full fidelity.  The
         # GUI thread performs any downscaling so zooming and full-screen views
         # can leverage every available pixel.
@@ -77,11 +91,12 @@ class _AdjustedImageWorker(QRunnable):
         try:
             adjustments_started = time.perf_counter()
             adjustments = {}
+            self.color_stats = compute_color_statistics(image)
+            self.source_identity = self.source_identity.repair_revision_from_stat()
             if self._edit_service is not None and self._edit_service.sidecar_exists(self._source):
-                stats = compute_color_statistics(image)
                 adjustments = self._edit_service.describe_adjustments(
                     self._source,
-                    color_stats=stats,
+                    color_stats=self.color_stats,
                 ).resolved_adjustments
             log_detail_profile(
                 "still_worker",
@@ -130,6 +145,7 @@ class PlayerViewController(QObject):
         placeholder: QWidget,
         live_badge: LiveBadge,
         edit_service_getter: Callable[[], EditServicePort | None] | None = None,
+        surface_budget_bytes: int = 192 * 1024 * 1024,
         parent: QObject | None = None,
     ) -> None:
         """Store references to the widgets composing the player area."""
@@ -154,12 +170,25 @@ class PlayerViewController(QObject):
         self._loading_started_at: float | None = None
         self._active_transaction: DetailRenderTransaction | None = None
         self._loading_transaction: DetailRenderTransaction | None = None
+        self._active_async_token: PlaybackAsyncToken | None = None
         self._current_still_source: Path | None = None
         self._current_still_generation = 0
         self._defer_still_updates = False
         self._pending_still: Optional[
-            tuple[Path, QImage, dict, DetailRenderTransaction | None]
+            tuple[
+                Path,
+                QImage,
+                dict,
+                DetailRenderTransaction | None,
+                PlaybackAsyncToken | None,
+                AssetSourceIdentity,
+                ColorStats,
+            ]
         ] = None
+        self._surface_budget = SurfaceRetentionBudget(surface_budget_bytes)
+        self._render_sessions: OrderedDict[tuple, PhotoRenderSessionHandle] = OrderedDict()
+        self._current_render_session: PhotoRenderSessionHandle | None = None
+        self._next_render_session_id = 1
 
         # Per-widget first-render tracking.  QRhiWidget backing textures are
         # uninitialised (transparent) until the first ``render()`` call fills
@@ -322,12 +351,14 @@ class PlayerViewController(QObject):
         *,
         placeholder: Optional[QPixmap] = None,
         transaction: DetailRenderTransaction | None = None,
+        async_token: PlaybackAsyncToken | None = None,
     ) -> bool:
         """Begin loading ``source`` asynchronously, returning scheduling success."""
         self._loading_source = source
         self._loading_started_at = time.perf_counter()
         self._active_transaction = transaction
         self._loading_transaction = transaction
+        self._active_async_token = async_token
 
         # 1) 先切到 GL 视图，保证有有效的 GL 上下文
         self.show_image_surface()
@@ -343,8 +374,25 @@ class PlayerViewController(QObject):
         worker = _AdjustedImageWorker(source, signals, edit_service=edit_service)
         self._active_workers.add(worker)
 
-        signals.completed.connect(self._on_adjusted_image_ready)
-        signals.failed.connect(self._on_adjusted_image_failed)
+        signals.completed.connect(
+            lambda source, image, adjustments, candidate=worker, token=async_token: (
+                self._on_adjusted_image_ready(
+                    source,
+                    image,
+                    adjustments,
+                    async_token=token,
+                    source_identity=candidate.source_identity,
+                    color_stats=candidate.color_stats,
+                )
+            )
+        )
+        signals.failed.connect(
+            lambda source, message, token=async_token: self._on_adjusted_image_failed(
+                source,
+                message,
+                async_token=token,
+            )
+        )
 
         def _finalize_on_completion(img_source: Path, img: QImage, adjustments: dict) -> None:
             self._release_worker(worker)
@@ -378,10 +426,46 @@ class PlayerViewController(QObject):
         """Apply any deferred still frame if available."""
         if self._pending_still is None:
             return False
-        source, image, adjustments, transaction = self._pending_still
+        (
+            source,
+            image,
+            adjustments,
+            transaction,
+            async_token,
+            source_identity,
+            color_stats,
+        ) = self._pending_still
         self._pending_still = None
-        self._apply_still_frame(source, image, adjustments, transaction=transaction)
+        surface_budget = getattr(self, "_surface_budget", None)
+        if surface_budget is not None:
+            surface_budget.release(0)
+        self._apply_still_frame(
+            source,
+            image,
+            adjustments,
+            transaction=transaction,
+            async_token=async_token,
+            source_identity=source_identity,
+            color_stats=color_stats,
+        )
         return True
+
+    def invalidate_async_work(self) -> None:
+        """Reject all late worker deliveries and release library-scoped surfaces."""
+
+        self._loading_source = None
+        self._loading_started_at = None
+        self._loading_transaction = None
+        self._active_transaction = None
+        self._active_async_token = None
+        self._pending_still = None
+        self._current_still_source = None
+        self._current_still_generation = 0
+        for session in self._render_sessions.values():
+            session.invalidate()
+        self._render_sessions.clear()
+        self._current_render_session = None
+        self._surface_budget.clear()
 
     def clear_image(self) -> None:
         """Remove any pixmap currently shown in the image viewer."""
@@ -445,10 +529,23 @@ class PlayerViewController(QObject):
     # ------------------------------------------------------------------
     # Worker callbacks
     # ------------------------------------------------------------------
-    def _on_adjusted_image_ready(self, source: Path, image: QImage, adjustments: dict) -> None:
+    def _on_adjusted_image_ready(
+        self,
+        source: Path,
+        image: QImage,
+        adjustments: dict,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+        source_identity: AssetSourceIdentity | None = None,
+        color_stats: ColorStats | None = None,
+    ) -> None:
         """Render *image* when the matching worker completes successfully."""
-        if self._loading_source != source:
+        if self._loading_source != source or (
+            async_token is not None and async_token != self._active_async_token
+        ):
             return
+        identity = source_identity or AssetSourceIdentity.create(source)
+        stats = color_stats or ColorStats()
 
         if self._loading_started_at is not None:
             log_detail_profile(
@@ -469,18 +566,28 @@ class PlayerViewController(QObject):
             return
 
         if self._defer_still_updates and self._player_stack.currentWidget() is self._video_area:
-            self._pending_still = (
-                source,
-                image,
-                adjustments,
-                self._loading_transaction,
-            )
+            reserve_pending = getattr(self, "_reserve_pending_surface", None)
+            if not callable(reserve_pending) or reserve_pending(image):
+                self._pending_still = (
+                    source,
+                    image,
+                    adjustments,
+                    self._loading_transaction,
+                    async_token,
+                    identity,
+                    stats,
+                )
+            else:
+                self._pending_still = None
         else:
             self._apply_still_frame(
                 source,
                 image,
                 adjustments,
                 transaction=self._loading_transaction,
+                async_token=async_token,
+                source_identity=identity,
+                color_stats=stats,
             )
 
         if self._loading_source == source:
@@ -488,10 +595,18 @@ class PlayerViewController(QObject):
             self._loading_started_at = None
             self._loading_transaction = None
 
-    def _on_adjusted_image_failed(self, source: Path, message: str) -> None:
+    def _on_adjusted_image_failed(
+        self,
+        source: Path,
+        message: str,
+        *,
+        async_token: PlaybackAsyncToken | None = None,
+    ) -> None:
         """Propagate worker failures while ensuring stale results are ignored."""
 
-        if self._loading_source != source:
+        if self._loading_source != source or (
+            async_token is not None and async_token != self._active_async_token
+        ):
             return
 
         if self._loading_source == source:
@@ -508,6 +623,9 @@ class PlayerViewController(QObject):
         adjustments: dict,
         *,
         transaction: DetailRenderTransaction | None = None,
+        async_token: PlaybackAsyncToken | None = None,
+        source_identity: AssetSourceIdentity | None = None,
+        color_stats: ColorStats | None = None,
     ) -> None:
         """Render the still image on the GL viewer."""
         apply_started = time.perf_counter()
@@ -515,6 +633,23 @@ class PlayerViewController(QObject):
         self._current_still_source = source
         self._current_still_generation = (
             transaction.generation if transaction is not None else 0
+        )
+        identity = (
+            transaction.source_identity
+            if transaction is not None
+            else source_identity or AssetSourceIdentity.create(source)
+        )
+        self._retain_render_session(
+            source=source,
+            image=image,
+            adjustments=adjustments,
+            identity=identity,
+            color_stats=color_stats or ColorStats(),
+            asset_id=(
+                transaction.asset_id
+                if transaction is not None
+                else async_token.asset_id if async_token is not None else source.name
+            ),
         )
         self.show_image_surface()
         self._image_viewer.set_image(
@@ -531,6 +666,199 @@ class PlayerViewController(QObject):
             path=source.name,
             has_adjustments=bool(adjustments),
         )
+
+    @property
+    def retained_surface_bytes(self) -> int:
+        return self._surface_budget.retained_bytes
+
+    @property
+    def surface_budget_bytes(self) -> int:
+        return self._surface_budget.max_bytes
+
+    def acquire_render_session(self, source: Path) -> PhotoRenderSessionHandle | None:
+        session = self._current_render_session
+        normalized = Path(source).expanduser().absolute()
+        if session is None or not session.valid or session.source != normalized:
+            return None
+        if session.current_surface is None:
+            return None
+        session.edit_references += 1
+        self._touch_render_session(session)
+        return session
+
+    def update_render_session(
+        self,
+        handle: PhotoRenderSessionHandle,
+        adjustments: dict,
+    ) -> EditRenderState | None:
+        if handle is not self._current_render_session or not handle.valid:
+            return None
+        state = handle.next_state(adjustments)
+        if state is not None:
+            self._image_viewer.set_adjustments(dict(state.shader_adjustments))
+        return state
+
+    def finish_render_session(
+        self,
+        handle: PhotoRenderSessionHandle,
+        *,
+        committed: bool,
+    ) -> bool:
+        if handle is not self._current_render_session or not handle.valid:
+            return False
+        handle.edit_references = max(0, handle.edit_references - 1)
+        if committed:
+            state = handle.next_state(handle.edit_state.raw_adjustments, kind="commit")
+            if state is not None:
+                handle.baseline_state = state
+        else:
+            handle.restore_baseline()
+        return True
+
+    def render_session_sidebar_input(
+        self,
+        handle: PhotoRenderSessionHandle,
+    ) -> tuple[QImage, ColorStats] | None:
+        if handle is not self._current_render_session or not handle.valid:
+            return None
+        surface = handle.current_surface
+        if surface is None:
+            return None
+        return QImage(surface.image), handle.edit_state.color_stats
+
+    def _retain_render_session(
+        self,
+        *,
+        source: Path,
+        image: QImage,
+        adjustments: dict,
+        identity: AssetSourceIdentity,
+        color_stats: ColorStats,
+        asset_id: str,
+    ) -> PhotoRenderSessionHandle | None:
+        if not identity.has_stable_revision:
+            return None
+        decode_key = DetailDecodeKey(
+            asset_id=str(asset_id).strip() or source.name,
+            source=identity.path,
+            source_revision=identity.revision,
+            orientation=identity.orientation,
+            decode_level="full",
+        )
+        surface = DecodedSurface(
+            image=QImage(image),
+            decode_key=decode_key,
+            source_size=(image.width(), image.height()),
+            decoded_size=(image.width(), image.height()),
+            decode_level="full",
+            backend="legacy-player-worker",
+            color_stats=color_stats,
+        )
+        session_key = (
+            decode_key.asset_id,
+            decode_key.source,
+            decode_key.source_revision,
+            decode_key.orientation,
+        )
+        session = self._render_sessions.get(session_key)
+        if session is None:
+            state = EditRenderState.create(
+                adjustments,
+                color_stats=color_stats,
+                revision=("index", identity.index_revision),
+            )
+            session = PhotoRenderSessionHandle(
+                session_id=self._next_render_session_id,
+                asset_id=decode_key.asset_id,
+                source_identity=identity,
+                current_surface=surface,
+                edit_state=state,
+                baseline_state=state,
+            )
+            self._next_render_session_id += 1
+        required = SurfaceRetentionBudget.surface_bytes(surface)
+        if required > self._surface_budget.max_bytes:
+            if session_key not in self._render_sessions:
+                session.invalidate()
+            return None
+        while not self._surface_budget.can_replace(session.session_id, required):
+            evicted = self._evict_oldest_render_session(excluding=session)
+            if not evicted:
+                if session_key not in self._render_sessions:
+                    session.invalidate()
+                return None
+        if session.current_surface is not surface and not session.replace_surface(surface):
+            return None
+        if (
+            session.edit_references == 0
+            and dict(session.baseline_state.raw_adjustments) != dict(adjustments)
+        ):
+            state = EditRenderState.create(
+                adjustments,
+                color_stats=color_stats,
+                revision=("index", identity.index_revision),
+            )
+            session.edit_state = state
+            session.baseline_state = state
+        if not self._surface_budget.replace(session.session_id, required):
+            return None
+
+        self._render_sessions.pop(session_key, None)
+        self._render_sessions[session_key] = session
+        self._current_render_session = session
+        while len(self._render_sessions) > 3:
+            if not self._evict_oldest_render_session(excluding=session):
+                break
+        return session
+
+    def _reserve_pending_surface(self, image: QImage) -> bool:
+        """Reserve one deferred still without escaping the unified budget."""
+
+        required = max(0, int(image.sizeInBytes()))
+        if required > self._surface_budget.max_bytes:
+            self._surface_budget.release(0)
+            return False
+        while not self._surface_budget.can_replace(0, required):
+            current = self._current_render_session
+            if current is None or current.edit_references > 0:
+                self._surface_budget.release(0)
+                return False
+            if not self._evict_oldest_render_session(excluding=current):
+                # The current Detail surface is no longer visible while Live
+                # motion plays, so it is the final safe eviction candidate.
+                for key, candidate in tuple(self._render_sessions.items()):
+                    if candidate is not current:
+                        continue
+                    self._render_sessions.pop(key, None)
+                    self._surface_budget.release(candidate.session_id)
+                    candidate.invalidate()
+                    self._current_render_session = None
+                    break
+                else:
+                    return False
+        return self._surface_budget.replace(0, required)
+
+    def _evict_oldest_render_session(
+        self,
+        *,
+        excluding: PhotoRenderSessionHandle,
+    ) -> bool:
+        for key, candidate in tuple(self._render_sessions.items()):
+            if candidate is excluding or candidate.edit_references > 0:
+                continue
+            self._render_sessions.pop(key, None)
+            self._surface_budget.release(candidate.session_id)
+            candidate.invalidate()
+            if candidate is self._current_render_session:
+                self._current_render_session = None
+            return True
+        return False
+
+    def _touch_render_session(self, session: PhotoRenderSessionHandle) -> None:
+        for key, candidate in tuple(self._render_sessions.items()):
+            if candidate is session:
+                self._render_sessions.move_to_end(key)
+                return
 
     def _release_worker(self, worker: _AdjustedImageWorker) -> None:
         """Drop completed workers so the thread pool can reclaim resources."""

--- a/src/iPhoto/gui/ui/window_manager.py
+++ b/src/iPhoto/gui/ui/window_manager.py
@@ -317,6 +317,11 @@ class FramelessWindowManager(QObject):
         ):
             edit_controller.exit_fullscreen_preview()
             return
+        if edit_controller is not None and edit_controller.is_editing():
+            cancel_edit = getattr(edit_controller, "cancel_edit_mode", None)
+            if callable(cancel_edit):
+                cancel_edit()
+            return
 
         if not self._immersive_active:
             return

--- a/src/iPhoto/legacy/appctx.py
+++ b/src/iPhoto/legacy/appctx.py
@@ -68,6 +68,10 @@ class AppContext:
         return self._runtime.library_session
 
     @property
+    def library_binding_token(self):
+        return self._runtime.library_binding_token
+
+    @property
     def recent_albums(self) -> list[Path]:
         return self._runtime.recent_albums
 

--- a/tests/application/test_appctx_runtime_context.py
+++ b/tests/application/test_appctx_runtime_context.py
@@ -19,6 +19,7 @@ def test_appctx_proxies_runtime_context(monkeypatch) -> None:
         theme=object(),
         asset_runtime=object(),
         library_session=object(),
+        library_binding_token=object(),
         recent_albums=[Path("A")],
         defer_startup_tasks=True,
     )
@@ -64,6 +65,7 @@ def test_appctx_proxies_runtime_context(monkeypatch) -> None:
     assert context.theme is runtime.theme
     assert context.asset_runtime is runtime.asset_runtime
     assert context.library_session is runtime.library_session
+    assert context.library_binding_token is runtime.library_binding_token
     assert context.recent_albums is runtime.recent_albums
 
     context.resume_startup_tasks()

--- a/tests/application/test_dialog_controller_runtime_binding.py
+++ b/tests/application/test_dialog_controller_runtime_binding.py
@@ -89,6 +89,31 @@ def test_bind_library_dialog_uses_runtime_open_library(
     )
 
 
+def test_bind_library_dialog_refuses_switch_during_active_edit(monkeypatch) -> None:
+    context = _Context(Path("/old"))
+    select_directory = Mock()
+    show_error = Mock()
+    monkeypatch.setattr(
+        "iPhoto.gui.ui.controllers.dialog_controller.dialogs.select_directory",
+        select_directory,
+    )
+    monkeypatch.setattr(
+        "iPhoto.gui.ui.controllers.dialog_controller.dialogs.show_error",
+        show_error,
+    )
+    controller = DialogController(
+        object(),
+        context,
+        Mock(),
+        library_rebind_preflight=lambda: False,
+    )
+
+    assert controller.bind_library_dialog() is None
+    select_directory.assert_not_called()
+    assert context.open_calls == []
+    show_error.assert_called_once()
+
+
 def test_bind_library_dialog_skips_initial_scan_when_scope_complete(
     monkeypatch,
     tmp_path: Path,

--- a/tests/application/test_runtime_context.py
+++ b/tests/application/test_runtime_context.py
@@ -338,3 +338,46 @@ def test_library_binding_token_changes_for_open_and_close(tmp_path: Path) -> Non
     assert second.root == second_root
     assert first.epoch < second.epoch < closed.epoch
     assert closed.root is None
+
+
+def test_new_library_epoch_is_visible_before_session_is_published(tmp_path: Path) -> None:
+    library_root = tmp_path / "library"
+    library_root.mkdir()
+    context, library, _asset_runtime = _runtime_context(library_root)
+    observed = []
+    original_bind = library.bind_library_session
+
+    def _observe_bind(session: object | None) -> None:
+        if session is not None:
+            observed.append(context.library_binding_token)
+        original_bind(session)
+
+    library.bind_library_session = _observe_bind  # type: ignore[method-assign]
+
+    context.open_library(library_root)
+
+    assert observed == [context.library_binding_token]
+    assert observed[0].epoch == 1
+    assert observed[0].root == library_root
+
+
+def test_closed_library_epoch_is_visible_before_session_is_unbound(tmp_path: Path) -> None:
+    library_root = tmp_path / "library"
+    library_root.mkdir()
+    context, library, _asset_runtime = _runtime_context(library_root)
+    context.open_library(library_root)
+    observed = []
+    original_bind = library.bind_library_session
+
+    def _observe_unbind(session: object | None) -> None:
+        if session is None:
+            observed.append(context.library_binding_token)
+        original_bind(session)
+
+    library.bind_library_session = _observe_unbind  # type: ignore[method-assign]
+
+    context.close_library()
+
+    assert observed == [context.library_binding_token]
+    assert observed[0].epoch == 2
+    assert observed[0].root is None

--- a/tests/gui/coordinators/test_edit_coordinator.py
+++ b/tests/gui/coordinators/test_edit_coordinator.py
@@ -28,6 +28,30 @@ def qapp():
     yield app
 
 
+def test_library_rebind_preflight_blocks_only_active_edit() -> None:
+    coordinator = EditCoordinator.__new__(EditCoordinator)
+    coordinator._session = object()
+    assert not EditCoordinator.preflight_library_rebind(coordinator)
+    coordinator._session = None
+    assert EditCoordinator.preflight_library_rebind(coordinator)
+
+
+def test_external_library_invalidation_exits_without_stale_handle_error() -> None:
+    coordinator = EditCoordinator.__new__(EditCoordinator)
+    handle = Mock()
+    coordinator._render_session_handle = handle
+    coordinator._session = object()
+    coordinator.leave_edit_mode = Mock()
+
+    EditCoordinator.invalidate_library_binding(coordinator)
+
+    handle.invalidate.assert_called_once_with()
+    coordinator.leave_edit_mode.assert_called_once_with(
+        restore_reason="library_invalidated",
+        restore_detail=False,
+    )
+
+
 def test_handle_done_clicked_delegates_to_adjustment_committer() -> None:
     coordinator = EditCoordinator.__new__(EditCoordinator)
     session = SimpleNamespace(

--- a/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
+++ b/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
@@ -10,6 +10,41 @@ from iPhoto.gui.coordinators.main_coordinator import MainCoordinator
 from iPhoto.people.service import PeopleService
 
 
+def test_same_library_tree_refresh_preserves_active_edit_session() -> None:
+    coordinator = MainCoordinator.__new__(MainCoordinator)
+    token = SimpleNamespace(epoch=7, root=Path("/library"))
+    coordinator._context = SimpleNamespace(library_binding_token=token)
+    coordinator._library_binding_token = token
+    coordinator._edit = MagicMock(is_editing=MagicMock(return_value=True))
+    coordinator._playback = MagicMock()
+
+    assert not MainCoordinator._synchronize_library_binding(coordinator)
+
+    coordinator._edit.invalidate_library_binding.assert_not_called()
+    coordinator._playback.rebind_library.assert_called_once_with(
+        token,
+        session_change=False,
+    )
+
+
+def test_external_library_session_change_safely_invalidates_edit() -> None:
+    coordinator = MainCoordinator.__new__(MainCoordinator)
+    previous = SimpleNamespace(epoch=7, root=Path("/library-a"))
+    current = SimpleNamespace(epoch=8, root=Path("/library-b"))
+    coordinator._context = SimpleNamespace(library_binding_token=current)
+    coordinator._library_binding_token = previous
+    coordinator._edit = MagicMock(is_editing=MagicMock(return_value=True))
+    coordinator._playback = MagicMock()
+
+    assert MainCoordinator._synchronize_library_binding(coordinator)
+
+    coordinator._edit.invalidate_library_binding.assert_called_once_with()
+    coordinator._playback.rebind_library.assert_called_once_with(
+        current,
+        session_change=True,
+    )
+
+
 def test_on_library_tree_updated_rebinds_asset_list_vm_and_reloads_selection() -> None:
     coordinator = MainCoordinator.__new__(MainCoordinator)
     root = Path("/library")

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -12,6 +12,7 @@ pytest.importorskip("PySide6", reason="PySide6 is required for playback coordina
 from iPhoto.application.ports import LocationWriteJobRecord
 from iPhoto.gui.coordinators import playback_coordinator as playback_coordinator_module
 from iPhoto.gui.coordinators.playback_coordinator import PlaybackCoordinator
+from iPhoto.gui.detail_pipeline import AssetSourceIdentity, PlaybackAsyncToken
 from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator, DetailRenderState
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
 from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
@@ -538,6 +539,106 @@ def test_live_still_rejects_previous_generation(tmp_path: Path) -> None:
 
     coordinator._refresh_face_name_overlay_for_current_presentation.assert_not_called()
     coordinator._asset_model.prioritize_rows.assert_not_called()
+
+
+def test_previous_library_metadata_result_is_rejected_even_for_same_path() -> None:
+    path = Path("/shared/photo.jpg")
+    identity = AssetSourceIdentity.create(path, source_mtime_ns=11, size_bytes=22)
+    old_token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=4,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    new_token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._active_async_token = new_token
+    coordinator._library_binding_token_getter = lambda: SimpleNamespace(epoch=2)
+    coordinator._info_panel_metadata_cache = {}
+    coordinator._info_panel_metadata_inflight = set()
+    coordinator._info_panel_metadata_attempted = set()
+
+    PlaybackCoordinator._handle_info_panel_metadata_ready(
+        coordinator,
+        InfoPanelMetadataResult(path=path, metadata={"iso": 100}),
+        async_token=old_token,
+    )
+
+    assert coordinator._info_panel_metadata_cache == {}
+
+
+def test_previous_library_location_result_cannot_update_current_panel() -> None:
+    path = Path("/shared/photo.jpg")
+    identity = AssetSourceIdentity.create(path, source_mtime_ns=11, size_bytes=22)
+    old_token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=4,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    new_token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._active_async_token = new_token
+    coordinator._library_binding_token_getter = lambda: SimpleNamespace(epoch=2)
+    coordinator._location_search_async_tokens = {17: old_token}
+    coordinator._location_search_dispatch_token = None
+    coordinator._info_panel = Mock()
+    coordinator._current_presentation = _make_presentation(path=str(path))
+    coordinator._location_assign_inflight = False
+
+    PlaybackCoordinator._handle_location_suggestions_ready(
+        coordinator,
+        17,
+        path,
+        "Berlin",
+        [object()],
+    )
+
+    coordinator._info_panel.set_location_suggestions.assert_not_called()
+
+
+def test_previous_library_location_write_result_cannot_touch_new_video() -> None:
+    path = Path("/shared/video.mov")
+    identity = AssetSourceIdentity.create(path, source_mtime_ns=11, size_bytes=22)
+    old_token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=4,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    new_token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._active_async_token = new_token
+    coordinator._library_binding_token_getter = lambda: SimpleNamespace(epoch=2)
+    coordinator._location_write_tokens_by_job = {"old-job": old_token}
+    coordinator._location_write_jobs_by_path = {path: "old-job"}
+    coordinator._complete_location_video_file_write = Mock()
+    result = LocationFileWriteResult(
+        job_id="old-job",
+        asset_path=path,
+        gps={},
+        location="Berlin",
+    )
+
+    PlaybackCoordinator._handle_location_file_write_verified(coordinator, result)
+
+    coordinator._complete_location_video_file_write.assert_not_called()
+    assert coordinator._location_write_jobs_by_path[path] == "old-job"
 
 
 def test_reset_for_gallery_closes_info_panel_and_clears_viewmodel_state() -> None:

--- a/tests/gui/test_detail_pipeline.py
+++ b/tests/gui/test_detail_pipeline.py
@@ -10,6 +10,7 @@ from iPhoto.gui.detail_pipeline import (
     DetailDecodeKey,
     DetailGeometryState,
     DetailRenderRequest,
+    PlaybackAsyncToken,
     select_detail_decode_level,
 )
 
@@ -88,6 +89,38 @@ def test_source_identity_remains_unstable_when_stat_fails(tmp_path: Path) -> Non
 
     assert legacy.repair_revision_from_stat() is legacy
     assert legacy.revision[0] == "legacy"
+
+
+def test_playback_async_token_checks_every_delivery_identity_field(tmp_path: Path) -> None:
+    first = AssetSourceIdentity.create(
+        tmp_path / "photo.jpg",
+        size_bytes=10,
+        source_mtime_ns=20,
+    )
+    replaced = AssetSourceIdentity.create(
+        tmp_path / "photo.jpg",
+        size_bytes=11,
+        source_mtime_ns=21,
+    )
+    token = PlaybackAsyncToken.create(
+        library_epoch=3,
+        asset_generation=4,
+        asset_id="asset",
+        source_identity=first,
+    )
+
+    assert token.matches(
+        library_epoch=3,
+        asset_generation=4,
+        asset_id="asset",
+        source_identity=first,
+    )
+    assert not token.matches(
+        library_epoch=3,
+        asset_generation=4,
+        asset_id="asset",
+        source_identity=replaced,
+    )
 
 
 def test_decode_key_distinguishes_source_orientation(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_render_session.py
+++ b/tests/gui/test_detail_render_session.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+
+from PySide6.QtGui import QImage
+
+from iPhoto.core.color_resolver import ColorStats
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailDecodeKey
+from iPhoto.gui.detail_render_session import (
+    EditRenderState,
+    PhotoRenderSessionHandle,
+    SurfaceRetentionBudget,
+)
+from iPhoto.gui.ui.controllers.player_view_controller import PlayerViewController
+
+
+def _surface(path: Path, *, side: int = 4, level: int | str = "full") -> DecodedSurface:
+    identity = AssetSourceIdentity.create(
+        path,
+        size_bytes=side * side * 4,
+        source_mtime_ns=1,
+        width=side,
+        height=side,
+    )
+    image = QImage(side, side, QImage.Format.Format_RGBA8888)
+    return DecodedSurface(
+        image=image,
+        decode_key=DetailDecodeKey(
+            asset_id=path.stem,
+            source=identity.path,
+            source_revision=identity.revision,
+            orientation=1,
+            decode_level=level,
+        ),
+        source_size=(side, side),
+        decoded_size=(side, side),
+        decode_level=level,
+        backend="test",
+    )
+
+
+def _handle(path: Path) -> PhotoRenderSessionHandle:
+    surface = _surface(path)
+    identity = AssetSourceIdentity.create(path, source_mtime_ns=1)
+    state = EditRenderState.create({}, color_stats=ColorStats(), revision=("index", 1))
+    return PhotoRenderSessionHandle(
+        session_id=1,
+        asset_id=path.stem,
+        source_identity=identity,
+        current_surface=surface,
+        edit_state=state,
+        baseline_state=state,
+    )
+
+
+def test_handle_releases_lower_lod_after_upload_and_invalidates_safely(tmp_path: Path) -> None:
+    handle = _handle(tmp_path / "photo.jpg")
+    low = handle.current_surface
+    high = _surface(tmp_path / "photo.jpg", side=8, level=4096)
+
+    assert handle.replace_surface(high, retain_upload_fallback=True)
+    assert handle.upload_fallback is low
+    handle.finish_upload()
+    assert handle.upload_fallback is None
+    assert handle.current_surface is high
+
+    handle.invalidate()
+    assert handle.current_surface is None
+    assert handle.next_state({"Exposure": 1.0}) is None
+    assert handle.restore_baseline() is None
+
+
+def test_surface_budget_never_accepts_more_than_its_hard_limit(tmp_path: Path) -> None:
+    budget = SurfaceRetentionBudget(128)
+    first = _surface(tmp_path / "first.jpg")
+    second = _surface(tmp_path / "second.jpg")
+
+    assert budget.replace(1, budget.surface_bytes(first))
+    assert budget.replace(2, budget.surface_bytes(second))
+    assert budget.retained_bytes == 128
+    assert not budget.replace(3, 1)
+    assert budget.retained_bytes == 128
+
+
+def test_player_view_evicts_sessions_to_keep_one_cpu_surface_budget(tmp_path: Path) -> None:
+    controller = PlayerViewController.__new__(PlayerViewController)
+    controller._surface_budget = SurfaceRetentionBudget(128)
+    controller._render_sessions = OrderedDict()
+    controller._current_render_session = None
+    controller._next_render_session_id = 1
+    handles = []
+
+    for index in range(3):
+        path = tmp_path / f"photo-{index}.jpg"
+        image = QImage(4, 4, QImage.Format.Format_RGBA8888)
+        identity = AssetSourceIdentity.create(path, source_mtime_ns=index + 1)
+        handles.append(
+            PlayerViewController._retain_render_session(
+                controller,
+                source=path,
+                image=image,
+                adjustments={},
+                identity=identity,
+                color_stats=ColorStats(),
+                asset_id=f"asset-{index}",
+            )
+        )
+
+    assert handles[0] is not None and not handles[0].valid
+    assert handles[1] is not None and handles[1].valid
+    assert handles[2] is not None and handles[2].valid
+    assert controller.retained_surface_bytes == 128
+    assert len(controller._render_sessions) == 2
+
+    oversized = QImage(10, 10, QImage.Format.Format_RGBA8888)
+    rejected = PlayerViewController._retain_render_session(
+        controller,
+        source=tmp_path / "oversized.jpg",
+        image=oversized,
+        adjustments={},
+        identity=AssetSourceIdentity.create(
+            tmp_path / "oversized.jpg",
+            source_mtime_ns=9,
+        ),
+        color_stats=ColorStats(),
+        asset_id="oversized",
+    )
+    assert rejected is None
+    assert controller.retained_surface_bytes == 128
+
+
+def test_deferred_still_uses_same_surface_budget() -> None:
+    controller = PlayerViewController.__new__(PlayerViewController)
+    controller._surface_budget = SurfaceRetentionBudget(128)
+    controller._render_sessions = OrderedDict()
+    controller._current_render_session = None
+
+    assert PlayerViewController._reserve_pending_surface(
+        controller,
+        QImage(4, 4, QImage.Format.Format_RGBA8888),
+    )
+    assert controller.retained_surface_bytes == 64
+    assert not PlayerViewController._reserve_pending_surface(
+        controller,
+        QImage(10, 10, QImage.Format.Format_RGBA8888),
+    )
+    assert controller.retained_surface_bytes == 0
+
+
+def test_stale_shared_edit_handle_returns_safely_instead_of_raising(tmp_path: Path) -> None:
+    controller = PlayerViewController.__new__(PlayerViewController)
+    controller._surface_budget = SurfaceRetentionBudget(1024)
+    controller._render_sessions = OrderedDict()
+    controller._current_render_session = None
+    controller._next_render_session_id = 1
+    path = tmp_path / "edit.jpg"
+    handle = PlayerViewController._retain_render_session(
+        controller,
+        source=path,
+        image=QImage(4, 4, QImage.Format.Format_RGBA8888),
+        adjustments={},
+        identity=AssetSourceIdentity.create(path, source_mtime_ns=1),
+        color_stats=ColorStats(),
+        asset_id="edit",
+    )
+    assert handle is not None
+    acquired = PlayerViewController.acquire_render_session(controller, path)
+    assert acquired is handle
+
+    handle.invalidate()
+
+    assert PlayerViewController.update_render_session(controller, handle, {}) is None
+    assert not PlayerViewController.finish_render_session(
+        controller,
+        handle,
+        committed=False,
+    )

--- a/tests/ui/controllers/test_player_view_controller_adjustments.py
+++ b/tests/ui/controllers/test_player_view_controller_adjustments.py
@@ -11,14 +11,18 @@ pytest.importorskip("PySide6.QtGui", reason="QtGui is required for GUI tests", e
 
 from PySide6.QtGui import QImage
 
-from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailRenderTransaction
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailRenderTransaction,
+    PlaybackAsyncToken,
+)
 from iPhoto.gui.ui.controllers.player_view_controller import (
     PlayerViewController,
     _AdjustedImageWorker,
 )
 
 
-def test_adjusted_image_worker_skips_color_stats_without_sidecar() -> None:
+def test_adjusted_image_worker_collects_shared_stats_without_sidecar() -> None:
     source = Path("/tmp/photo.jpg")
     signals = Mock()
     edit_service = Mock()
@@ -35,7 +39,7 @@ def test_adjusted_image_worker_skips_color_stats_without_sidecar() -> None:
         worker.run()
 
     edit_service.describe_adjustments.assert_not_called()
-    compute_stats.assert_not_called()
+    compute_stats.assert_called_once_with(image)
     signals.completed.emit.assert_called_once_with(source, image, {})
 
 
@@ -92,9 +96,39 @@ def test_deferred_still_keeps_original_live_transaction_until_applied() -> None:
     assert controller._pending_still[3] is transaction
 
     assert PlayerViewController.apply_pending_still(controller)
-    controller._apply_still_frame.assert_called_once_with(
-        source,
-        image,
-        {},
-        transaction=transaction,
+    call = controller._apply_still_frame.call_args
+    assert call.args == (source, image, {})
+    assert call.kwargs["transaction"] is transaction
+
+
+def test_worker_result_from_previous_library_epoch_is_rejected_for_same_path() -> None:
+    source = Path("/shared/photo.jpg")
+    identity = AssetSourceIdentity.create(source, source_mtime_ns=1)
+    old_token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=1,
+        asset_id="asset",
+        source_identity=identity,
     )
+    new_token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=2,
+        asset_id="asset",
+        source_identity=identity,
+    )
+    controller = SimpleNamespace(
+        _loading_source=source,
+        _loading_started_at=None,
+        _active_async_token=new_token,
+        _apply_still_frame=Mock(),
+    )
+
+    PlayerViewController._on_adjusted_image_ready(
+        controller,
+        source,
+        QImage(4, 4, QImage.Format.Format_RGBA8888),
+        {},
+        async_token=old_token,
+    )
+
+    controller._apply_still_frame.assert_not_called()

--- a/tests/ui/test_window_manager_geometry.py
+++ b/tests/ui/test_window_manager_geometry.py
@@ -67,6 +67,19 @@ def test_apply_screen_change_fix_rescales_and_repositions() -> None:
     assert manager._last_screen_dpr == 2.0
 
 
+def test_escape_cancels_active_edit_before_window_fullscreen_logic() -> None:
+    manager = FramelessWindowManager.__new__(FramelessWindowManager)
+    edit = MagicMock()
+    edit.is_editing.return_value = True
+    edit.is_in_fullscreen.return_value = False
+    manager._edit_controller = MagicMock(return_value=edit)
+    manager._immersive_active = False
+
+    FramelessWindowManager.exit_fullscreen(manager)
+
+    edit.cancel_edit_mode.assert_called_once_with()
+
+
 # ---------------------------------------------------------------------------
 # _is_wayland helper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fifth replacement PR for #890. This isolates review findings 3, 4, and the active portion of 8 without importing Recognition/Pets or the broad #890 merge history.

- publish immutable Library binding epochs before synchronous session bind/unbind callbacks
- add `PlaybackAsyncToken(library_epoch, asset_generation, asset_id, source_path, source_revision)` and reject late still, metadata, location-search, location-write, and manual-face deliveries
- stop video, cancel presentation state, clear library-scoped surfaces, and invalidate transactions on a real session switch
- distinguish same-library `treeUpdated` refreshes from actual session changes
- block user-initiated library switches while Edit is active; Done commits and Escape cancels
- safely invalidate unexpected external switches without stale-handle exceptions or old-session writes
- share the current Detail still with Edit through a safely invalidatable render handle
- enforce a PlayerView-level 192 MiB CPU surface budget; retain only current/upload-fallback surfaces, include deferred stills in the same budget, and evict sessions instead of retaining every LOD
- refuse reusable render sessions when source revision is unstable
- add Linux/macOS/Windows Detail/Edit/Library lifecycle contracts

## Validation

- focused lifecycle suite: `168 passed`
- non-UI regression suite: `2328 passed, 13 skipped`
- complete UI suite: `372 passed`
- architecture checks, compile checks, workflow YAML, and `git diff --check` passed

Supersedes the Detail/Edit/Library lifecycle and CPU-retention portions of #890.