### PR TITLE
Add recoverable Recognition mutation coordination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,3 +223,39 @@ jobs:
           tests/ui/controllers/test_player_view_controller_adjustments.py
           tests/ui/controllers/test_player_view_init_cover.py
           tests/ui/test_window_manager_geometry.py
+
+  recognition-contracts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libegl1 libgl1 libxkbcommon0 libpulse0
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run Recognition recovery and concurrency contracts
+        env:
+          QT_QPA_PLATFORM: offscreen
+          NUMBA_DISABLE_JIT: "1"
+        run: >-
+          python -m pytest -q
+          tests/test_recognition_operation_journal.py

--- a/src/iPhoto/recognition/__init__.py
+++ b/src/iPhoto/recognition/__init__.py
@@ -1,0 +1,27 @@
+"""Shared recognition coordination infrastructure."""
+
+from .mutation_coordinator import (
+    RecognitionMutationCoordinator,
+    RecognitionMutationFailure,
+    RecognitionMutationOutcome,
+    get_recognition_mutation_coordinator,
+)
+from .operation_journal import (
+    RecognitionOperation,
+    RecognitionOperationJournal,
+    RecognitionOperationKind,
+    RecognitionOperationState,
+    RecognitionOutboxEvent,
+)
+
+__all__ = [
+    "RecognitionMutationCoordinator",
+    "RecognitionMutationFailure",
+    "RecognitionMutationOutcome",
+    "RecognitionOperation",
+    "RecognitionOperationJournal",
+    "RecognitionOperationKind",
+    "RecognitionOperationState",
+    "RecognitionOutboxEvent",
+    "get_recognition_mutation_coordinator",
+]

--- a/src/iPhoto/recognition/mutation_coordinator.py
+++ b/src/iPhoto/recognition/mutation_coordinator.py
@@ -1,0 +1,315 @@
+"""Library-scoped admission, recovery, and event dispatch for recognition writes."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from iPhoto.utils.pathutils import ensure_work_dir
+
+from .operation_journal import (
+    RecognitionOperation,
+    RecognitionOperationJournal,
+    RecognitionOperationKind,
+    RecognitionOperationState,
+    RecognitionOutboxEvent,
+)
+
+
+class RecognitionMutationFailure(StrEnum):
+    REJECTED = "rejected"
+    RECOVERY_PENDING = "recovery_pending"
+    SHUTTING_DOWN = "shutting_down"
+
+
+@dataclass(frozen=True, slots=True)
+class RecognitionMutationOutcome[T]:
+    succeeded: bool
+    value: T | None = None
+    failure: RecognitionMutationFailure | None = None
+    operation_id: str | None = None
+
+
+@dataclass(slots=True)
+class _ExecutionLease:
+    lock: threading.RLock
+    references: int = 0
+
+
+RecoveryHandler = Callable[[RecognitionOperation], bool]
+EventSubscriber = Callable[[RecognitionOutboxEvent], None]
+
+
+_EXECUTION_LOCKS: dict[Path, _ExecutionLease] = {}
+_EXECUTION_LOCKS_GUARD = threading.Lock()
+
+
+def _acquire_execution_lease(library_root: Path) -> threading.RLock:
+    """Return the process-wide lifecycle lease for one recognition library."""
+
+    resolved = Path(library_root).resolve()
+    with _EXECUTION_LOCKS_GUARD:
+        lease = _EXECUTION_LOCKS.get(resolved)
+        if lease is None:
+            lease = _ExecutionLease(threading.RLock())
+            _EXECUTION_LOCKS[resolved] = lease
+        lease.references += 1
+        return lease.lock
+
+
+def _release_execution_lease(library_root: Path) -> None:
+    resolved = Path(library_root).resolve()
+    with _EXECUTION_LOCKS_GUARD:
+        lease = _EXECUTION_LOCKS.get(resolved)
+        if lease is None:
+            return
+        lease.references -= 1
+        if lease.references <= 0:
+            _EXECUTION_LOCKS.pop(resolved, None)
+
+
+class RecognitionMutationCoordinator:
+    """The only owner of a library's global recognition operation journal.
+
+    Domain coordinators register typed recovery handlers, while normal writes use
+    this object for global admission. Event delivery is at-least-once: a crash
+    after publishing but before the dispatched CAS may replay the same event id.
+    """
+
+    def __init__(self, library_root: Path) -> None:
+        self._library_root = Path(library_root).resolve()
+        self._journal = RecognitionOperationJournal(
+            ensure_work_dir(self._library_root) / "recognition" / "operations.db"
+        )
+        self._execution_lock = _acquire_execution_lease(self._library_root)
+        self._closed = False
+        self._lock = threading.RLock()
+        self._handlers: dict[str, list[RecoveryHandler]] = {}
+        self._subscribers: list[EventSubscriber] = []
+        self._recovery_error: Exception | None = None
+
+    @property
+    def library_root(self) -> Path:
+        return self._library_root
+
+    @property
+    def recovery_pending(self) -> bool:
+        return bool(self._journal.unfinished()) or self._recovery_error is not None
+
+    @property
+    def recovery_error(self) -> Exception | None:
+        return self._recovery_error
+
+    @property
+    def execution_lock(self) -> threading.RLock:
+        """The shared lease that covers a mutation's complete apply lifecycle."""
+
+        return self._execution_lock
+
+    @contextmanager
+    def mutation_scope(self) -> Iterator[None]:
+        """Prevent live work from being mistaken for crash recovery.
+
+        The lease is shared by every coordinator instance for this library and
+        intentionally remains held from admission through commit/finalize. A
+        process crash releases it, allowing the next process to recover the
+        durable journal head.
+        """
+
+        with self._execution_lock:
+            if self._closed:
+                raise RuntimeError("Recognition mutation coordinator is closed.")
+            yield
+
+    def register_recovery_handler(
+        self,
+        kinds: set[str | RecognitionOperationKind],
+        handler: RecoveryHandler,
+    ) -> None:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Recognition mutation coordinator is closed.")
+            for kind in kinds:
+                normalized = str(kind)
+                handlers = self._handlers.setdefault(normalized, [])
+                if handler not in handlers:
+                    handlers.insert(0, handler)
+
+    def subscribe(self, subscriber: EventSubscriber) -> None:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Recognition mutation coordinator is closed.")
+            if subscriber not in self._subscribers:
+                self._subscribers.append(subscriber)
+        self.dispatch_pending()
+
+    def unsubscribe(self, subscriber: EventSubscriber) -> None:
+        with self._lock:
+            if subscriber in self._subscribers:
+                self._subscribers.remove(subscriber)
+
+    def close(self) -> None:
+        """Release session-owned handlers, subscribers, and the root lease."""
+
+        if self._closed:
+            return
+        with self._execution_lock, self._lock:
+            if self._closed:
+                return
+            self._handlers.clear()
+            self._subscribers.clear()
+            self._closed = True
+        _release_execution_lease(self._library_root)
+
+    def recover_pending(self) -> bool:
+        with self.mutation_scope(), self._lock:
+            try:
+                while (operation := self._journal.unfinished_head()) is not None:
+                    if operation.state == RecognitionOperationState.COMMITTED and self._subscribers:
+                        if not self.dispatch_pending():
+                            return False
+                        continue
+                    handlers = self._handlers.get(operation.kind, ())
+                    if not handlers:
+                        self._recovery_error = RuntimeError(
+                            "No recovery handler is registered for recognition operation "
+                            f"{operation.kind}/{operation.operation_id}."
+                        )
+                        return False
+                    if not any(handler(operation) for handler in tuple(handlers)):
+                        self._recovery_error = RuntimeError(
+                            "Recognition operation recovery is incomplete for "
+                            f"{operation.kind}/{operation.operation_id}."
+                        )
+                        return False
+                self._recovery_error = None
+                return True
+            except Exception as exc:  # noqa: BLE001
+                self._recovery_error = exc
+                return False
+
+    def try_prepare(
+        self,
+        kind: str | RecognitionOperationKind,
+        payload: dict[str, Any],
+    ) -> str | None:
+        with self.mutation_scope(), self._lock:
+            operation_id = self._journal.try_prepare(kind, payload)
+            if operation_id is None:
+                return None
+            if not self._journal.transition(
+                operation_id,
+                RecognitionOperationState.APPLYING,
+                expected_state=RecognitionOperationState.PREPARED,
+            ):
+                raise RuntimeError(f"Recognition operation lost its prepared lease: {operation_id}")
+            return operation_id
+
+    def prepare(self, kind: str, payload: dict[str, Any]) -> str:
+        """Compatibility primitive for recovery fixtures and legacy tests."""
+
+        with self.mutation_scope():
+            return self._journal.prepare(kind, payload)
+
+    def transition(self, *args, **kwargs) -> bool:
+        with self.mutation_scope():
+            operation_id = str(args[0] if args else kwargs.get("operation_id") or "")
+            if kwargs.get("expected_state") is None:
+                current = next(
+                    (
+                        operation.state
+                        for operation in self._journal.unfinished()
+                        if operation.operation_id == operation_id
+                    ),
+                    None,
+                )
+                if current is None:
+                    raise RuntimeError(
+                        f"Recognition operation has no active state lease: {operation_id}"
+                    )
+                kwargs["expected_state"] = current
+            succeeded = self._journal.transition(*args, **kwargs)
+            if not succeeded:
+                raise RuntimeError(f"Recognition operation state CAS failed: {operation_id}")
+            return True
+
+    def commit_outbox(self, *args, **kwargs) -> str:
+        with self.mutation_scope():
+            return self._journal.commit_outbox(*args, **kwargs)
+
+    def commit_and_dispatch(
+        self,
+        operation_id: str,
+        event: dict[str, Any],
+        dispatch: Callable[[], None],
+    ) -> str:
+        """Persist an event before delivery, then finalize its CAS acknowledgment."""
+
+        with self.mutation_scope(), self._lock:
+            event_id = self._journal.commit_outbox(operation_id, event)
+            dispatch()
+            if not self._journal.mark_dispatched(operation_id):
+                raise RuntimeError(f"Recognition event dispatch CAS failed: {event_id}")
+            return event_id
+
+    def mark_dispatched(self, operation_id: str) -> bool:
+        with self.mutation_scope():
+            return self._journal.mark_dispatched(operation_id)
+
+    def mark_published(self, operation_id: str) -> None:
+        with self.mutation_scope():
+            self._journal.mark_published(operation_id)
+
+    def unfinished(self) -> tuple[RecognitionOperation, ...]:
+        with self.mutation_scope():
+            return self._journal.unfinished()
+
+    def unfinished_head(self) -> RecognitionOperation | None:
+        with self.mutation_scope():
+            return self._journal.unfinished_head()
+
+    def pending_events(self) -> tuple[RecognitionOutboxEvent, ...]:
+        with self.mutation_scope():
+            return self._journal.pending_events()
+
+    def dispatch_pending(self) -> bool:
+        with self.mutation_scope(), self._lock:
+            for event in self._journal.pending_events():
+                try:
+                    for subscriber in tuple(self._subscribers):
+                        subscriber(event)
+                except Exception as exc:  # noqa: BLE001
+                    self._recovery_error = exc
+                    return False
+                if not self._journal.mark_dispatched(event.operation_id):
+                    self._recovery_error = RuntimeError(
+                        f"Recognition event dispatch CAS failed: {event.event_id}"
+                    )
+                    return False
+            return True
+
+
+def get_recognition_mutation_coordinator(
+    library_root: Path,
+) -> RecognitionMutationCoordinator:
+    """Compatibility factory; production sessions inject their owned instance."""
+
+    return RecognitionMutationCoordinator(Path(library_root).resolve())
+
+
+def reset_recognition_mutation_coordinators() -> None:
+    """Compatibility no-op retained for older tests."""
+
+
+__all__ = [
+    "RecognitionMutationCoordinator",
+    "RecognitionMutationFailure",
+    "RecognitionMutationOutcome",
+    "get_recognition_mutation_coordinator",
+    "reset_recognition_mutation_coordinators",
+]

--- a/src/iPhoto/recognition/operation_journal.py
+++ b/src/iPhoto/recognition/operation_journal.py
@@ -1,0 +1,413 @@
+"""Crash-recoverable journal and event outbox for recognition mutations."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from contextlib import closing
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from iPhoto.sqlite_utils import configure_sqlite_connection, connect_sqlite
+
+
+class RecognitionOperationKind(StrEnum):
+    PEOPLE_SCAN_COMMIT = "people_scan_commit"
+    PEOPLE_ADD_MANUAL_FACE = "people_add_manual_face"
+    PEOPLE_DELETE_FACE = "people_delete_face"
+    PEOPLE_MOVE_FACE = "people_move_face"
+    PEOPLE_MOVE_FACE_NEW = "people_move_face_new"
+    PEOPLE_MERGE = "people_merge"
+    PEOPLE_CREATE_GROUP = "people_create_group"
+    PEOPLE_DELETE_GROUP = "people_delete_group"
+    PEOPLE_RENAME = "people_rename"
+    RECOGNITION_MERGE = "recognition_merge"
+    RECOGNITION_DETECTION_ASSIGNMENT = "recognition_detection_assignment"
+
+
+class RecognitionOperationState(StrEnum):
+    PREPARED = "prepared"
+    APPLYING = "applying"
+    COMMITTED = "committed"
+    FINALIZED = "finalized"
+
+
+@dataclass(frozen=True)
+class RecognitionOperation:
+    sequence: int
+    operation_id: str
+    kind: RecognitionOperationKind | str
+    state: RecognitionOperationState
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RecognitionOutboxEvent:
+    event_id: str
+    operation_id: str
+    event: dict[str, Any]
+
+
+class RecognitionOperationJournal:
+    """Persist recognition operations through prepared/applying/committed/finalized."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+        self._initialize()
+
+    def prepare(self, kind: str | RecognitionOperationKind, payload: dict[str, Any]) -> str:
+        """Append an operation without applying the global-empty guard.
+
+        Recovery and test setup use this primitive. New user mutations should
+        use :meth:`try_prepare` so two owners cannot both start work.
+        """
+
+        operation_id = self._insert_operation(kind, payload, require_empty=False)
+        if operation_id is None:
+            raise RuntimeError("Unconditional recognition operation insert was rejected.")
+        return operation_id
+
+    def try_prepare(
+        self,
+        kind: str | RecognitionOperationKind,
+        payload: dict[str, Any],
+    ) -> str | None:
+        """Atomically append an operation only when the global queue is empty."""
+
+        return self._insert_operation(kind, payload, require_empty=True)
+
+    def _insert_operation(
+        self,
+        kind: str | RecognitionOperationKind,
+        payload: dict[str, Any],
+        *,
+        require_empty: bool,
+    ) -> str | None:
+        operation_id = uuid.uuid4().hex
+        with closing(self._connect()) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            if require_empty:
+                pending = conn.execute(
+                    "SELECT 1 FROM operations WHERE state != 'finalized' LIMIT 1"
+                ).fetchone()
+                if pending is not None:
+                    conn.rollback()
+                    return None
+            conn.execute(
+                """
+                INSERT INTO operations (
+                    operation_id, kind, state, payload_json, created_at, updated_at
+                ) VALUES (?, ?, 'prepared', ?, datetime('now'), datetime('now'))
+                """,
+                (operation_id, str(kind), _json(payload)),
+            )
+            conn.commit()
+        return operation_id
+
+    def transition(
+        self,
+        operation_id: str,
+        state: str | RecognitionOperationState,
+        *,
+        expected_state: str | RecognitionOperationState | None = None,
+        payload: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> bool:
+        normalized_state = str(state)
+        if normalized_state not in {value.value for value in RecognitionOperationState}:
+            raise ValueError(f"Unsupported recognition operation state: {state}")
+        with closing(self._connect()) as conn:
+            if payload is None:
+                if expected_state is None:
+                    cursor = conn.execute(
+                        """
+                        UPDATE operations
+                        SET state = ?, last_error = ?, updated_at = datetime('now')
+                        WHERE operation_id = ?
+                        """,
+                        (normalized_state, error, operation_id),
+                    )
+                else:
+                    cursor = conn.execute(
+                        """
+                        UPDATE operations
+                        SET state = ?, last_error = ?, updated_at = datetime('now')
+                        WHERE operation_id = ? AND state = ?
+                        """,
+                        (normalized_state, error, operation_id, str(expected_state)),
+                    )
+            else:
+                if expected_state is None:
+                    cursor = conn.execute(
+                        """
+                        UPDATE operations
+                        SET state = ?, payload_json = ?, last_error = ?,
+                            updated_at = datetime('now')
+                        WHERE operation_id = ?
+                        """,
+                        (normalized_state, _json(payload), error, operation_id),
+                    )
+                else:
+                    cursor = conn.execute(
+                        """
+                        UPDATE operations
+                        SET state = ?, payload_json = ?, last_error = ?,
+                            updated_at = datetime('now')
+                        WHERE operation_id = ? AND state = ?
+                        """,
+                        (
+                            normalized_state,
+                            _json(payload),
+                            error,
+                            operation_id,
+                            str(expected_state),
+                        ),
+                    )
+            conn.commit()
+        return int(cursor.rowcount or 0) == 1
+
+    def commit_outbox(
+        self,
+        operation_id: str,
+        event: dict[str, Any],
+        *,
+        event_id: str | None = None,
+    ) -> str:
+        stable_event_id = str(event_id or operation_id)
+        with closing(self._connect()) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT INTO event_outbox (
+                    event_id, operation_id, event_json, delivery_state
+                ) VALUES (?, ?, ?, 'pending')
+                ON CONFLICT(operation_id) DO UPDATE SET
+                    event_json = excluded.event_json,
+                    delivery_state = CASE
+                        WHEN event_outbox.delivery_state = 'dispatched' THEN 'dispatched'
+                        ELSE 'pending'
+                    END
+                """,
+                (stable_event_id, operation_id, _json(event)),
+            )
+            cursor = conn.execute(
+                """
+                UPDATE operations
+                SET state = 'committed', updated_at = datetime('now')
+                WHERE operation_id = ? AND state IN ('applying', 'committed')
+                """,
+                (operation_id,),
+            )
+            if int(cursor.rowcount or 0) != 1:
+                conn.rollback()
+                raise RuntimeError(
+                    "Recognition operation cannot commit outbox from its current state: "
+                    f"{operation_id}"
+                )
+            conn.commit()
+        return stable_event_id
+
+    def mark_dispatched(self, operation_id: str) -> bool:
+        with closing(self._connect()) as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            event_cursor = conn.execute(
+                """
+                UPDATE event_outbox
+                SET delivery_state = 'dispatched'
+                WHERE operation_id = ? AND delivery_state IN ('pending', 'dispatched')
+                """,
+                (operation_id,),
+            )
+            operation_cursor = conn.execute(
+                """
+                UPDATE operations
+                SET state = 'finalized', updated_at = datetime('now')
+                WHERE operation_id = ? AND state = 'committed'
+                """,
+                (operation_id,),
+            )
+            if int(event_cursor.rowcount or 0) != 1 or int(operation_cursor.rowcount or 0) != 1:
+                conn.rollback()
+                return False
+            conn.commit()
+        return True
+
+    def mark_published(self, operation_id: str) -> None:
+        """Compatibility alias for callers migrating to dispatcher terminology."""
+
+        if not self.mark_dispatched(operation_id):
+            raise RuntimeError(
+                f"Recognition event cannot be dispatched from its current state: {operation_id}"
+            )
+
+    def pending_events(self) -> tuple[RecognitionOutboxEvent, ...]:
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                """
+                SELECT event_id, operation_id, event_json
+                FROM event_outbox
+                WHERE delivery_state = 'pending'
+                ORDER BY rowid ASC
+                """
+            ).fetchall()
+        return tuple(
+            RecognitionOutboxEvent(
+                event_id=str(row["event_id"]),
+                operation_id=str(row["operation_id"]),
+                event=json.loads(str(row["event_json"] or "{}")),
+            )
+            for row in rows
+        )
+
+    def unfinished(self) -> tuple[RecognitionOperation, ...]:
+        with closing(self._connect()) as conn:
+            rows = conn.execute(
+                """
+                SELECT sequence, operation_id, kind, state, payload_json
+                FROM operations
+                WHERE state != 'finalized'
+                ORDER BY sequence ASC
+                """
+            ).fetchall()
+        return tuple(
+            RecognitionOperation(
+                sequence=int(row["sequence"]),
+                operation_id=str(row["operation_id"]),
+                kind=_parse_operation_kind(str(row["kind"])),
+                state=RecognitionOperationState(str(row["state"])),
+                payload=json.loads(str(row["payload_json"] or "{}")),
+            )
+            for row in rows
+        )
+
+    def unfinished_head(self) -> RecognitionOperation | None:
+        pending = self.unfinished()
+        return pending[0] if pending else None
+
+    def _initialize(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(self._connect()) as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'operations'"
+            ).fetchone()
+            if existing is None:
+                self._create_operations_table(conn, "operations")
+            else:
+                columns = {
+                    str(row["name"])
+                    for row in conn.execute("PRAGMA table_info(operations)").fetchall()
+                }
+                if "sequence" not in columns:
+                    conn.execute("BEGIN IMMEDIATE")
+                    self._create_operations_table(conn, "operations_v2")
+                    conn.execute(
+                        """
+                        INSERT INTO operations_v2 (
+                            operation_id, kind, state, payload_json, last_error,
+                            created_at, updated_at
+                        )
+                        SELECT operation_id, kind, state, payload_json, last_error,
+                               created_at, updated_at
+                        FROM operations
+                        ORDER BY created_at ASC, operation_id ASC
+                        """
+                    )
+                    conn.execute("DROP TABLE operations")
+                    conn.execute("ALTER TABLE operations_v2 RENAME TO operations")
+            self._initialize_outbox(conn)
+            conn.commit()
+
+    @staticmethod
+    def _initialize_outbox(conn: sqlite3.Connection) -> None:
+        existing = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'event_outbox'"
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                """
+                CREATE TABLE event_outbox (
+                    event_id TEXT NOT NULL PRIMARY KEY,
+                    operation_id TEXT NOT NULL UNIQUE,
+                    event_json TEXT NOT NULL,
+                    delivery_state TEXT NOT NULL DEFAULT 'pending'
+                )
+                """
+            )
+            return
+        columns = {
+            str(row["name"]) for row in conn.execute("PRAGMA table_info(event_outbox)").fetchall()
+        }
+        if {"event_id", "delivery_state"}.issubset(columns):
+            return
+        conn.execute("ALTER TABLE event_outbox RENAME TO event_outbox_legacy")
+        conn.execute(
+            """
+            CREATE TABLE event_outbox (
+                event_id TEXT NOT NULL PRIMARY KEY,
+                operation_id TEXT NOT NULL UNIQUE,
+                event_json TEXT NOT NULL,
+                delivery_state TEXT NOT NULL DEFAULT 'pending'
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO event_outbox (
+                event_id, operation_id, event_json, delivery_state
+            )
+            SELECT operation_id, operation_id, event_json,
+                   CASE WHEN published = 1 THEN 'dispatched' ELSE 'pending' END
+            FROM event_outbox_legacy
+            """
+        )
+        conn.execute("DROP TABLE event_outbox_legacy")
+
+    @staticmethod
+    def _create_operations_table(conn: sqlite3.Connection, name: str) -> None:
+        if name not in {"operations", "operations_v2"}:
+            raise ValueError(f"Unsupported operations table name: {name}")
+        conn.execute(
+            f"""
+            CREATE TABLE {name} (
+                sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                operation_id TEXT NOT NULL UNIQUE,
+                kind TEXT NOT NULL,
+                state TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = connect_sqlite(self._db_path)
+        conn.row_factory = sqlite3.Row
+        configure_sqlite_connection(conn, self._db_path, wal=True)
+        return conn
+
+
+def _json(value: dict[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _parse_operation_kind(value: str) -> RecognitionOperationKind | str:
+    try:
+        return RecognitionOperationKind(value)
+    except ValueError:
+        # Preserve unknown legacy/future values so FIFO recovery blocks at the
+        # exact operation instead of silently discarding data.
+        return value
+
+
+__all__ = [
+    "RecognitionOperation",
+    "RecognitionOperationJournal",
+    "RecognitionOperationKind",
+    "RecognitionOperationState",
+    "RecognitionOutboxEvent",
+]

--- a/tests/test_recognition_operation_journal.py
+++ b/tests/test_recognition_operation_journal.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from iPhoto.recognition.mutation_coordinator import RecognitionMutationCoordinator
+from iPhoto.recognition.operation_journal import RecognitionOperationJournal
+
+
+def test_unfinished_operations_follow_insertion_sequence(tmp_path: Path) -> None:
+    journal = RecognitionOperationJournal(tmp_path / "operations.db")
+
+    inserted = [journal.prepare("test", {"index": index}) for index in range(20)]
+
+    pending = journal.unfinished()
+    assert [operation.operation_id for operation in pending] == inserted
+    assert [operation.sequence for operation in pending] == list(range(1, 21))
+
+
+def test_legacy_operations_schema_migrates_deterministically(tmp_path: Path) -> None:
+    db_path = tmp_path / "operations.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE operations (
+                operation_id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                state TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                last_error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO operations (
+                operation_id, kind, state, payload_json, created_at, updated_at
+            ) VALUES (?, 'test', 'applying', ?, '2026-07-27 10:00:00',
+                      '2026-07-27 10:00:00')
+            """,
+            [(operation_id, json.dumps({"id": operation_id})) for operation_id in ("c", "a", "b")],
+        )
+
+    journal = RecognitionOperationJournal(db_path)
+
+    assert [operation.operation_id for operation in journal.unfinished()] == ["a", "b", "c"]
+    with sqlite3.connect(db_path) as connection:
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(operations)")}
+    assert "sequence" in columns
+
+
+def test_try_prepare_allows_only_one_global_owner(tmp_path: Path) -> None:
+    db_path = tmp_path / "operations.db"
+    RecognitionOperationJournal(db_path)
+
+    def prepare(index: int) -> str | None:
+        return RecognitionOperationJournal(db_path).try_prepare(
+            f"owner-{index}",
+            {"index": index},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(prepare, range(8)))
+
+    assert sum(result is not None for result in results) == 1
+    assert len(RecognitionOperationJournal(db_path).unfinished()) == 1
+
+
+def test_transition_compare_and_set_allows_only_expected_state(tmp_path: Path) -> None:
+    journal = RecognitionOperationJournal(tmp_path / "operations.db")
+    operation_id = journal.prepare("test", {})
+
+    assert journal.transition(
+        operation_id,
+        "applying",
+        expected_state="prepared",
+    )
+    assert not journal.transition(
+        operation_id,
+        "committed",
+        expected_state="prepared",
+    )
+
+
+def test_legacy_outbox_schema_migrates_to_pending_event_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "operations.db"
+    journal = RecognitionOperationJournal(db_path)
+    operation_id = journal.prepare("test", {})
+    journal.transition(operation_id, "applying")
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("DROP TABLE event_outbox")
+        connection.execute(
+            """
+            CREATE TABLE event_outbox (
+                operation_id TEXT PRIMARY KEY,
+                event_json TEXT NOT NULL,
+                published INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        connection.execute(
+            "INSERT INTO event_outbox VALUES (?, '{\"changed\":true}', 0)",
+            (operation_id,),
+        )
+        connection.execute(
+            "UPDATE operations SET state = 'committed' WHERE operation_id = ?",
+            (operation_id,),
+        )
+
+    reopened = RecognitionOperationJournal(db_path)
+
+    assert reopened.pending_events()[0].event_id == operation_id
+    assert reopened.pending_events()[0].event == {"changed": True}
+    assert reopened.mark_dispatched(operation_id)
+    assert reopened.unfinished() == ()
+
+
+def test_mutation_coordinator_recovers_registered_operations_fifo(tmp_path: Path) -> None:
+    coordinator = RecognitionMutationCoordinator(tmp_path)
+    recovered: list[int] = []
+
+    def recover(operation) -> bool:
+        recovered.append(int(operation.payload["index"]))
+        return coordinator.transition(
+            operation.operation_id,
+            "finalized",
+            expected_state="applying",
+        )
+
+    coordinator.register_recovery_handler({"legacy-test"}, recover)
+    for index in range(3):
+        operation_id = coordinator.prepare("legacy-test", {"index": index})
+        assert coordinator.transition(operation_id, "applying", expected_state="prepared")
+
+    assert coordinator.recover_pending()
+    assert recovered == [0, 1, 2]
+
+
+def test_live_mutation_lease_prevents_second_owner_from_recovering_active_work(
+    tmp_path: Path,
+) -> None:
+    active_owner = RecognitionMutationCoordinator(tmp_path)
+    recovery_owner = RecognitionMutationCoordinator(tmp_path)
+    recovery_called = threading.Event()
+
+    def recover(operation) -> bool:
+        recovery_called.set()
+        return recovery_owner.transition(operation.operation_id, "finalized")
+
+    recovery_owner.register_recovery_handler({"people_rename"}, recover)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        with active_owner.mutation_scope():
+            operation_id = active_owner.try_prepare(
+                "people_rename",
+                {"person_id": "person-a"},
+            )
+            assert operation_id is not None
+            recovery = executor.submit(recovery_owner.recover_pending)
+
+            assert not recovery_called.wait(timeout=0.2)
+            assert not recovery.done()
+            active_owner.transition(
+                operation_id,
+                "finalized",
+                expected_state="applying",
+            )
+
+        assert recovery.result(timeout=2.0) is True
+    assert not recovery_called.is_set()
+
+
+def test_mutation_coordinator_unknown_kind_blocks_head(tmp_path: Path) -> None:
+    coordinator = RecognitionMutationCoordinator(tmp_path)
+    operation_id = coordinator.prepare("future-unknown-kind", {})
+    assert coordinator.transition(operation_id, "applying", expected_state="prepared")
+
+    assert not coordinator.recover_pending()
+    head = coordinator.unfinished_head()
+    assert head is not None and head.operation_id == operation_id
+    assert "No recovery handler" in str(coordinator.recovery_error)
+
+
+def test_mutation_coordinator_dispatches_stable_outbox_event(tmp_path: Path) -> None:
+    coordinator = RecognitionMutationCoordinator(tmp_path)
+    operation_id = coordinator.try_prepare(
+        "people_rename",
+        {"person_id": "person-a"},
+    )
+    assert operation_id is not None
+    event_id = coordinator.commit_outbox(operation_id, {"changed": ["person-a"]})
+    delivered = []
+
+    coordinator.subscribe(delivered.append)
+
+    assert [event.event_id for event in delivered] == [event_id]
+    assert delivered[0].operation_id == operation_id
+    assert coordinator.unfinished() == ()
+
+
+def test_dispatch_failure_leaves_committed_event_for_stable_replay(tmp_path: Path) -> None:
+    coordinator = RecognitionMutationCoordinator(tmp_path)
+    operation_id = coordinator.try_prepare(
+        "people_rename",
+        {"person_id": "person-a"},
+    )
+    assert operation_id is not None
+
+    def fail_dispatch() -> None:
+        raise RuntimeError("injected dispatch crash")
+
+    with pytest.raises(RuntimeError, match="injected dispatch crash"):
+        coordinator.commit_and_dispatch(
+            operation_id,
+            {"changed": ["pet-a"]},
+            fail_dispatch,
+        )
+
+    pending = coordinator.pending_events()
+    assert [event.event_id for event in pending] == [operation_id]
+    delivered = []
+    coordinator.subscribe(delivered.append)
+    assert [event.event_id for event in delivered] == [operation_id]
+    assert coordinator.unfinished() == ()


### PR DESCRIPTION
替代 PR #6，supersedes PR #890 中可独立拆分的 Recognition 恢复与并发基础设施。

本 PR 仅包含 Recognition 写入协调，不包含 Detail/Edit 渲染、混合 People/Pets 查询、跨物种合并或 Pets 业务实现：
- 库级 SQLite 操作日志：prepared → applying → committed → finalized
- 原子全局 admission 与 compare-and-set 状态迁移
- 跨 coordinator 实例共享的完整 mutation 生命周期租约
- FIFO 恢复，未知操作在队首安全阻塞
- 稳定 event outbox，派发失败后可重放
- legacy operations/outbox schema 确定性迁移
- Linux/macOS/Windows Recognition 专项合同 job

本地验证：
- `python tools/check_architecture.py`
- `pytest tests/test_recognition_operation_journal.py tests/test_people_service.py tests/test_people_repository.py`（79 passed）
- `ruff check src/iPhoto/recognition`
- `ruff format --check ...`

Pets 对该基础设施的接入将在后续独立替代 PR 完成。