### PR TITLE
Fix PR #890 review blockers and lifecycle races

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, codex/startup-chain-optimization]
   pull_request:
     branches: [main, codex/startup-chain-optimization, codex/pets-review-remediation]
 
@@ -154,6 +154,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -188,6 +189,7 @@ jobs:
           tests/gui/test_startup_orchestrator.py
           tests/gui/test_gui_startup_job_queue.py
           tests/gui/test_startup_import_boundary.py
+          tests/gui/test_startup_shutdown_smoke.py
           tests/test_library_bind_double_scan.py
           tests/test_startup_benchmark.py
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -1,0 +1,214 @@
+# PR #890 延期技术债务台账
+
+更新日期：2026-08-09
+
+## 状态与范围
+
+- 原审查基线：`59c961875a5e337299cf7f2fb1bff59c63b74f93`
+- Bug-only 修复提交：`588682c29f526e9903dd90c32796bb7e3e744fe5`
+- 修复 PR：[#902](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/pull/902)
+- 当前状态：`deferred / not_started`
+
+PR #902 只修复 PR #890 审查项 1–6、9，并补充第 10 项的正常解释器退出
+smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR 的组织方式，以及
+后续分支 promotion 策略均未在该 bugfix PR 中改动。
+
+本台账用于后续独立实施，不得把下列事项误报为 PR #902 已完成。实现时应先取得
+可重复基线，再进行所有权或存储结构调整；不要在没有 profiler、RSS 和 I/O 证据的
+情况下同时重写缓存、RenderSession 和 RAW 解码链路。
+
+## 技术债务总览
+
+| ID | 优先级 | 债务 | 当前风险 | 状态 |
+| --- | --- | --- | --- | --- |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | 大 surface 命中仍完整扫描 payload；每次写入复制整块 RGBA 并全目录排序 | `not_started` |
+| TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | LRU 淘汰不能释放 session 强引用；RAW 中间数组不受最终 surface 预算约束 | `not_started` |
+| TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
+| TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
+| TD-890-05 | P3 | 大型跨子系统 PR 的回滚和归因边界不足 | 历史 PR 无法安全追溯拆分；未来同类变更仍可能形成不可独立回滚的组合 | `process_debt` |
+
+## TD-890-01：磁盘 surface cache 的线性成本
+
+### 当前证据
+
+主要代码位于 `src/iPhoto/gui/detail_surface_cache.py`：
+
+- `NeutralSurfaceStore.load()` 在返回 mmap-backed `QImage` 前对整个 RGBA payload
+  计算 checksum。该校验会读取并预 fault 所有映射页，因此 cache hit 仍为
+  `O(surface_bytes)`。
+- `NeutralSurfaceStore.write()` 使用 `bytes(image.constBits()[...])` 创建完整 payload
+  副本，再写临时文件并原子 replace。写入期间至少多持有一份 surface 大小的
+  Python bytes。
+- 每次成功写入都会调用 `prune()`；`prune()` 遍历、stat 并排序全部
+  `*.ipsurface`，单次写入成本包含 `O(N log N)` 的目录维护。
+- 当前磁盘预算按可用空间的 2% 计算并上限为 2 GiB，但预算只限制最终占用，
+  不限制单次命中、写入和 prune 的延迟或瞬时内存。
+
+### 目标设计
+
+1. 建立持久 metadata index。可使用 SQLite 或具备事务/崩溃恢复语义的 manifest，
+   至少记录 digest、size、last-access、decoder contract 和校验状态。
+2. prune 改为按累计写入字节、时间窗口或超预算水位批量触发；普通单次写入不得
+   全目录扫描和排序。
+3. 保持临时文件 + 原子 replace，改用 buffer protocol、分块写入或其他无完整
+   Python bytes 副本的路径。
+4. 完整 checksum 保留在首次写入、异常恢复、抽样审计或不可信 entry 路径；
+   正常命中策略必须有明确的损坏检测和 decoder-contract 失效协议，不能简单删除
+   完整性校验。
+5. last-access 更新采用批量刷新，避免每次命中的 metadata/fsync 放大。
+
+### 验收门禁
+
+- 新增 cold hit、warm hit、write、prune 的基准，至少覆盖 16 MiB、64 MiB 和接近
+  当前最大 surface 的样例。
+- 普通 cache hit 不再无条件完整扫描 payload；若仍扫描，必须用目标平台数据证明
+  不影响纹理上传关键路径。
+- 单次写入的额外 heap 峰值不随 surface 大小增加一份完整 payload；测试应记录
+  RSS/分配峰值，而不只检查返回值。
+- 未到 prune 水位时，连续写入的目录遍历次数为常数；超预算回收仍满足 LRU 或
+  明确定义的近似 LRU 语义。
+- 覆盖 crash 后临时文件、metadata 与 payload 不一致、checksum 错误、decoder
+  contract 提升和同路径 source revision 更新。
+- Detail cold/warm benchmark 不退化，跨平台 shutdown 不遗留 cache executor 或
+  打开的 mmap/file owner。
+
+## TD-890-02：统一 surface/RAW 内存所有权
+
+### 当前证据
+
+当前至少存在四套相互独立的保留策略：
+
+1. `MappedSurfaceCache` 有 128–512 MiB 的 CPU/mmap LRU 预算。
+2. `PhotoRenderSessionHandle._surfaces_by_key` 强引用该 session 获得过的所有 LOD，
+   没有字节预算；`PlayerViewController` 最多保留三个 session，但只按数量淘汰。
+3. `TextureManager` 和 `RhiImageRenderer` 各自使用固定 192 MiB GPU still residency
+   预算，与 CPU/session 预算没有统一计费或 backpressure。
+4. RAW full decode 会先创建完整 demosaic/RGB ndarray，再转换为 `QImage`，之后才
+   缩放到 target surface；最终 192 MiB 限制不覆盖这些中间数组。
+
+因此 surface 从 `MappedSurfaceCache` 淘汰后，仍可能被 RenderSession、当前
+presentation、pending upload 或 GPU staging 间接保留。当前 `budget_bytes` 不能代表
+进程真实 RSS 上限。
+
+### 目标设计
+
+1. 定义单一的 `SurfaceOwner`/`SurfaceLease` 协议，统一记录 source key、LOD、CPU
+   heap bytes、mmap bytes、upload staging bytes、GPU estimated bytes 和引用 owner。
+2. RenderSession 优先保存 key/lease，不无限强引用所有 `DecodedSurface`。高 LOD
+   成功后，根据当前 viewport、Edit baseline 和回退需求主动释放不再需要的低 LOD。
+3. 将 current、Edit、prefetch、memory cache 和 upload queue 的优先级写入统一
+   eviction policy；正在编辑的 baseline 可以 pin，但 pin 必须计费且有上限。
+4. Library rebind、session eviction、Edit Done/Cancel 和 renderer teardown 必须显式
+   release owner，并可通过诊断快照证明没有旧 library lease。
+5. RAW decoder 在选择 embedded/half/full candidate 前申请中间内存额度。无法满足时
+   应降级到 preview/half-size、tile 或明确失败，不能先分配后再检查最终尺寸。
+6. 物理内存比例、最低/最高值和 GPU 预算应由一个 runtime policy 生成；平台后端
+   可以有不同上限，但不能继续使用互不知情的固定常量。
+
+### 建议的分阶段实现
+
+1. **观测阶段**：只增加 owner/bytes 诊断事件和 benchmark，不改变淘汰行为。
+2. **CPU/session 阶段**：统一 memory cache 与 RenderSession LOD 计费，验证 Edit
+   baseline、Live Photo still restore 和相邻预取行为。
+3. **RAW 阶段**：加入 decode reservation、降级策略和超大 RAW 峰值测试。
+4. **GPU 阶段**：把 GL/QRhi residency 与统一 policy 对接，保留后端自己的资源销毁
+   线程约束。
+
+不要把四个阶段压入一个不可回滚提交。每个阶段都必须保持现有 generation、
+library epoch、source identity 和 Edit handle 生命周期合同。
+
+### 验收门禁
+
+- 构造三个 session、每个包含 preview/2K/4K/full LOD 的压力场景，断言总计费、
+  淘汰顺序和实际 RSS 都在“配置预算 + 明确的 bounded overhead”内。
+- 大 RAW 测试同时记录 demosaic ndarray、QImage、缩放结果和上传 staging 的峰值；
+  不能只断言最终 surface 尺寸。
+- Edit active session 在预算压力下保持 baseline 可恢复；非 active LOD 可回收。
+- Live Motion → still restore、相邻预取、快速切图、切库和关闭应用后，旧 lease 数量
+  归零且不会使用已释放 mmap/GPU resource。
+- GL 和 QRhi 后端执行同一 ownership 合同测试；平台特定 GPU 销毁仍在合法线程。
+- 性能基准证明统一计费没有把 warm Detail 打开或 Edit slider 延迟推离现有门禁。
+
+## TD-890-03：Windows Pets production-shape 合同超时
+
+### 证据
+
+PR #902 的 [GitHub Actions run 31333850127](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31333850127)
+共有 12 个检查：11 个成功，唯一非成功项是
+[`pets-production-shape-contract (windows-latest)`](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31333850127/job/93296293595)。
+
+该 job 在 `tests/contracts/test_pets_scale_contract.py` 的 50k×384 production-shape
+路径运行约 27 分 36 秒后，被 30 分钟 job timeout 注入 `KeyboardInterrupt`；日志为
+`1 skipped in 1656.66s` 和 `The operation was canceled`，没有测试断言失败。相同 run
+中的 Ubuntu/macOS production-shape、Windows startup、Windows Detail 和常规测试均
+成功。PR #902 没有修改 Pets repository 或该合同实现，因此未在 bug-only PR 中通过
+放宽 timeout、缩小数据规模或跳过 Windows 来制造绿灯。
+
+### 后续计划与验收
+
+1. 在 `_benchmark_growth()` 增加分阶段耗时和进度采样，区分 SQLite mutation、
+   USearch add/rebuild、restart、merge/delete 和 RSS probe。
+2. 使用 Windows profiler/ETW 或等价工具确认 50k batch-16 增长的主热点，并与同一
+   runner image 上的 Ubuntu/macOS 结构对比。
+3. 优先修复算法或 I/O 放大；只有在有稳定 P95 数据证明工作量合理且不可再优化时，
+   才单独评估 job timeout。
+4. 不得通过减少 50k、降低 384 维、禁用 USearch/fallback 或把取消标为成功来关闭
+   本项。
+5. 完成标准为三平台 production-shape 在同一 commit SHA 上成功，Windows 至少连续
+   两次低于 job 上限并输出完整 metrics；独立 4 维快速合同继续保留。
+
+## TD-890-04：CI promotion 与分支触发策略
+
+PR #902 当前只保证 `codex/startup-chain-optimization` 阶段的 pull request 和 push
+触发。`edit-base`/`main` 的向前合并、同一或组合 SHA 的重新验证，以及 stacked PR
+解除后的最终 required-check 策略未在本轮修改。
+
+后续应为每个实际 promotion base 明确：
+
+- `pull_request.branches` 匹配 base branch，不把 head branch 写成 base filter；
+- push 后哪些平台合同必须重新运行；
+- stacked PR 合并后以 merge SHA、head SHA 还是发布 artifact SHA 作为证据；
+- required checks 的稳定名称，以及取消/超时是否阻止 promotion；
+- `workflow_dispatch` 只作为补充证据，不能替代正常 PR/push 触发。
+
+完成标准是在 `edit-base` 和最终 `main` promotion 上各取得一次由正常事件触发的完整
+成功 run，并把 run URL、commit SHA 和 artifact/build manifest 对应关系回填到现有
+工程关闭文档。
+
+## TD-890-05：未来大型 PR 的可回滚性
+
+PR #890 历史上同时覆盖 startup、Detail、Edit、Live Photo、Pets、cache、CI 和 legacy
+清理。该历史提交图不在本轮追溯拆分：强制拆分会重新组合已经联调的生命周期合同，
+风险高于当前收益。
+
+未来变更采用前向规则：
+
+- 一个 PR 只拥有一个主要 runtime 生命周期或存储迁移边界；
+- 跨 PR 依赖通过明确 base、handoff 文档和可单独执行的合同测试表达；
+- schema/数据迁移与行为切换提供独立回滚或向前恢复策略；
+- cache、renderer、Edit session 和 startup 不在同一提交中同时更换 owner；
+- PR 正文记录可独立回滚的 commit、风险开关和验证 SHA；
+- stacked PR 的每一层都必须实际触发 CI，不以更高层组合 run 代替底层证据。
+
+此项是工程流程债，不以重写 PR #890 历史为完成条件。后续连续的大型改造按上述规则
+执行并形成可独立回滚记录后，可将状态改为 `adopted`。
+
+## 推荐实施顺序
+
+1. TD-890-01/02 的观测与基线：建立 I/O、延迟、RSS、owner/lease 数据。
+2. TD-890-03：定位 Windows 50k×384 热点，使当前 CI 证据稳定。
+3. TD-890-01：先处理 prune 与写入复制，再评估命中校验策略。
+4. TD-890-02：按 CPU/session → RAW → GPU 顺序迁移统一所有权。
+5. TD-890-04：在向 `edit-base`/`main` promotion 前闭环触发和 required checks。
+6. TD-890-05：作为后续所有大型改造的持续交付规则执行。
+
+## 关闭规则
+
+- 每项只能更新为 `in_progress`、`automated_pass`、`manual_pending` 或附证据的
+  `not_applicable`，不得仅凭“代码已提交”标记完成。
+- benchmark 必须保存平台、物理内存、Python/PySide/Qt、runner image、commit SHA、
+  fixture 规模和原始 metrics。
+- 技术债修复不得削弱 PR #902 已建立的 Live Photo surface、library epoch/token、
+  Edit rebind、startup owner-thread、bounded shutdown 和 stable source identity 回归。
+- 全部自动化和真实平台证据闭环后，再把本文移动到
+  `docs/finished/requirements/`；未完成前保留在当前目录。

--- a/src/iPhoto/bootstrap/gui_startup_job_queue.py
+++ b/src/iPhoto/bootstrap/gui_startup_job_queue.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from PySide6.QtCore import QObject, QTimer, Signal
+from PySide6.QtCore import QObject, QThread, QTimer, Signal, Slot
 
 from .startup_profile import mark
 
@@ -90,10 +90,17 @@ class GuiStartupJobQueue(QObject):
     def wake(self) -> None:
         """Re-check the head job after an external prerequisite changes."""
 
+        self._assert_owner_thread()
         if self._closed or self._scheduled or self._running or not self._jobs:
             return
         self._scheduled = True
         self._scheduler(self._run_one)
+
+    @Slot(int)
+    def wake_for_generation(self, _generation: int) -> None:
+        """Queued signal target used when a worker satisfies a prerequisite."""
+
+        self.wake()
 
     def cancel_generation(self, generation: int) -> None:
         """Invalidate queued and future work for one startup generation."""
@@ -119,6 +126,7 @@ class GuiStartupJobQueue(QObject):
         )
 
     def _run_one(self) -> None:
+        self._assert_owner_thread()
         self._scheduled = False
         if self._closed or self._running:
             return
@@ -190,6 +198,10 @@ class GuiStartupJobQueue(QObject):
                 exception=error,
             )
         )
+
+    def _assert_owner_thread(self) -> None:
+        if QThread.currentThread() is not self.thread():
+            raise RuntimeError("GUI startup jobs must run on their QObject owner thread")
 
 
 __all__ = [

--- a/src/iPhoto/bootstrap/runtime_context.py
+++ b/src/iPhoto/bootstrap/runtime_context.py
@@ -81,6 +81,7 @@ class RuntimeContext:
     translation: "TranslationManager" = field(init=False)
     theme: "ThemeManager" = field(init=False)
     library_session: "LibrarySession | None" = field(init=False, default=None)
+    _library_epoch: int = field(init=False, default=0, repr=False)
     _facade: "AppFacade | None" = field(init=False, default=None, repr=False)
     _asset_runtime: "LibraryAssetRuntime | None" = field(init=False, default=None, repr=False)
     _container: "DependencyContainer | None" = field(
@@ -133,6 +134,12 @@ class RuntimeContext:
             self._facade = _create_facade()
             self._facade.bind_library(self.library)
         return self._facade
+
+    @property
+    def library_epoch(self) -> int:
+        """Monotonic identity for the currently published library binding."""
+
+        return self._library_epoch
 
     @facade.setter
     def facade(self, value: "AppFacade") -> None:
@@ -338,6 +345,8 @@ class RuntimeContext:
                 asset_runtime=self.asset_runtime,
                 bind_asset_runtime=False,
             )
+        # Advance before synchronous bind callbacks publish the new session.
+        self._library_epoch += 1
         bind_library_session = getattr(self.library, "bind_library_session", None)
         used_session_binding = callable(bind_library_session)
         if used_session_binding:
@@ -405,6 +414,11 @@ class RuntimeContext:
     def close_library(self) -> None:
         """Close the active library-scoped session if one exists."""
 
+        session = getattr(self, "library_session", None)
+        if session is not None:
+            # Publish invalidation before synchronous unbind callbacks.
+            self.library_session = None
+            self._library_epoch += 1
         bind_library_session = getattr(self.library, "bind_library_session", None)
         if callable(bind_library_session):
             bind_library_session(None)
@@ -480,11 +494,9 @@ class RuntimeContext:
             if callable(bind_scan_service):
                 bind_scan_service(None)
 
-        session = getattr(self, "library_session", None)
         if session is None:
             return
         session.shutdown()
-        self.library_session = None
 
     def remember_album(self, root: Path) -> None:
         """Track *root* in the recent albums list, keeping the most recent first."""

--- a/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
+++ b/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
@@ -73,6 +73,7 @@ class DesktopCoordinatorRuntime(QObject):
         super().__init__(window)
         self._window = window
         self._context = context
+        self._observed_library_epoch = self._context_library_epoch()
         self._is_shutting_down = False
         self._shutdown_complete = False
         # facade reference kept for signal wiring as some systems still emit through it
@@ -227,6 +228,7 @@ class DesktopCoordinatorRuntime(QObject):
             event_bus=self._event_bus,
             location_write_queue=None,
             edit_service_getter=edit_service_getter,
+            library_epoch_getter=self._context_library_epoch,
         )
 
         # Inject optional dependencies into Playback
@@ -258,7 +260,12 @@ class DesktopCoordinatorRuntime(QObject):
         self._edit: EditCoordinator | None = None
 
         # --- Legacy Controllers ---
-        self._dialog = DialogController(window, context, window.ui.status_bar)
+        self._dialog = DialogController(
+            window,
+            context,
+            window.ui.status_bar,
+            library_rebind_preflight=self._library_rebind_preflight,
+        )
         self._facade.register_restore_prompt(self._dialog.prompt_restore_to_root)
         self._status_bar = StatusBarController(
             window.ui.status_bar,
@@ -383,6 +390,7 @@ class DesktopCoordinatorRuntime(QObject):
             library_root_getter=self._library_root,
             asset_query_service_getter=self._asset_query_service,
             asset_state_service_getter=self._asset_state_service,
+            library_rebind_preflight=self._library_rebind_preflight,
             parent=self,
         )
         self.detail = DetailCoordinator(
@@ -436,6 +444,13 @@ class DesktopCoordinatorRuntime(QObject):
 
     def _enter_edit_mode(self, *args) -> None:
         self._ensure_edit_coordinator().enter_edit_mode(*args)
+
+    def _library_rebind_preflight(self) -> bool:
+        edit = getattr(self, "_edit", None)
+        if edit is None:
+            return True
+        preflight = getattr(edit, "preflight_library_rebind", None)
+        return bool(preflight()) if callable(preflight) else not edit.is_editing()
 
     def _handle_asset_metadata_updated(self, event: AssetMetadataUpdated) -> None:
         asset_path = event.asset_path
@@ -825,8 +840,20 @@ class DesktopCoordinatorRuntime(QObject):
     def _on_library_tree_updated(self) -> None:
         root = self._library_root()
         self._logger.debug("_on_library_tree_updated: root=%s", root)
+        library_epoch = DesktopCoordinatorRuntime._context_library_epoch(self)
+        previous_epoch = getattr(self, "_observed_library_epoch", library_epoch)
+        session_changed = library_epoch != previous_epoch
+        self._observed_library_epoch = library_epoch
+        if session_changed:
+            edit = getattr(self, "_edit", None)
+            invalidate = getattr(edit, "invalidate_library_binding", None)
+            if callable(invalidate):
+                invalidate()
         self.gallery.rebind_library()
-        self.detail.rebind_library()
+        self.detail.rebind_library(
+            library_epoch,
+            session_changed=session_changed,
+        )
         window = getattr(self, "_window", None)
         ui = getattr(window, "ui", None)
         map_feature_active = ui is not None and hasattr(ui, "map_view")
@@ -851,6 +878,14 @@ class DesktopCoordinatorRuntime(QObject):
 
     def _active_session(self):
         return getattr(self._context, "library_session", None)
+
+    def _context_library_epoch(self) -> int:
+        value = getattr(self._context, "library_epoch", 0)
+        if isinstance(value, bool):
+            return int(value)
+        if not isinstance(value, int):
+            return 0
+        return max(0, value)
 
     def _library_root(self) -> Path | None:
         session = self._active_session()

--- a/src/iPhoto/gui/coordinators/detail_coordinator.py
+++ b/src/iPhoto/gui/coordinators/detail_coordinator.py
@@ -37,11 +37,16 @@ class DetailCoordinator(QObject):
     def reset_for_gallery(self) -> None:
         self._playback.reset_for_gallery()
 
-    def rebind_library(self) -> None:
+    def rebind_library(
+        self,
+        library_epoch: int | None = None,
+        *,
+        session_changed: bool = True,
+    ) -> None:
         """Rebind Detail state without touching optional recognition/location domains."""
         rebind_playback = getattr(self._playback, "rebind_library", None)
         if callable(rebind_playback):
-            rebind_playback()
+            rebind_playback(library_epoch, session_changed=session_changed)
         if self._detail_viewmodel is None or self._asset_state_service_getter is None:
             return
         self._detail_viewmodel.bind_asset_state_service(

--- a/src/iPhoto/gui/coordinators/edit_coordinator.py
+++ b/src/iPhoto/gui/coordinators/edit_coordinator.py
@@ -309,6 +309,20 @@ class EditCoordinator(QObject):
 
         return self._session is not None
 
+    def preflight_library_rebind(self) -> bool:
+        """Refuse a user-initiated library switch while edits are unresolved."""
+
+        return self._session is None
+
+    def invalidate_library_binding(self) -> None:
+        """Safely abandon Edit before an unexpected session invalidates its handle."""
+
+        if self._session is not None:
+            self.leave_edit_mode(
+                restore_reason="library_invalidated",
+                restore_detail=False,
+            )
+
     # ------------------------------------------------------------------
     # Public transport API (used by AppShortcutManager)
     # ------------------------------------------------------------------
@@ -492,7 +506,12 @@ class EditCoordinator(QObject):
             self._ui.edit_sidebar.set_light_preview_image(result.image, color_stats=result.stats)
             self._ui.edit_sidebar.refresh()
 
-    def leave_edit_mode(self, *, restore_reason: str = "edit_exit"):
+    def leave_edit_mode(
+        self,
+        *,
+        restore_reason: str = "edit_exit",
+        restore_detail: bool = True,
+    ):
         """Returns to detail view."""
         source = self._current_source
         is_video_source = (
@@ -500,7 +519,8 @@ class EditCoordinator(QObject):
             and source.suffix.lower() in VIDEO_EXTENSIONS
         )
         should_restore_detail = (
-            source is not None
+            restore_detail
+            and source is not None
             and self._media_session is not None
         )
         _LOGGER.debug(
@@ -574,7 +594,7 @@ class EditCoordinator(QObject):
                     duration_sec=pending_duration_sec if is_video_source else None,
                 )
             )
-        elif source is not None and not is_video_source:
+        elif should_restore_detail and source is not None and not is_video_source:
             try:
                 self.stillEditFinished.emit(source, restore_reason)
             except RuntimeError:

--- a/src/iPhoto/gui/coordinators/gallery_coordinator.py
+++ b/src/iPhoto/gui/coordinators/gallery_coordinator.py
@@ -24,6 +24,7 @@ class GalleryCoordinator(QObject):
         library_root_getter: Callable[[], Path | None] | None = None,
         asset_query_service_getter: Callable[[], object | None] | None = None,
         asset_state_service_getter: Callable[[], object | None] | None = None,
+        library_rebind_preflight: Callable[[], bool] | None = None,
         rebind_library: Callable[[], None] | None = None,
         parent: QObject | None = None,
     ) -> None:
@@ -36,6 +37,7 @@ class GalleryCoordinator(QObject):
         self._library_root_getter = library_root_getter
         self._asset_query_service_getter = asset_query_service_getter
         self._asset_state_service_getter = asset_state_service_getter
+        self._library_rebind_preflight = library_rebind_preflight
         self._legacy_rebind_library = rebind_library
 
     @property
@@ -90,6 +92,12 @@ class GalleryCoordinator(QObject):
         open_library = getattr(self._context, "open_library", None)
         if not callable(open_library):
             return True
+        preflight = getattr(self, "_library_rebind_preflight", None)
+        if preflight is not None and not preflight():
+            self._facade.errorRaised.emit(
+                "Finish the current edit with Done or Cancel before switching libraries."
+            )
+            return False
         try:
             open_library(path)
         except Exception as exc:  # noqa: BLE001 - GUI error boundary

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -32,6 +32,7 @@ from iPhoto.gui.detail_pipeline import (
     AssetSourceIdentity,
     DetailPrefetchDescriptor,
     DetailRenderTransaction,
+    PlaybackAsyncToken,
     VideoPresentationState,
 )
 from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
@@ -138,8 +139,8 @@ class _RecognitionOverlayWorker(QRunnable):
 
 
 class _VideoPreparationSignals(QObject):
-    ready = Signal(int, object)
-    failed = Signal(int, Path, object)
+    ready = Signal(object, object)
+    failed = Signal(object, object)
 
 
 class _VideoPreparationWorker(QRunnable):
@@ -149,11 +150,13 @@ class _VideoPreparationWorker(QRunnable):
         self,
         *,
         presentation: DetailPresentation,
+        token: PlaybackAsyncToken,
         edit_service_getter: Callable[[], EditServicePort | None] | None,
         signals: _VideoPreparationSignals,
     ) -> None:
         super().__init__()
         self._presentation = presentation
+        self._token = token
         self._edit_service_getter = edit_service_getter
         self._signals = signals
 
@@ -212,27 +215,26 @@ class _VideoPreparationWorker(QRunnable):
                 linux_180_hint=linux_hint,
             )
         except Exception as exc:  # noqa: BLE001 - codec/sidecar boundary
-            self._signals.failed.emit(generation, presentation.path, exc)
+            self._signals.failed.emit(self._token, exc)
             return
-        self._signals.ready.emit(generation, state)
+        self._signals.ready.emit(self._token, state)
 
 
 class _DeferredLocationSignals(QObject):
-    ready = Signal(int, Path, str)
+    ready = Signal(object, str)
 
 
 class _DeferredLocationWorker(QRunnable):
-    def __init__(self, generation: int, path: Path, gps: dict, signals) -> None:
+    def __init__(self, token: PlaybackAsyncToken, gps: dict, signals) -> None:
         super().__init__()
-        self._generation = generation
-        self._path = path
+        self._token = token
         self._gps = dict(gps)
         self._signals = signals
 
     def run(self) -> None:  # pragma: no cover - worker thread
         location = resolve_location_name(self._gps)
         if location:
-            self._signals.ready.emit(self._generation, self._path, location)
+            self._signals.ready.emit(self._token, location)
 
 
 class PlaybackCoordinator(QObject):
@@ -271,6 +273,7 @@ class PlaybackCoordinator(QObject):
         event_bus: EventBus | None = None,
         location_write_queue: LocationFileWriteQueue | None = None,
         edit_service_getter: Callable[[], EditServicePort | None] | None = None,
+        library_epoch_getter: Callable[[], int] | None = None,
     ) -> None:
         super().__init__()
         self._player_bar = player_bar
@@ -315,6 +318,12 @@ class PlaybackCoordinator(QObject):
         self._event_bus = event_bus
         self._location_write_queue = location_write_queue
         self._edit_service_getter = edit_service_getter
+        self._library_epoch_getter = library_epoch_getter
+        self._library_epoch = self._read_library_epoch()
+        self._asset_generation = 0
+        self._active_async_token: PlaybackAsyncToken | None = None
+        self._pending_video_token: PlaybackAsyncToken | None = None
+        self._pending_location_token: PlaybackAsyncToken | None = None
 
         self._is_playing = False
         self._navigation: NavigationCoordinator | None = None
@@ -418,9 +427,28 @@ class PlaybackCoordinator(QObject):
     def set_recognition_merge_service(self, service: object | None) -> None:
         self._recognition_merge_service = service
 
-    def rebind_library(self) -> None:
+    def rebind_library(
+        self,
+        library_epoch: int | None = None,
+        *,
+        session_changed: bool = True,
+    ) -> None:
         """Invalidate library-scoped media preparation and decoded-frame caches."""
 
+        if not session_changed:
+            return
+        self._library_epoch = (
+            self._read_library_epoch()
+            if library_epoch is None
+            else max(0, int(library_epoch))
+        )
+        self._asset_generation = int(getattr(self, "_asset_generation", 0)) + 1
+        self._detail_request_generation = int(
+            getattr(self, "_detail_request_generation", 0)
+        ) + 1
+        self._active_async_token = None
+        self._pending_video_token = None
+        self._pending_location_token = None
         self._invalidate_overlay_requests(clear=True)
         for pool_name in ("_video_prepare_pool", "_deferred_location_pool"):
             pool = getattr(self, pool_name, None)
@@ -429,9 +457,86 @@ class PlaybackCoordinator(QObject):
         deferred_locations = getattr(self, "_deferred_locations", None)
         if deferred_locations is not None:
             deferred_locations.clear()
+        render_coordinator = self._render_transaction_coordinator()
+        render_coordinator.reset()
+        self._detail_render_transaction = None
+        self._current_presentation = None
+        self._active_live_motion = None
+        self._active_live_still = None
+        self._active_live_asset_id = ""
+        self._presented_still_generation = 0
+        self._presented_still_source = None
+        video_area = self._player_view.video_area
+        video_area.stop()
+        self._player_view.defer_still_updates(False)
+        cancel_stills = getattr(self._player_view, "cancel_pending_image_requests", None)
+        if callable(cancel_stills):
+            cancel_stills()
         clear_frames = getattr(self._player_view, "clear_frame_cache", None)
         if callable(clear_frames):
             clear_frames()
+        self._player_view.show_placeholder()
+        self._player_bar.setEnabled(False)
+        self._is_playing = False
+        self._update_header(None)
+        info_panel = getattr(self, "_info_panel", None)
+        if info_panel is not None:
+            info_panel.close()
+        self._clear_info_panel_metadata_state()
+        self._clear_confirmed_location_metadata()
+
+    def _read_library_epoch(self) -> int:
+        getter = getattr(self, "_library_epoch_getter", None)
+        if getter is None:
+            return max(0, int(getattr(self, "_library_epoch", 0)))
+        try:
+            return max(0, int(getter()))
+        except (TypeError, ValueError):
+            return max(0, int(getattr(self, "_library_epoch", 0)))
+
+    def _token_for_presentation(
+        self,
+        presentation: DetailPresentation,
+    ) -> PlaybackAsyncToken:
+        identity = presentation.source_identity
+        if identity is None or identity.path != presentation.path:
+            identity = AssetSourceIdentity.from_info(
+                presentation.path,
+                presentation.info if identity is None else None,
+            )
+        return PlaybackAsyncToken.create(
+            library_epoch=int(getattr(self, "_library_epoch", 0)),
+            asset_generation=int(getattr(self, "_asset_generation", 0)),
+            asset_id=presentation.asset_id,
+            source_identity=identity,
+        )
+
+    def _async_token_is_current(
+        self,
+        token: object,
+        *,
+        expected_path: Path | None = None,
+    ) -> bool:
+        if not isinstance(token, PlaybackAsyncToken):
+            return False
+        active = getattr(self, "_active_async_token", None)
+        if active is None:
+            return False
+        if self._read_library_epoch() != int(getattr(self, "_library_epoch", -1)):
+            return False
+        if token.library_epoch != active.library_epoch:
+            return False
+        if token.asset_generation != active.asset_generation:
+            return False
+        if token.asset_id != active.asset_id:
+            return False
+        if expected_path is not None and token.source_path != Path(expected_path):
+            return False
+        if token.source_path == active.source_path and (
+            token.source_revision != active.source_revision
+        ):
+            return False
+        return True
 
     def set_info_panel(self, panel: InfoPanel) -> None:
         self._info_panel = panel
@@ -867,6 +972,11 @@ class PlaybackCoordinator(QObject):
             source_identity=identity,
         )
         self._detail_render_transaction = transaction
+        self._asset_generation = int(getattr(self, "_asset_generation", 0)) + 1
+        self._library_epoch = self._read_library_epoch()
+        self._active_async_token = self._token_for_presentation(presentation)
+        self._pending_video_token = None
+        self._pending_location_token = None
         self._render_transaction_coordinator().begin(transaction)
         self._select_filmstrip_row(row)
         self._player_view.show_placeholder("")
@@ -879,19 +989,23 @@ class PlaybackCoordinator(QObject):
         # paints before decoding, sidecar reads or media backend preparation.
         QTimer.singleShot(
             0,
-            lambda candidate=presentation, generation=self._detail_request_generation:
-            self._render_if_current(candidate, generation),
+            lambda candidate=presentation, generation=self._detail_request_generation,
+            token=self._active_async_token:
+            self._render_if_current(candidate, generation, token),
         )
 
     def _render_if_current(
         self,
         presentation: DetailPresentation,
         generation: int,
+        token: PlaybackAsyncToken | None = None,
     ) -> None:
         if generation != self._detail_request_generation:
             return
         current = self._current_presentation
         if current is None or current.path != presentation.path:
+            return
+        if token is not None and token != getattr(self, "_active_async_token", None):
             return
         if not self._render_transaction_coordinator().mark_routed(
             generation,
@@ -1065,22 +1179,25 @@ class PlaybackCoordinator(QObject):
         self._deferred_location_pool.clear()
         self._deferred_location_pool.start(
             _DeferredLocationWorker(
-                presentation.request_generation,
-                presentation.path,
+                self._active_async_token,
                 gps,
                 self._deferred_location_signals,
             )
         )
+        self._pending_location_token = self._active_async_token
 
-    @Slot(int, Path, str)
+    @Slot(object, str)
     def _on_deferred_location_ready(
         self,
-        generation: int,
-        path: Path,
+        token: object,
         location: str,
     ) -> None:
-        if generation != getattr(self, "_detail_request_generation", 0):
+        if token != getattr(self, "_pending_location_token", None):
             return
+        if not self._async_token_is_current(token):
+            return
+        self._pending_location_token = None
+        path = token.source_path
         presentation = getattr(self, "_current_presentation", None)
         if presentation is None or presentation.path != path:
             return
@@ -1094,32 +1211,41 @@ class PlaybackCoordinator(QObject):
         self._update_header(presentation)
 
     def _schedule_video_preparation(self, presentation: DetailPresentation) -> None:
+        token = self._token_for_presentation(presentation)
+        self._pending_video_token = token
         self._video_prepare_pool.clear()
         self._video_prepare_pool.start(
             _VideoPreparationWorker(
                 presentation=presentation,
+                token=token,
                 edit_service_getter=self._edit_service_getter,
                 signals=self._video_prepare_signals,
             )
         )
 
-    @Slot(int, object)
+    @Slot(object, object)
     def _on_video_preparation_ready(
         self,
-        generation: int,
+        token: object,
         state: object,
     ) -> None:
-        if generation != getattr(self, "_detail_request_generation", 0):
+        if token != getattr(self, "_pending_video_token", None):
             return
         presentation = getattr(self, "_current_presentation", None)
         is_live_motion = bool(getattr(self, "_active_live_motion", None))
         if presentation is None or (not presentation.is_video and not is_live_motion):
             return
+        expected_path = (
+            self._active_live_motion if is_live_motion else presentation.path
+        )
+        if not self._async_token_is_current(token, expected_path=expected_path):
+            return
         if not isinstance(state, VideoPresentationState):
             return
         transaction = self._detail_render_transaction
-        if transaction is None or transaction.generation != generation:
+        if transaction is None or transaction.generation != state.request_generation:
             return
+        self._pending_video_token = None
         state = replace(state, transaction=transaction)
         if not self._player_view.video_area.commit_presentation(state):
             return
@@ -1130,15 +1256,22 @@ class PlaybackCoordinator(QObject):
             self._trim_out_ms = 0
         self._player_view.video_area.play()
 
-    @Slot(int, Path, object)
+    @Slot(object, object)
     def _on_video_preparation_failed(
         self,
-        generation: int,
-        source: Path,
+        token: object,
         error: object,
     ) -> None:
-        if generation != getattr(self, "_detail_request_generation", 0):
+        if token != getattr(self, "_pending_video_token", None):
             return
+        if not self._async_token_is_current(token):
+            return
+        self._pending_video_token = None
+        transaction = getattr(self, "_detail_render_transaction", None)
+        if transaction is None:
+            return
+        generation = transaction.generation
+        source = token.source_path
         self._render_transaction_coordinator().mark_failed(generation, str(error))
         self._player_view.video_area.stop()
         self._player_view.show_placeholder(
@@ -1154,7 +1287,11 @@ class PlaybackCoordinator(QObject):
         is_live_motion = bool(getattr(self, "_active_live_motion", None))
         if presentation is None or (not presentation.is_video and not is_live_motion):
             return
-        if not self._render_transaction_coordinator().mark_presented(generation):
+        surface_kind = "live_motion_frame" if is_live_motion else "video_frame"
+        if not self._render_transaction_coordinator().mark_surface_presented(
+            generation,
+            surface_kind,
+        ):
             return
         self._player_view.show_video_surface(interactive=not is_live_motion)
         # Do not reclaim the user's scroll position when decoding completes.
@@ -1228,20 +1365,26 @@ class PlaybackCoordinator(QObject):
             return
         still = self._active_live_still
         asset_id = self._active_live_asset_id
+        transaction = getattr(self, "_detail_render_transaction", None)
         self._active_live_motion = None
         self._active_live_asset_id = ""
         self._player_view.defer_still_updates(False)
         if not self._player_view.apply_pending_still():
-            presentation = getattr(self, "_current_presentation", None)
-            kwargs = {}
-            if presentation is not None and presentation.path == still:
-                kwargs["source_identity"] = presentation.source_identity
-            self._player_view.display_image(still, asset_id=asset_id, **kwargs)
+            if (
+                transaction is not None
+                and transaction.media_kind == "live_motion"
+                and transaction.source_identity.path == still
+                and self._render_transaction_coordinator().owns_generation(
+                    transaction.generation
+                )
+            ):
+                self._player_view.display_image(still, transaction=transaction)
+            else:
+                self._player_view.display_image(still, asset_id=asset_id)
         self._player_bar.setEnabled(False)
         self._player_view.show_live_badge()
         self._player_view.set_live_replay_enabled(True)
         self._is_playing = False
-        self._refresh_face_name_overlay_for_current_presentation()
 
     def _hide_face_name_overlay(self, *, clear_annotations: bool) -> None:
         overlay = getattr(self, "_face_name_overlay", None)
@@ -1274,7 +1417,23 @@ class PlaybackCoordinator(QObject):
             return
         if getattr(self, "_active_live_motion", None):
             return
-        if not self._render_transaction_coordinator().mark_presented(int(generation)):
+        transaction = getattr(self, "_detail_render_transaction", None)
+        if (
+            transaction is None
+            or transaction.generation != int(generation)
+            or transaction.source_identity.path != presented_source
+            or not self._render_transaction_coordinator().owns_generation(
+                int(generation)
+            )
+        ):
+            return
+        surface_kind = (
+            "live_still" if transaction.media_kind == "live_motion" else "still"
+        )
+        if not self._render_transaction_coordinator().mark_surface_presented(
+            int(generation),
+            surface_kind,
+        ):
             return
         self._presented_still_source = presented_source
         self._presented_still_generation = int(generation)

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -36,7 +36,10 @@ from iPhoto.gui.detail_pipeline import (
     VideoPresentationState,
 )
 from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
-from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator
+from iPhoto.gui.detail_render_coordinator import (
+    DetailRenderCoordinator,
+    DetailSurfacePresentationResult,
+)
 from iPhoto.gui.i18n import tr
 from iPhoto.gui.ui.controllers.edit_zoom_handler import EditZoomHandler
 from iPhoto.gui.ui.controllers.header_controller import HeaderController
@@ -1288,10 +1291,11 @@ class PlaybackCoordinator(QObject):
         if presentation is None or (not presentation.is_video and not is_live_motion):
             return
         surface_kind = "live_motion_frame" if is_live_motion else "video_frame"
-        if not self._render_transaction_coordinator().mark_surface_presented(
+        result = self._render_transaction_coordinator().mark_surface_presented(
             generation,
             surface_kind,
-        ):
+        )
+        if result is DetailSurfacePresentationResult.REJECTED_STALE:
             return
         self._player_view.show_video_surface(interactive=not is_live_motion)
         # Do not reclaim the user's scroll position when decoding completes.
@@ -1430,10 +1434,11 @@ class PlaybackCoordinator(QObject):
         surface_kind = (
             "live_still" if transaction.media_kind == "live_motion" else "still"
         )
-        if not self._render_transaction_coordinator().mark_surface_presented(
+        result = self._render_transaction_coordinator().mark_surface_presented(
             int(generation),
             surface_kind,
-        ):
+        )
+        if result is DetailSurfacePresentationResult.REJECTED_STALE:
             return
         self._presented_still_source = presented_source
         self._presented_still_generation = int(generation)

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -1275,6 +1275,25 @@ class PlaybackCoordinator(QObject):
             return
         generation = transaction.generation
         source = token.source_path
+        active_live_motion = getattr(self, "_active_live_motion", None)
+        if (
+            transaction.media_kind == "live_motion"
+            and active_live_motion is not None
+            and Path(active_live_motion) == source
+            and self._restore_live_still(stop_motion=True)
+        ):
+            emit_detail_event(
+                "live_motion_failed",
+                generation=generation,
+                asset_id=transaction.asset_id,
+                message=str(error),
+            )
+            LOGGER.warning(
+                "Live Motion preparation failed for %s; restored still: %s",
+                source.name,
+                error,
+            )
+            return
         self._render_transaction_coordinator().mark_failed(generation, str(error))
         self._player_view.video_area.stop()
         self._player_view.show_placeholder(
@@ -1364,12 +1383,16 @@ class PlaybackCoordinator(QObject):
         self._player_bar.setEnabled(False)
         self._is_playing = True
 
-    def _handle_playback_finished(self) -> None:
+    def _restore_live_still(self, *, stop_motion: bool = False) -> bool:
+        """End one Live Motion attempt and restore its primary still asset."""
+
         if not self._active_live_motion or not self._active_live_still:
-            return
+            return False
         still = self._active_live_still
         asset_id = self._active_live_asset_id
         transaction = getattr(self, "_detail_render_transaction", None)
+        if stop_motion:
+            self._player_view.video_area.stop()
         self._active_live_motion = None
         self._active_live_asset_id = ""
         self._player_view.defer_still_updates(False)
@@ -1389,6 +1412,10 @@ class PlaybackCoordinator(QObject):
         self._player_view.show_live_badge()
         self._player_view.set_live_replay_enabled(True)
         self._is_playing = False
+        return True
+
+    def _handle_playback_finished(self) -> None:
+        self._restore_live_still()
 
     def _hide_face_name_overlay(self, *, clear_annotations: bool) -> None:
         overlay = getattr(self, "_face_name_overlay", None)

--- a/src/iPhoto/gui/detail_pipeline.py
+++ b/src/iPhoto/gui/detail_pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Literal
@@ -75,6 +75,58 @@ class AssetSourceIdentity:
         if self.index_revision > 0:
             return ("index", self.size_bytes, self.index_revision)
         return ("legacy", self.size_bytes, 0)
+
+    @property
+    def has_stable_revision(self) -> bool:
+        """Whether this identity can safely participate in a reusable cache."""
+
+        return self.source_mtime_ns > 0 or self.index_revision > 0
+
+    def repair_revision_from_stat(self) -> AssetSourceIdentity:
+        """Repair an unversioned identity from a worker-thread stat call."""
+
+        if self.has_stable_revision:
+            return self
+        try:
+            source_stat = self.path.stat()
+        except OSError:
+            return self
+        mtime_ns = max(0, int(getattr(source_stat, "st_mtime_ns", 0) or 0))
+        if mtime_ns <= 0:
+            return self
+        return replace(
+            self,
+            size_bytes=max(0, int(source_stat.st_size)),
+            source_mtime_ns=mtime_ns,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PlaybackAsyncToken:
+    """Complete delivery identity for library-scoped playback work."""
+
+    library_epoch: int
+    asset_generation: int
+    asset_id: str
+    source_path: Path
+    source_revision: tuple[str, int, int]
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        library_epoch: int,
+        asset_generation: int,
+        asset_id: str,
+        source_identity: AssetSourceIdentity,
+    ) -> PlaybackAsyncToken:
+        return cls(
+            library_epoch=max(0, int(library_epoch)),
+            asset_generation=max(0, int(asset_generation)),
+            asset_id=str(asset_id).strip() or source_identity.path.name,
+            source_path=source_identity.path,
+            source_revision=source_identity.revision,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -391,6 +443,7 @@ __all__ = [
     "DetailMediaPreparation",
     "DetailOpenTrace",
     "DetailPrefetchDescriptor",
+    "PlaybackAsyncToken",
     "DetailRenderTransaction",
     "DetailRenderRequest",
     "DetailResidencySlot",

--- a/src/iPhoto/gui/detail_render_coordinator.py
+++ b/src/iPhoto/gui/detail_render_coordinator.py
@@ -30,6 +30,14 @@ _TERMINAL_STATES = {
 DetailSurfaceKind = Literal["still", "video_frame", "live_motion_frame", "live_still"]
 
 
+class DetailSurfacePresentationResult(str, Enum):
+    """Classify lifecycle bookkeeping for one visible surface delivery."""
+
+    REJECTED_STALE = "rejected_stale"
+    NEW_SURFACE = "new_surface"
+    DUPLICATE_CURRENT_SURFACE = "duplicate_current_surface"
+
+
 @dataclass(frozen=True, slots=True)
 class DetailRenderSnapshot:
     transaction: DetailRenderTransaction
@@ -96,21 +104,28 @@ class DetailRenderCoordinator(QObject):
         self,
         generation: int,
         surface_kind: DetailSurfaceKind,
-    ) -> bool:
+    ) -> DetailSurfacePresentationResult:
         """Record one visible surface while keeping one terminal transaction."""
 
         snapshot = self._snapshot
         if snapshot is None or snapshot.transaction.generation != int(generation):
-            return False
+            return DetailSurfacePresentationResult.REJECTED_STALE
         if snapshot.state in {DetailRenderState.FAILED, DetailRenderState.CANCELLED}:
-            return False
+            return DetailSurfacePresentationResult.REJECTED_STALE
+        allowed_surfaces = {
+            "image": {"still"},
+            "video": {"video_frame"},
+            "live_motion": {"live_motion_frame", "live_still"},
+        }.get(snapshot.transaction.media_kind, set())
+        if surface_kind not in allowed_surfaces:
+            return DetailSurfacePresentationResult.REJECTED_STALE
         if surface_kind in snapshot.presented_surfaces:
-            return False
+            return DetailSurfacePresentationResult.DUPLICATE_CURRENT_SURFACE
         if snapshot.state is DetailRenderState.PRESENTED and (
             snapshot.transaction.media_kind != "live_motion"
             or surface_kind not in {"live_motion_frame", "live_still"}
         ):
-            return False
+            return DetailSurfacePresentationResult.REJECTED_STALE
         self._snapshot = DetailRenderSnapshot(
             transaction=snapshot.transaction,
             state=snapshot.state,
@@ -125,11 +140,11 @@ class DetailRenderCoordinator(QObject):
         )
         if snapshot.state is not DetailRenderState.PRESENTED:
             if not self.mark_presented(generation):
-                return False
+                return DetailSurfacePresentationResult.REJECTED_STALE
         current = self._snapshot
         if current is not None:
             self.surfacePresented.emit(current, surface_kind)
-        return True
+        return DetailSurfacePresentationResult.NEW_SURFACE
 
     def mark_routed(self, generation: int, *, row: int) -> bool:
         if not self._can_transition(generation, {DetailRenderState.CREATED}):
@@ -237,4 +252,5 @@ __all__ = [
     "DetailRenderSnapshot",
     "DetailRenderState",
     "DetailSurfaceKind",
+    "DetailSurfacePresentationResult",
 ]

--- a/src/iPhoto/gui/detail_render_coordinator.py
+++ b/src/iPhoto/gui/detail_render_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Literal
 
 from PySide6.QtCore import QObject, Signal
 
@@ -26,12 +27,15 @@ _TERMINAL_STATES = {
     DetailRenderState.CANCELLED,
 }
 
+DetailSurfaceKind = Literal["still", "video_frame", "live_motion_frame", "live_still"]
+
 
 @dataclass(frozen=True, slots=True)
 class DetailRenderSnapshot:
     transaction: DetailRenderTransaction
     state: DetailRenderState
     message: str = ""
+    presented_surfaces: tuple[DetailSurfaceKind, ...] = ()
 
 
 class DetailRenderCoordinator(QObject):
@@ -41,6 +45,7 @@ class DetailRenderCoordinator(QObject):
     presented = Signal(object)
     failed = Signal(object)
     cancelled = Signal(object)
+    surfacePresented = Signal(object, str)
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -63,17 +68,67 @@ class DetailRenderCoordinator(QObject):
             and snapshot.state not in _TERMINAL_STATES
         )
 
+    def owns_generation(self, generation: int) -> bool:
+        """Return whether the transaction still owns follow-on surface delivery."""
+
+        snapshot = self._snapshot
+        return bool(
+            snapshot is not None
+            and snapshot.transaction.generation == int(generation)
+            and snapshot.state
+            not in {DetailRenderState.FAILED, DetailRenderState.CANCELLED}
+        )
+
     def begin(self, transaction: DetailRenderTransaction) -> bool:
         if transaction.generation <= 0:
             raise ValueError("Detail render transaction generation must be positive")
         current = self._snapshot
         if current is not None:
-            if current.transaction == transaction and current.state not in _TERMINAL_STATES:
+            if current.transaction == transaction:
                 return False
             if current.state not in _TERMINAL_STATES:
                 self._transition(DetailRenderState.CANCELLED)
         self._snapshot = DetailRenderSnapshot(transaction, DetailRenderState.CREATED)
         self.stateChanged.emit(self._snapshot)
+        return True
+
+    def mark_surface_presented(
+        self,
+        generation: int,
+        surface_kind: DetailSurfaceKind,
+    ) -> bool:
+        """Record one visible surface while keeping one terminal transaction."""
+
+        snapshot = self._snapshot
+        if snapshot is None or snapshot.transaction.generation != int(generation):
+            return False
+        if snapshot.state in {DetailRenderState.FAILED, DetailRenderState.CANCELLED}:
+            return False
+        if surface_kind in snapshot.presented_surfaces:
+            return False
+        if snapshot.state is DetailRenderState.PRESENTED and (
+            snapshot.transaction.media_kind != "live_motion"
+            or surface_kind not in {"live_motion_frame", "live_still"}
+        ):
+            return False
+        self._snapshot = DetailRenderSnapshot(
+            transaction=snapshot.transaction,
+            state=snapshot.state,
+            message=snapshot.message,
+            presented_surfaces=(*snapshot.presented_surfaces, surface_kind),
+        )
+        emit_detail_event(
+            "surface_presented",
+            generation=int(generation),
+            media_type=snapshot.transaction.media_kind,
+            surface_kind=surface_kind,
+        )
+        if snapshot.state is not DetailRenderState.PRESENTED:
+            if not self.mark_presented(generation):
+                return False
+        current = self._snapshot
+        if current is not None:
+            self.surfacePresented.emit(current, surface_kind)
         return True
 
     def mark_routed(self, generation: int, *, row: int) -> bool:
@@ -137,6 +192,12 @@ class DetailRenderCoordinator(QObject):
         self._transition(DetailRenderState.CANCELLED)
         return True
 
+    def reset(self) -> None:
+        """Forget the active transaction after invalidating any live work."""
+
+        self.cancel_current()
+        self._snapshot = None
+
     def _can_transition(
         self,
         generation: int,
@@ -153,7 +214,12 @@ class DetailRenderCoordinator(QObject):
         snapshot = self._snapshot
         if snapshot is None:
             return
-        self._snapshot = DetailRenderSnapshot(snapshot.transaction, state, message)
+        self._snapshot = DetailRenderSnapshot(
+            snapshot.transaction,
+            state,
+            message,
+            snapshot.presented_surfaces,
+        )
         emit = {
             DetailRenderState.PRESENTED: self.presented,
             DetailRenderState.FAILED: self.failed,
@@ -170,4 +236,5 @@ __all__ = [
     "DetailRenderCoordinator",
     "DetailRenderSnapshot",
     "DetailRenderState",
+    "DetailSurfaceKind",
 ]

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -96,6 +96,8 @@ class MappedSurfaceCache:
             return self._used_bytes
 
     def get(self, key: DetailDecodeKey) -> DecodedSurface | None:
+        if key.source_revision[0] == "legacy":
+            return None
         with self._lock:
             value = self._entries.pop(key, None)
             if value is None:
@@ -106,7 +108,12 @@ class MappedSurfaceCache:
 
     def put(self, surface: DecodedSurface) -> bool:
         size = _surface_bytes(surface)
-        if surface.image.isNull() or size <= 0 or size > self._budget_bytes:
+        if (
+            surface.decode_key.source_revision[0] == "legacy"
+            or surface.image.isNull()
+            or size <= 0
+            or size > self._budget_bytes
+        ):
             return False
         with self._lock:
             previous = self._entries.pop(surface.decode_key, None)
@@ -179,6 +186,8 @@ class NeutralSurfaceStore:
             self._root = root
 
     def entry_path(self, request: DetailRenderRequest) -> Path | None:
+        if not request.source_identity.has_stable_revision:
+            return None
         root = self.root
         if root is None:
             return None
@@ -412,19 +421,21 @@ class CachedStillDecodeBackend:
     def decode(self, request: DetailRenderRequest, cancellation: CancellationToken) -> DecodedSurface:
         prepared = request.with_decode_level()
         key = DetailDecodeKey.from_request(prepared)
+        cacheable = prepared.source_identity.has_stable_revision
         if cancellation.is_cancelled():
             raise DecodeCancelledError("Still-image decode cancelled")
-        surface = self.memory_cache.get(key)
+        surface = self.memory_cache.get(key) if cacheable else None
         if surface is not None:
             self._remember_color_stats(prepared, surface.color_stats)
             emit_detail_event("surface_cache_hit", generation=prepared.generation, asset_id=key.asset_id, tier="memory")
             return surface
-        try:
-            surface = self.store.load(prepared)
-        except SurfaceCacheCorruptError:
-            emit_detail_event("surface_cache_corrupt", generation=prepared.generation, asset_id=key.asset_id)
-            self._submit(self.store.discard, prepared)
-            surface = None
+        if cacheable:
+            try:
+                surface = self.store.load(prepared)
+            except SurfaceCacheCorruptError:
+                emit_detail_event("surface_cache_corrupt", generation=prepared.generation, asset_id=key.asset_id)
+                self._submit(self.store.discard, prepared)
+                surface = None
         if surface is not None:
             if cancellation.is_cancelled():
                 raise DecodeCancelledError("Still-image decode cancelled")
@@ -434,7 +445,7 @@ class CachedStillDecodeBackend:
             return surface
         emit_detail_event("surface_cache_miss", generation=prepared.generation, asset_id=key.asset_id)
         surface = self._delegate.decode(prepared, cancellation)
-        stats = self._cached_color_stats(prepared)
+        stats = self._cached_color_stats(prepared) if cacheable else None
         if stats is None:
             started = time.perf_counter()
             stats = compute_color_statistics(surface.image)
@@ -446,10 +457,12 @@ class CachedStillDecodeBackend:
                 width=surface.decoded_size[0],
                 height=surface.decoded_size[1],
             )
-        stats = self._remember_color_stats(prepared, stats)
+        if cacheable:
+            stats = self._remember_color_stats(prepared, stats)
         surface = replace(surface, color_stats=stats)
-        self.memory_cache.put(surface)
-        self._submit(self._write_surface, prepared, surface)
+        if cacheable:
+            self.memory_cache.put(surface)
+            self._submit(self._write_surface, prepared, surface)
         return surface
 
     def _write_surface(self, request: DetailRenderRequest, surface: DecodedSurface) -> None:

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -38,6 +38,7 @@ _MACOS_EXTERNAL_TOOL_PATHS = (
 _STARTUP_GALLERY_WARMUP_FALLBACK_MS = 3000
 _STARTUP_HANG_DIAG_ENV = "IPHOTO_STARTUP_HANG_DIAG"
 _STARTUP_HANG_DIAG_TIMEOUT_SECONDS = 15
+_QUEUED_CONNECTION = Qt.ConnectionType.QueuedConnection
 _STARTUP_INPUT_EVENT_TYPES = frozenset(
     event_type
     for name in (
@@ -157,7 +158,7 @@ class _StartupModulePreloader(QObject):
         thread = threading.Thread(
             target=_load,
             name=f"StartupModulePreloader-{generation}",
-            daemon=False,
+            daemon=True,
         )
         with self._lock:
             self._threads[generation] = thread
@@ -176,16 +177,25 @@ class _StartupModulePreloader(QObject):
             self._cancelled.add(generation)
         self._registry.discard(generation)
 
-    def close(self) -> None:
+    def close(self, *, timeout_ms: int = 1500) -> tuple[str, ...]:
+        """Cancel publication and wait for workers only up to ``timeout_ms``."""
+
         with self._lock:
             self._closed = True
             self._cancelled.update(self._threads)
             threads = tuple(self._threads.values())
+        deadline = time.monotonic() + max(0, int(timeout_ms)) / 1000.0
         for thread in threads:
-            if thread is not threading.current_thread():
-                thread.join()
-        with self._lock:
-            self._threads.clear()
+            if thread is threading.current_thread():
+                continue
+            thread.join(max(0.0, deadline - time.monotonic()))
+        lingering = tuple(thread.name for thread in threads if thread.is_alive())
+        if lingering:
+            _logger.warning(
+                "Startup import workers exceeded the shutdown deadline: %s",
+                ", ".join(lingering),
+            )
+        return lingering
 
 
 class _StartupInputGuard(QObject):
@@ -554,7 +564,10 @@ def main(argv: list[str] | None = None) -> int:
     startup_imports = _StartupModulePreloader(
         app if isinstance(app, QObject) else None,
     )
-    startup_imports.settled.connect(lambda _generation: startup_jobs.wake())
+    startup_imports.settled.connect(
+        startup_jobs.wake_for_generation,
+        _QUEUED_CONNECTION,
+    )
     startup.begin()
     startup.transition(StartupPhase.APP_CREATED)
 

--- a/src/iPhoto/gui/ui/controllers/dialog_controller.py
+++ b/src/iPhoto/gui/ui/controllers/dialog_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,10 +29,12 @@ class DialogController:
         parent: QWidget,
         context: RuntimeEntryContract,
         status_bar: ChromeStatusBar,
+        library_rebind_preflight: Callable[[], bool] | None = None,
     ) -> None:
         self._parent = parent
         self._context = context
         self._status = status_bar
+        self._library_rebind_preflight = library_rebind_preflight
 
     # ------------------------------------------------------------------
     # Public API
@@ -43,6 +46,19 @@ class DialogController:
         )
 
     def bind_library_dialog(self) -> Path | None:
+        if (
+            self._library_rebind_preflight is not None
+            and not self._library_rebind_preflight()
+        ):
+            dialogs.show_error(
+                self._parent,
+                QCoreApplication.translate(
+                    "DialogController",
+                    "Finish the current edit with Done, or press Escape to cancel it, before switching libraries.",
+                    None,
+                ),
+            )
+            return None
         root = dialogs.select_directory(
             self._parent,
             QCoreApplication.translate("DialogController", "Select Basic Library", None),

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -232,7 +232,7 @@ class _AdjustmentPreparationWorker(QRunnable):
         try:
             if self._cancelled:
                 return
-            identity = self.source_identity
+            identity = self.source_identity.repair_revision_from_stat()
             if (
                 is_raw_extension(identity.path.suffix)
                 and (identity.width <= 0 or identity.height <= 0)

--- a/tests/application/test_dialog_controller_runtime_binding.py
+++ b/tests/application/test_dialog_controller_runtime_binding.py
@@ -110,3 +110,28 @@ def test_bind_library_dialog_skips_initial_scan_when_scope_complete(
 
     scan_service.is_scan_scope_complete.assert_called_once_with(selected_root)
     context.facade.scan_root_async.assert_not_called()
+
+
+def test_bind_library_dialog_refuses_switch_during_active_edit(monkeypatch) -> None:
+    context = _Context(Path("/old"))
+    select_directory = Mock()
+    show_error = Mock()
+    monkeypatch.setattr(
+        "iPhoto.gui.ui.controllers.dialog_controller.dialogs.select_directory",
+        select_directory,
+    )
+    monkeypatch.setattr(
+        "iPhoto.gui.ui.controllers.dialog_controller.dialogs.show_error",
+        show_error,
+    )
+    controller = DialogController(
+        object(),
+        context,
+        Mock(),
+        library_rebind_preflight=lambda: False,
+    )
+
+    assert controller.bind_library_dialog() is None
+    select_directory.assert_not_called()
+    assert context.open_calls == []
+    show_error.assert_called_once()

--- a/tests/application/test_runtime_context.py
+++ b/tests/application/test_runtime_context.py
@@ -198,7 +198,41 @@ def _runtime_context(root: Path) -> tuple[RuntimeContext, _FakeLibrary, _FakeAss
     context.asset_runtime = asset_runtime
     context._container = None
     context._pending_basic_library_path = root
+    context._library_epoch = 0
     return context, library, asset_runtime
+
+
+def test_library_epoch_advances_for_open_and_close(tmp_path: Path) -> None:
+    library_root = tmp_path / "library"
+    library_root.mkdir()
+    context, _library, _asset_runtime = _runtime_context(library_root)
+
+    assert context.library_epoch == 0
+    context.open_library(library_root)
+    opened_epoch = context.library_epoch
+    context.close_library()
+
+    assert opened_epoch == 1
+    assert context.library_epoch == 2
+
+
+def test_new_epoch_is_visible_before_session_bind_callback(tmp_path: Path) -> None:
+    library_root = tmp_path / "library"
+    library_root.mkdir()
+    context, library, _asset_runtime = _runtime_context(library_root)
+    observed_epochs: list[int] = []
+    original_bind = library.bind_library_session
+
+    def observe_bind(session: object | None) -> None:
+        if session is not None:
+            observed_epochs.append(context.library_epoch)
+        original_bind(session)
+
+    library.bind_library_session = observe_bind  # type: ignore[method-assign]
+
+    context.open_library(library_root)
+
+    assert observed_epochs == [1]
 
 
 def test_resume_startup_tasks_scans_when_work_dir_exists_without_index(

--- a/tests/gui/coordinators/test_edit_coordinator.py
+++ b/tests/gui/coordinators/test_edit_coordinator.py
@@ -224,6 +224,19 @@ def test_leave_edit_mode_still_does_not_request_detail_reload() -> None:
     coordinator._media_session.request_restore.assert_not_called()
 
 
+def test_unexpected_library_rebind_safely_leaves_active_edit() -> None:
+    coordinator = EditCoordinator.__new__(EditCoordinator)
+    coordinator._session = object()
+    coordinator.leave_edit_mode = Mock()
+
+    EditCoordinator.invalidate_library_binding(coordinator)
+
+    coordinator.leave_edit_mode.assert_called_once_with(
+        restore_reason="library_invalidated",
+        restore_detail=False,
+    )
+
+
 def test_leave_edit_mode_can_emit_edit_done_restore_reason() -> None:
     coordinator = EditCoordinator.__new__(EditCoordinator)
     source = Path("/fake/video.mp4")

--- a/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
+++ b/tests/gui/coordinators/test_main_coordinator_asset_runtime_boundary.py
@@ -36,7 +36,10 @@ def test_on_library_tree_updated_rebinds_core_domains_only() -> None:
     coordinator._on_library_tree_updated()
 
     coordinator.gallery.rebind_library.assert_called_once_with()
-    coordinator.detail.rebind_library.assert_called_once_with()
+    coordinator.detail.rebind_library.assert_called_once_with(
+        0,
+        session_changed=False,
+    )
     coordinator._map_extension_download.set_package_root.assert_called_once_with(
         Path("/session/maps").resolve()
     )
@@ -144,6 +147,28 @@ def test_open_album_from_path_reuses_session_for_album_inside_library(
     coordinator._navigation.open_album.assert_called_once_with(album_root)
 
 
+def test_open_album_from_path_blocks_cross_library_switch_during_edit(
+    tmp_path: Path,
+) -> None:
+    coordinator = GalleryCoordinator.__new__(GalleryCoordinator)
+    old_root = tmp_path / "Old"
+    new_root = tmp_path / "New"
+    old_root.mkdir()
+    new_root.mkdir()
+    coordinator._context = MagicMock()
+    coordinator._context.library_session = None
+    coordinator._context.library.root.return_value = old_root
+    coordinator._facade = MagicMock()
+    coordinator._navigation = MagicMock()
+    coordinator._library_rebind_preflight = lambda: False
+
+    GalleryCoordinator.open_album_from_path(coordinator, new_root)
+
+    coordinator._context.open_library.assert_not_called()
+    coordinator._navigation.open_album.assert_not_called()
+    coordinator._facade.errorRaised.emit.assert_called_once()
+
+
 def test_on_library_tree_updated_rebinds_created_optional_domains() -> None:
     coordinator = MainCoordinator.__new__(MainCoordinator)
     root = Path("/library")
@@ -164,11 +189,38 @@ def test_on_library_tree_updated_rebinds_created_optional_domains() -> None:
     coordinator._on_library_tree_updated()
 
     coordinator.gallery.rebind_library.assert_called_once_with()
-    coordinator.detail.rebind_library.assert_called_once_with()
+    coordinator.detail.rebind_library.assert_called_once_with(
+        0,
+        session_changed=False,
+    )
     coordinator._recognition.rebind_library.assert_called_once_with()
     coordinator._location_info.rebind_library.assert_called_once_with()
     coordinator._map_extension_download.set_package_root.assert_called_once_with(
         Path("/session/maps").resolve()
+    )
+
+
+def test_external_library_epoch_change_safely_invalidates_edit_first() -> None:
+    coordinator = MainCoordinator.__new__(MainCoordinator)
+    coordinator._context = MagicMock(library_epoch=8)
+    coordinator._context.library_session = None
+    coordinator._context.library.root.return_value = Path("/library-b")
+    coordinator._observed_library_epoch = 7
+    coordinator._edit = MagicMock()
+    coordinator.gallery = MagicMock()
+    coordinator.detail = MagicMock()
+    coordinator._recognition = None
+    coordinator._location_info = None
+    coordinator._logger = MagicMock()
+    coordinator._map_extension_download = MagicMock()
+    coordinator._window = MagicMock(ui=SimpleNamespace())
+
+    coordinator._on_library_tree_updated()
+
+    coordinator._edit.invalidate_library_binding.assert_called_once_with()
+    coordinator.detail.rebind_library.assert_called_once_with(
+        8,
+        session_changed=True,
     )
 
 

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -19,7 +19,10 @@ from iPhoto.gui.detail_pipeline import (
     PlaybackAsyncToken,
     VideoPresentationState,
 )
-from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator
+from iPhoto.gui.detail_render_coordinator import (
+    DetailRenderCoordinator,
+    DetailSurfacePresentationResult,
+)
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
 from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
 from iPhoto.gui.ui.widgets.recognition_annotations import RecognitionAnnotation
@@ -767,7 +770,11 @@ def test_live_photo_fallback_reuses_the_asset_identity() -> None:
 
 def test_live_motion_first_frame_completes_current_transaction() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
-    render_coordinator = Mock(mark_surface_presented=Mock(return_value=True))
+    render_coordinator = Mock(
+        mark_surface_presented=Mock(
+            return_value=DetailSurfacePresentationResult.NEW_SURFACE
+        )
+    )
     coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     coordinator._detail_request_generation = 7
     coordinator._active_live_motion = Path("/fake/photo.mov")
@@ -793,7 +800,11 @@ def test_live_motion_first_frame_completes_current_transaction() -> None:
 
 def test_regular_video_first_frame_enables_interactive_controls() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
-    render_coordinator = Mock(mark_surface_presented=Mock(return_value=True))
+    render_coordinator = Mock(
+        mark_surface_presented=Mock(
+            return_value=DetailSurfacePresentationResult.NEW_SURFACE
+        )
+    )
     coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     coordinator._detail_request_generation = 7
     coordinator._active_live_motion = None
@@ -811,7 +822,11 @@ def test_regular_video_first_frame_enables_interactive_controls() -> None:
 
 def test_live_motion_deferred_still_frame_does_not_complete_transaction() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
-    render_coordinator = Mock(mark_surface_presented=Mock(return_value=True))
+    render_coordinator = Mock(
+        mark_surface_presented=Mock(
+            return_value=DetailSurfacePresentationResult.NEW_SURFACE
+        )
+    )
     coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     still = Path("/fake/photo.heic")
     coordinator._active_live_motion = Path("/fake/photo.mov")
@@ -825,6 +840,44 @@ def test_live_motion_deferred_still_frame_does_not_complete_transaction() -> Non
     PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
 
     render_coordinator.mark_surface_presented.assert_not_called()
+
+
+def test_rejected_still_surface_does_not_refresh_overlay_or_prefetch() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.heic")
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(still),
+    )
+    render_coordinator = Mock(
+        owns_generation=Mock(return_value=True),
+        mark_surface_presented=Mock(
+            return_value=DetailSurfacePresentationResult.REJECTED_STALE
+        ),
+    )
+    coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
+    coordinator._detail_render_transaction = transaction
+    coordinator._active_live_motion = None
+    coordinator._current_presentation = _make_presentation(
+        path=str(still),
+        asset_id="asset-1",
+        is_video=False,
+        is_live=True,
+        request_generation=7,
+    )
+    coordinator._presented_still_source = Path("/fake/previous.heic")
+    coordinator._presented_still_generation = 6
+    coordinator._schedule_recognition_overlay = Mock()
+    coordinator._prefetch_neighbor_stills = Mock()
+
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+
+    assert coordinator._presented_still_source == Path("/fake/previous.heic")
+    assert coordinator._presented_still_generation == 6
+    coordinator._schedule_recognition_overlay.assert_not_called()
+    coordinator._prefetch_neighbor_stills.assert_not_called()
 
 
 @pytest.mark.parametrize("has_pending_still", [False, True])
@@ -890,6 +943,88 @@ def test_live_photo_motion_to_still_runs_overlay_and_prefetch(
         7,
     )
     coordinator._prefetch_neighbor_stills.assert_called_once_with(0)
+
+
+def test_live_photo_second_replay_restores_overlay_without_reopening_transaction(
+    qapp,
+) -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.heic")
+    motion = Path("/fake/photo.mov")
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(still),
+    )
+    lifecycle = DetailRenderCoordinator()
+    terminal_presentations = []
+    lifecycle_surfaces = []
+    lifecycle.presented.connect(terminal_presentations.append)
+    lifecycle.surfacePresented.connect(
+        lambda _snapshot, kind: lifecycle_surfaces.append(kind)
+    )
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(7)
+    presentation = replace(
+        _make_presentation(
+            path=str(still),
+            asset_id="asset-1",
+            is_video=False,
+            is_live=True,
+            request_generation=7,
+        ),
+        live_motion_abs=motion,
+    )
+    coordinator._render_transaction_coordinator = Mock(return_value=lifecycle)
+    coordinator._detail_render_transaction = transaction
+    coordinator._detail_request_generation = 7
+    coordinator._current_presentation = presentation
+    coordinator._face_name_overlay = Mock()
+    coordinator._player_view = Mock(
+        video_area=Mock(begin_load=Mock()),
+        defer_still_updates=Mock(),
+        apply_pending_still=Mock(return_value=False),
+        display_image=Mock(),
+        show_video_surface=Mock(),
+        show_live_badge=Mock(),
+        set_live_replay_enabled=Mock(),
+    )
+    coordinator._player_bar = Mock(setEnabled=Mock())
+    coordinator._schedule_video_preparation = Mock()
+    coordinator._schedule_recognition_overlay = Mock()
+    coordinator._prefetch_neighbor_stills = Mock()
+    coordinator._is_playing = False
+
+    PlaybackCoordinator._autoplay_live_motion(coordinator, presentation)
+    PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
+    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+
+    PlaybackCoordinator.replay_live_photo(coordinator)
+    PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
+    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+
+    assert len(terminal_presentations) == 1
+    assert lifecycle_surfaces == ["live_motion_frame", "live_still"]
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.presented_surfaces == (
+        "live_motion_frame",
+        "live_still",
+    )
+    assert coordinator._presented_still_source == still
+    assert coordinator._presented_still_generation == 7
+    assert coordinator._schedule_recognition_overlay.call_count == 2
+    assert coordinator._prefetch_neighbor_stills.call_args_list == [call(0), call(0)]
+    assert coordinator._player_view.display_image.call_args_list == [
+        call(still, transaction=transaction),
+        call(still, transaction=transaction),
+    ]
+    assert coordinator._face_name_overlay.set_overlay_active.call_args_list == [
+        call(False),
+        call(False),
+    ]
 
 
 def test_old_video_preparation_result_is_rejected_after_rebind() -> None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -21,6 +21,7 @@ from iPhoto.gui.detail_pipeline import (
 )
 from iPhoto.gui.detail_render_coordinator import (
     DetailRenderCoordinator,
+    DetailRenderState,
     DetailSurfacePresentationResult,
 )
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
@@ -768,6 +769,130 @@ def test_live_photo_fallback_reuses_the_asset_identity() -> None:
     assert coordinator._active_live_asset_id == ""
 
 
+def test_live_photo_motion_preparation_failure_restores_pending_still() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.heic")
+    motion = Path("/fake/photo.mov")
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(still),
+    )
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(7)
+    token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=2,
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(motion),
+    )
+    presentation = replace(
+        _make_presentation(
+            path=str(still),
+            asset_id="asset-1",
+            is_video=False,
+            is_live=True,
+            request_generation=7,
+        ),
+        live_motion_abs=motion,
+    )
+    coordinator._pending_video_token = token
+    coordinator._async_token_is_current = Mock(return_value=True)
+    coordinator._render_transaction_coordinator = Mock(return_value=lifecycle)
+    coordinator._detail_render_transaction = transaction
+    coordinator._current_presentation = presentation
+    coordinator._active_live_motion = motion
+    coordinator._active_live_still = still
+    coordinator._active_live_asset_id = "asset-1"
+    coordinator._player_view = Mock(
+        video_area=Mock(stop=Mock()),
+        defer_still_updates=Mock(),
+        apply_pending_still=Mock(return_value=True),
+        display_image=Mock(),
+        show_live_badge=Mock(),
+        set_live_replay_enabled=Mock(),
+        show_placeholder=Mock(),
+    )
+    coordinator._player_bar = Mock(setEnabled=Mock())
+    coordinator._schedule_recognition_overlay = Mock()
+    coordinator._prefetch_neighbor_stills = Mock()
+    coordinator._is_playing = True
+
+    PlaybackCoordinator._on_video_preparation_failed(
+        coordinator,
+        token,
+        RuntimeError("broken motion metadata"),
+    )
+
+    assert coordinator._pending_video_token is None
+    assert coordinator._active_live_motion is None
+    assert coordinator._active_live_asset_id == ""
+    assert coordinator._is_playing is False
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.state is DetailRenderState.PREPARING
+    coordinator._player_view.video_area.stop.assert_called_once_with()
+    coordinator._player_view.defer_still_updates.assert_called_once_with(False)
+    coordinator._player_view.apply_pending_still.assert_called_once_with()
+    coordinator._player_view.display_image.assert_not_called()
+    coordinator._player_view.show_placeholder.assert_not_called()
+    coordinator._player_view.show_live_badge.assert_called_once_with()
+    coordinator._player_view.set_live_replay_enabled.assert_called_once_with(True)
+
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+
+    assert lifecycle.snapshot.state is DetailRenderState.PRESENTED
+    assert lifecycle.snapshot.presented_surfaces == ("live_still",)
+    coordinator._schedule_recognition_overlay.assert_called_once_with(presentation, 7)
+    coordinator._prefetch_neighbor_stills.assert_called_once_with(0)
+
+
+def test_regular_video_preparation_failure_remains_terminal() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    video = Path("/fake/video.mov")
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="video",
+        source_identity=AssetSourceIdentity.create(video),
+    )
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(7)
+    token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=2,
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(video),
+    )
+    coordinator._pending_video_token = token
+    coordinator._async_token_is_current = Mock(return_value=True)
+    coordinator._render_transaction_coordinator = Mock(return_value=lifecycle)
+    coordinator._detail_render_transaction = transaction
+    coordinator._active_live_motion = None
+    coordinator._player_view = Mock(
+        video_area=Mock(stop=Mock()),
+        defer_still_updates=Mock(),
+        show_placeholder=Mock(),
+    )
+
+    PlaybackCoordinator._on_video_preparation_failed(
+        coordinator,
+        token,
+        RuntimeError("broken video metadata"),
+    )
+
+    assert coordinator._pending_video_token is None
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.state is DetailRenderState.FAILED
+    coordinator._player_view.video_area.stop.assert_called_once_with()
+    coordinator._player_view.defer_still_updates.assert_not_called()
+    coordinator._player_view.show_placeholder.assert_called_once_with(
+        "Unable to load this video."
+    )
+
+
 def test_live_motion_first_frame_completes_current_transaction() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
     render_coordinator = Mock(
@@ -1025,6 +1150,88 @@ def test_live_photo_second_replay_restores_overlay_without_reopening_transaction
         call(False),
         call(False),
     ]
+
+
+def test_live_photo_replay_preparation_failure_restores_overlay() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.heic")
+    motion = Path("/fake/photo.mov")
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(still),
+    )
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(7)
+    lifecycle.mark_surface_presented(7, "live_motion_frame")
+    lifecycle.mark_surface_presented(7, "live_still")
+    presentation = replace(
+        _make_presentation(
+            path=str(still),
+            asset_id="asset-1",
+            is_video=False,
+            is_live=True,
+            request_generation=7,
+        ),
+        live_motion_abs=motion,
+    )
+    token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=2,
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(motion),
+    )
+    coordinator._render_transaction_coordinator = Mock(return_value=lifecycle)
+    coordinator._detail_render_transaction = transaction
+    coordinator._detail_request_generation = 7
+    coordinator._current_presentation = presentation
+    coordinator._face_name_overlay = Mock()
+    coordinator._player_view = Mock(
+        video_area=Mock(begin_load=Mock(), stop=Mock()),
+        defer_still_updates=Mock(),
+        apply_pending_still=Mock(return_value=False),
+        display_image=Mock(),
+        show_video_surface=Mock(),
+        show_live_badge=Mock(),
+        set_live_replay_enabled=Mock(),
+        show_placeholder=Mock(),
+    )
+    coordinator._player_bar = Mock(setEnabled=Mock())
+    coordinator._schedule_video_preparation = Mock()
+    coordinator._schedule_recognition_overlay = Mock()
+    coordinator._prefetch_neighbor_stills = Mock()
+    coordinator._async_token_is_current = Mock(return_value=True)
+    coordinator._active_live_motion = None
+    coordinator._active_live_still = still
+    coordinator._active_live_asset_id = ""
+    coordinator._is_playing = False
+
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+    PlaybackCoordinator.replay_live_photo(coordinator)
+    coordinator._pending_video_token = token
+    PlaybackCoordinator._on_video_preparation_failed(
+        coordinator,
+        token,
+        RuntimeError("replay metadata failed"),
+    )
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.state is DetailRenderState.PRESENTED
+    assert lifecycle.snapshot.presented_surfaces == (
+        "live_motion_frame",
+        "live_still",
+    )
+    coordinator._player_view.video_area.stop.assert_called_once_with()
+    coordinator._player_view.display_image.assert_called_once_with(
+        still,
+        transaction=transaction,
+    )
+    coordinator._player_view.show_placeholder.assert_not_called()
+    assert coordinator._schedule_recognition_overlay.call_count == 2
+    assert coordinator._prefetch_neighbor_stills.call_args_list == [call(0), call(0)]
 
 
 def test_old_video_preparation_result_is_rejected_after_rebind() -> None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -12,7 +12,14 @@ pytest.importorskip("PySide6", reason="PySide6 is required for playback coordina
 from iPhoto.application.ports import LocationWriteJobRecord
 from iPhoto.gui.coordinators import playback_coordinator as playback_coordinator_module
 from iPhoto.gui.coordinators.playback_coordinator import PlaybackCoordinator
-from iPhoto.gui.detail_pipeline import DetailPrefetchDescriptor
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailPrefetchDescriptor,
+    DetailRenderTransaction,
+    PlaybackAsyncToken,
+    VideoPresentationState,
+)
+from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
 from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
 from iPhoto.gui.ui.widgets.recognition_annotations import RecognitionAnnotation
@@ -730,6 +737,15 @@ def test_live_photo_fallback_reuses_the_asset_identity() -> None:
     coordinator._active_live_motion = Path("/fake/photo.mov")
     coordinator._active_live_still = still
     coordinator._active_live_asset_id = "asset-1"
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(still),
+    )
+    coordinator._detail_render_transaction = transaction
+    render_coordinator = Mock(owns_generation=Mock(return_value=True))
+    coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     coordinator._player_view = Mock(
         defer_still_updates=Mock(),
         apply_pending_still=Mock(return_value=False),
@@ -744,14 +760,14 @@ def test_live_photo_fallback_reuses_the_asset_identity() -> None:
 
     coordinator._player_view.display_image.assert_called_once_with(
         still,
-        asset_id="asset-1",
+        transaction=transaction,
     )
     assert coordinator._active_live_asset_id == ""
 
 
 def test_live_motion_first_frame_completes_current_transaction() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
-    render_coordinator = Mock(mark_presented=Mock(return_value=True))
+    render_coordinator = Mock(mark_surface_presented=Mock(return_value=True))
     coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     coordinator._detail_request_generation = 7
     coordinator._active_live_motion = Path("/fake/photo.mov")
@@ -768,13 +784,16 @@ def test_live_motion_first_frame_completes_current_transaction() -> None:
 
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
 
-    render_coordinator.mark_presented.assert_called_once_with(7)
+    render_coordinator.mark_surface_presented.assert_called_once_with(
+        7,
+        "live_motion_frame",
+    )
     coordinator._player_view.show_video_surface.assert_called_once_with(interactive=False)
 
 
 def test_regular_video_first_frame_enables_interactive_controls() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
-    render_coordinator = Mock(mark_presented=Mock(return_value=True))
+    render_coordinator = Mock(mark_surface_presented=Mock(return_value=True))
     coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     coordinator._detail_request_generation = 7
     coordinator._active_live_motion = None
@@ -783,13 +802,16 @@ def test_regular_video_first_frame_enables_interactive_controls() -> None:
 
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
 
-    render_coordinator.mark_presented.assert_called_once_with(7)
+    render_coordinator.mark_surface_presented.assert_called_once_with(
+        7,
+        "video_frame",
+    )
     coordinator._player_view.show_video_surface.assert_called_once_with(interactive=True)
 
 
 def test_live_motion_deferred_still_frame_does_not_complete_transaction() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
-    render_coordinator = Mock(mark_presented=Mock(return_value=True))
+    render_coordinator = Mock(mark_surface_presented=Mock(return_value=True))
     coordinator._render_transaction_coordinator = Mock(return_value=render_coordinator)
     still = Path("/fake/photo.heic")
     coordinator._active_live_motion = Path("/fake/photo.mov")
@@ -802,7 +824,284 @@ def test_live_motion_deferred_still_frame_does_not_complete_transaction() -> Non
 
     PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
 
-    render_coordinator.mark_presented.assert_not_called()
+    render_coordinator.mark_surface_presented.assert_not_called()
+
+
+@pytest.mark.parametrize("has_pending_still", [False, True])
+def test_live_photo_motion_to_still_runs_overlay_and_prefetch(
+    qapp,
+    has_pending_still: bool,
+) -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.heic")
+    motion = Path("/fake/photo.mov")
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="live_motion",
+        source_identity=AssetSourceIdentity.create(still),
+    )
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(7)
+    coordinator._render_transaction_coordinator = Mock(return_value=lifecycle)
+    coordinator._detail_render_transaction = transaction
+    coordinator._detail_request_generation = 7
+    coordinator._active_live_motion = motion
+    coordinator._active_live_still = still
+    coordinator._active_live_asset_id = "asset-1"
+    coordinator._current_presentation = _make_presentation(
+        path=str(still),
+        asset_id="asset-1",
+        is_video=False,
+        is_live=True,
+        request_generation=7,
+    )
+    coordinator._player_view = Mock(
+        defer_still_updates=Mock(),
+        apply_pending_still=Mock(return_value=has_pending_still),
+        display_image=Mock(),
+        show_video_surface=Mock(),
+        show_live_badge=Mock(),
+        set_live_replay_enabled=Mock(),
+    )
+    coordinator._player_bar = Mock(setEnabled=Mock())
+    coordinator._schedule_recognition_overlay = Mock()
+    coordinator._prefetch_neighbor_stills = Mock()
+
+    PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
+    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
+
+    if has_pending_still:
+        coordinator._player_view.display_image.assert_not_called()
+    else:
+        coordinator._player_view.display_image.assert_called_once_with(
+            still,
+            transaction=transaction,
+        )
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.presented_surfaces == (
+        "live_motion_frame",
+        "live_still",
+    )
+    coordinator._schedule_recognition_overlay.assert_called_once_with(
+        coordinator._current_presentation,
+        7,
+    )
+    coordinator._prefetch_neighbor_stills.assert_called_once_with(0)
+
+
+def test_old_video_preparation_result_is_rejected_after_rebind() -> None:
+    path = Path("/shared/video.mov")
+    identity = AssetSourceIdentity.create(path, size_bytes=10, source_mtime_ns=11)
+    old_token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=4,
+        asset_id="asset-1",
+        source_identity=identity,
+    )
+    new_token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset-1",
+        source_identity=identity,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._library_epoch = 2
+    coordinator._library_epoch_getter = lambda: 2
+    coordinator._active_async_token = new_token
+    coordinator._pending_video_token = old_token
+    coordinator._current_presentation = _make_presentation(path=str(path))
+    coordinator._active_live_motion = None
+    coordinator._player_view = Mock(video_area=Mock(commit_presentation=Mock()))
+
+    PlaybackCoordinator._on_video_preparation_ready(
+        coordinator,
+        old_token,
+        object(),
+    )
+
+    coordinator._player_view.video_area.commit_presentation.assert_not_called()
+
+
+def test_current_video_preparation_token_commits_result() -> None:
+    path = Path("/shared/video.mov")
+    identity = AssetSourceIdentity.create(path, size_bytes=10, source_mtime_ns=11)
+    token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset-1",
+        source_identity=identity,
+    )
+    transaction = DetailRenderTransaction(
+        generation=7,
+        asset_id="asset-1",
+        media_kind="video",
+        source_identity=identity,
+    )
+    state = VideoPresentationState(
+        request_generation=7,
+        adjustments={},
+        trim_range_ms=None,
+        adjusted_preview=False,
+        rotation_cw=0,
+        raw_width=1920,
+        raw_height=1080,
+        linux_180_hint=False,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._library_epoch = 2
+    coordinator._library_epoch_getter = lambda: 2
+    coordinator._active_async_token = token
+    coordinator._pending_video_token = token
+    coordinator._current_presentation = _make_presentation(
+        path=str(path),
+        request_generation=7,
+    )
+    coordinator._active_live_motion = None
+    coordinator._detail_render_transaction = transaction
+    coordinator._player_view = Mock(
+        video_area=Mock(commit_presentation=Mock(return_value=True), play=Mock())
+    )
+
+    PlaybackCoordinator._on_video_preparation_ready(coordinator, token, state)
+
+    committed = coordinator._player_view.video_area.commit_presentation.call_args.args[0]
+    assert committed.transaction is transaction
+    coordinator._player_view.video_area.play.assert_called_once_with()
+
+
+def test_old_deferred_geocode_result_is_rejected_after_rebind() -> None:
+    path = Path("/shared/photo.jpg")
+    identity = AssetSourceIdentity.create(path, size_bytes=10, source_mtime_ns=11)
+    old_token = PlaybackAsyncToken.create(
+        library_epoch=1,
+        asset_generation=4,
+        asset_id="asset-1",
+        source_identity=identity,
+    )
+    new_token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset-1",
+        source_identity=identity,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._library_epoch = 2
+    coordinator._library_epoch_getter = lambda: 2
+    coordinator._active_async_token = new_token
+    coordinator._pending_location_token = old_token
+    coordinator._deferred_locations = {}
+    coordinator._current_presentation = _make_presentation(
+        path=str(path),
+        is_video=False,
+    )
+    coordinator._update_header = Mock()
+
+    PlaybackCoordinator._on_deferred_location_ready(
+        coordinator,
+        old_token,
+        "Berlin",
+    )
+
+    assert coordinator._deferred_locations == {}
+    coordinator._update_header.assert_not_called()
+
+
+def test_current_deferred_geocode_token_updates_current_header() -> None:
+    path = Path("/shared/photo.jpg")
+    identity = AssetSourceIdentity.create(path, size_bytes=10, source_mtime_ns=11)
+    token = PlaybackAsyncToken.create(
+        library_epoch=2,
+        asset_generation=5,
+        asset_id="asset-1",
+        source_identity=identity,
+    )
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._library_epoch = 2
+    coordinator._library_epoch_getter = lambda: 2
+    coordinator._active_async_token = token
+    coordinator._pending_location_token = token
+    coordinator._deferred_locations = {}
+    coordinator._current_presentation = _make_presentation(
+        path=str(path),
+        is_video=False,
+    )
+    coordinator._update_header = Mock()
+
+    PlaybackCoordinator._on_deferred_location_ready(coordinator, token, "Berlin")
+
+    assert coordinator._deferred_locations == {path: "Berlin"}
+    assert coordinator._current_presentation.location == "Berlin"
+    coordinator._update_header.assert_called_once_with(
+        coordinator._current_presentation
+    )
+
+
+def test_same_library_tree_refresh_does_not_clear_render_session() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._player_view = Mock(clear_frame_cache=Mock())
+    coordinator._invalidate_overlay_requests = Mock()
+
+    PlaybackCoordinator.rebind_library(
+        coordinator,
+        7,
+        session_changed=False,
+    )
+
+    coordinator._player_view.clear_frame_cache.assert_not_called()
+    coordinator._invalidate_overlay_requests.assert_not_called()
+
+
+def test_session_rebind_invalidates_tokens_and_render_state() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._library_epoch = 1
+    coordinator._library_epoch_getter = lambda: 2
+    coordinator._asset_generation = 4
+    coordinator._detail_request_generation = 9
+    coordinator._active_async_token = object()
+    coordinator._pending_video_token = object()
+    coordinator._pending_location_token = object()
+    coordinator._invalidate_overlay_requests = Mock()
+    coordinator._video_prepare_pool = Mock(clear=Mock())
+    coordinator._deferred_location_pool = Mock(clear=Mock())
+    coordinator._deferred_locations = {Path("/old.jpg"): "Old"}
+    lifecycle = Mock(reset=Mock())
+    coordinator._render_transaction_coordinator = Mock(return_value=lifecycle)
+    coordinator._detail_render_transaction = object()
+    coordinator._current_presentation = object()
+    coordinator._active_live_motion = Path("/old.mov")
+    coordinator._active_live_still = Path("/old.jpg")
+    coordinator._active_live_asset_id = "old"
+    coordinator._presented_still_generation = 9
+    coordinator._presented_still_source = Path("/old.jpg")
+    coordinator._player_view = Mock(
+        video_area=Mock(stop=Mock()),
+        defer_still_updates=Mock(),
+        cancel_pending_image_requests=Mock(),
+        clear_frame_cache=Mock(),
+        show_placeholder=Mock(),
+    )
+    coordinator._player_bar = Mock(setEnabled=Mock())
+    coordinator._is_playing = True
+    coordinator._update_header = Mock()
+    coordinator._info_panel = None
+    coordinator._clear_info_panel_metadata_state = Mock()
+    coordinator._clear_confirmed_location_metadata = Mock()
+
+    PlaybackCoordinator.rebind_library(coordinator, 2, session_changed=True)
+
+    assert coordinator._library_epoch == 2
+    assert coordinator._asset_generation == 5
+    assert coordinator._detail_request_generation == 10
+    assert coordinator._active_async_token is None
+    assert coordinator._pending_video_token is None
+    assert coordinator._pending_location_token is None
+    assert coordinator._current_presentation is None
+    lifecycle.reset.assert_called_once_with()
+    coordinator._player_view.video_area.stop.assert_called_once_with()
+    coordinator._player_view.clear_frame_cache.assert_called_once_with()
 
 
 def test_neighbor_prefetch_preserves_asset_descriptors() -> None:

--- a/tests/gui/test_detail_pipeline.py
+++ b/tests/gui/test_detail_pipeline.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -68,6 +70,40 @@ def test_source_identity_creation_never_stats_on_the_calling_thread(tmp_path: Pa
             height=3000,
         )
     assert identity.revision == ("mtime", 100, 200)
+
+
+def test_source_identity_repairs_missing_revision_from_stat(tmp_path: Path) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"first")
+    legacy = AssetSourceIdentity.create(source)
+
+    repaired = legacy.repair_revision_from_stat()
+
+    assert legacy.has_stable_revision is False
+    assert repaired.has_stable_revision is True
+    assert repaired.size_bytes == len(b"first")
+    assert repaired.revision[0] == "mtime"
+
+
+def test_same_path_replacement_changes_repaired_decode_key(tmp_path: Path) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"first")
+    first_stat = source.stat()
+    first_identity = AssetSourceIdentity.create(source).repair_revision_from_stat()
+    first_request = replace(_request(tmp_path), source_identity=first_identity)
+
+    source.write_bytes(b"replacement-is-larger")
+    os.utime(
+        source,
+        ns=(first_stat.st_atime_ns, first_stat.st_mtime_ns + 1_000_000_000),
+    )
+    second_identity = AssetSourceIdentity.create(source).repair_revision_from_stat()
+    second_request = replace(_request(tmp_path), source_identity=second_identity)
+
+    assert first_identity.revision != second_identity.revision
+    assert DetailDecodeKey.from_request(first_request) != DetailDecodeKey.from_request(
+        second_request
+    )
 
 
 def test_decode_key_distinguishes_source_orientation(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_render_coordinator.py
+++ b/tests/gui/test_detail_render_coordinator.py
@@ -49,6 +49,34 @@ def test_new_transaction_cancels_old_and_rejects_stale_result(qapp) -> None:
     assert coordinator.mark_presented(2)
 
 
+def test_live_motion_and_restored_still_are_distinct_surfaces(qapp) -> None:
+    coordinator = DetailRenderCoordinator()
+    terminals = []
+    surfaces = []
+    coordinator.presented.connect(terminals.append)
+    coordinator.surfacePresented.connect(
+        lambda snapshot, kind: surfaces.append((snapshot, kind))
+    )
+
+    coordinator.begin(_transaction(7, media_kind="live_motion"))
+    coordinator.mark_preparing(7)
+
+    assert coordinator.mark_surface_presented(7, "live_motion_frame")
+    assert coordinator.mark_surface_presented(7, "live_still")
+    assert not coordinator.mark_surface_presented(7, "live_still")
+    assert coordinator.owns_generation(7)
+    assert len(terminals) == 1
+    assert [kind for _snapshot, kind in surfaces] == [
+        "live_motion_frame",
+        "live_still",
+    ]
+    assert coordinator.snapshot is not None
+    assert coordinator.snapshot.presented_surfaces == (
+        "live_motion_frame",
+        "live_still",
+    )
+
+
 def test_still_request_is_derived_from_transaction(tmp_path: Path) -> None:
     from iPhoto.gui.detail_pipeline import DetailGeometryState, DetailRenderRequest
 

--- a/tests/gui/test_detail_render_coordinator.py
+++ b/tests/gui/test_detail_render_coordinator.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailRenderTransaction
-from iPhoto.gui.detail_render_coordinator import DetailRenderCoordinator, DetailRenderState
+from iPhoto.gui.detail_render_coordinator import (
+    DetailRenderCoordinator,
+    DetailRenderState,
+    DetailSurfacePresentationResult,
+)
 
 
 def _transaction(generation: int, *, media_kind: str = "image") -> DetailRenderTransaction:
@@ -61,9 +65,22 @@ def test_live_motion_and_restored_still_are_distinct_surfaces(qapp) -> None:
     coordinator.begin(_transaction(7, media_kind="live_motion"))
     coordinator.mark_preparing(7)
 
-    assert coordinator.mark_surface_presented(7, "live_motion_frame")
-    assert coordinator.mark_surface_presented(7, "live_still")
-    assert not coordinator.mark_surface_presented(7, "live_still")
+    assert (
+        coordinator.mark_surface_presented(7, "live_motion_frame")
+        is DetailSurfacePresentationResult.NEW_SURFACE
+    )
+    assert (
+        coordinator.mark_surface_presented(7, "live_still")
+        is DetailSurfacePresentationResult.NEW_SURFACE
+    )
+    assert (
+        coordinator.mark_surface_presented(7, "live_motion_frame")
+        is DetailSurfacePresentationResult.DUPLICATE_CURRENT_SURFACE
+    )
+    assert (
+        coordinator.mark_surface_presented(7, "live_still")
+        is DetailSurfacePresentationResult.DUPLICATE_CURRENT_SURFACE
+    )
     assert coordinator.owns_generation(7)
     assert len(terminals) == 1
     assert [kind for _snapshot, kind in surfaces] == [
@@ -74,6 +91,32 @@ def test_live_motion_and_restored_still_are_distinct_surfaces(qapp) -> None:
     assert coordinator.snapshot.presented_surfaces == (
         "live_motion_frame",
         "live_still",
+    )
+
+
+def test_surface_presentation_rejects_stale_failed_and_cancelled_transactions(qapp) -> None:
+    coordinator = DetailRenderCoordinator()
+
+    coordinator.begin(_transaction(7, media_kind="live_motion"))
+    assert (
+        coordinator.mark_surface_presented(6, "live_motion_frame")
+        is DetailSurfacePresentationResult.REJECTED_STALE
+    )
+    assert (
+        coordinator.mark_surface_presented(7, "still")
+        is DetailSurfacePresentationResult.REJECTED_STALE
+    )
+    assert coordinator.mark_failed(7, "decode failed")
+    assert (
+        coordinator.mark_surface_presented(7, "live_motion_frame")
+        is DetailSurfacePresentationResult.REJECTED_STALE
+    )
+
+    coordinator.begin(_transaction(8, media_kind="live_motion"))
+    assert coordinator.cancel_current()
+    assert (
+        coordinator.mark_surface_presented(8, "live_motion_frame")
+        is DetailSurfacePresentationResult.REJECTED_STALE
     )
 
 

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -192,6 +192,28 @@ def test_unbound_store_is_a_disabled_disk_tier(tmp_path: Path) -> None:
     assert store.write(request, _surface(request)) is False
 
 
+def test_unstable_identity_bypasses_reusable_memory_and_disk_cache(
+    tmp_path: Path,
+) -> None:
+    request = replace(
+        _request(tmp_path / "missing.jpg"),
+        source_identity=AssetSourceIdentity.create(tmp_path / "missing.jpg"),
+    )
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    store = Mock()
+    backend = CachedStillDecodeBackend(delegate, store=store)
+
+    backend.decode(request, _Token())
+    backend.decode(request, _Token())
+    backend.shutdown()
+
+    assert delegate.decode.call_count == 2
+    assert backend.memory_cache.used_bytes == 0
+    store.load.assert_not_called()
+    store.write.assert_not_called()
+
+
 def test_color_stats_are_computed_once_across_lod_decodes(tmp_path: Path) -> None:
     first = _request(tmp_path / "photo.jpg", level=1024)
     second = _request(tmp_path / "photo.jpg", level=2048)

--- a/tests/gui/test_gui_startup_job_queue.py
+++ b/tests/gui/test_gui_startup_job_queue.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import time
+
+from PySide6.QtCore import QThread, Qt
+
 from iPhoto.bootstrap import gui_startup_job_queue as queue_module
 from iPhoto.bootstrap.gui_startup_job_queue import GuiStartupJobQueue
+from iPhoto.gui.main import _StartupModulePreloader
 
 
 class _ManualScheduler:
@@ -49,6 +54,31 @@ def test_prerequisite_preserves_order_until_woken(qapp) -> None:
     scheduler.tick()
     scheduler.tick()
     assert calls == ["blocked", "after"]
+
+
+def test_worker_settled_wakes_queue_on_qapplication_thread(qapp) -> None:
+    queue = GuiStartupJobQueue()
+    preloader = _StartupModulePreloader()
+    callback_threads: list[QThread] = []
+    preloader.settled.connect(
+        queue.wake_for_generation,
+        Qt.ConnectionType.QueuedConnection,
+    )
+    queue.enqueue(
+        "import-dependent",
+        1,
+        lambda: callback_threads.append(QThread.currentThread()),
+        prerequisite=lambda: preloader.ready(1),
+    )
+
+    assert preloader.start(1, lambda: object())
+    deadline = time.monotonic() + 2.0
+    while not callback_threads and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    preloader.close()
+
+    assert callback_threads == [qapp.thread()]
 
 
 def test_records_one_stall_only_when_budget_is_exceeded(qapp, monkeypatch) -> None:

--- a/tests/gui/test_startup_orchestrator.py
+++ b/tests/gui/test_startup_orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import time
 
 import pytest
 
@@ -30,6 +31,28 @@ def test_startup_import_registry_isolates_retry_generations() -> None:
     else:
         raise AssertionError("first startup generation unexpectedly resolved")
     assert registry.resolve(2) is second_value
+
+
+def test_startup_module_preloader_close_is_bounded(qapp) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    preloader = _StartupModulePreloader()
+
+    def blocked_loader() -> object:
+        started.set()
+        release.wait(timeout=2.0)
+        return object()
+
+    assert preloader.start(1, blocked_loader)
+    assert started.wait(timeout=1.0)
+    before = time.monotonic()
+    lingering = preloader.close(timeout_ms=10)
+    elapsed = time.monotonic() - before
+    release.set()
+
+    assert elapsed < 0.5
+    assert lingering == ("StartupModulePreloader-1",)
+    assert preloader.ready(1) is False
 
 
 def test_startup_module_preloader_rejects_cancelled_late_result(qapp) -> None:

--- a/tests/gui/test_startup_shutdown_smoke.py
+++ b/tests/gui/test_startup_shutdown_smoke.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_application_startup_exits_through_normal_interpreter_shutdown(
+    tmp_path: Path,
+) -> None:
+    """Exercise the real entrypoint without the native-finalizer test runner."""
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "IPHOTO_DISABLE_OPENGL": "1",
+            "IPHOTO_STARTUP_BENCHMARK_AUTO_EXIT_MS": "0",
+            "NUMBA_DISABLE_JIT": "1",
+            "QT_QPA_PLATFORM": "offscreen",
+            "XDG_CACHE_HOME": str(tmp_path / "cache"),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        }
+    )
+    completed = subprocess.run(
+        [sys.executable, "-m", "iPhoto.gui.main"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert completed.returncode == 0, (
+        f"application exited with {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )

--- a/tests/ui/controllers/test_player_view_controller_adjustments.py
+++ b/tests/ui/controllers/test_player_view_controller_adjustments.py
@@ -21,9 +21,35 @@ from iPhoto.gui.detail_pipeline import (
 from iPhoto.gui.detail_render_session import EditRenderState, PhotoRenderSessionHandle
 from iPhoto.gui.ui.controllers.player_view_controller import (
     PlayerViewController,
+    _AdjustmentPreparationSignals,
+    _AdjustmentPreparationWorker,
     _PreparedRequestIntent,
     _StillSurfaceDecodeWorker,
 )
+
+
+def test_adjustment_preparation_repairs_legacy_source_revision(
+    qapp,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "photo.jpg"
+    source.write_bytes(b"source")
+    signals = _AdjustmentPreparationSignals()
+    prepared = []
+    signals.ready.connect(lambda _key, state: prepared.append(state))
+    worker = _AdjustmentPreparationWorker(
+        ("asset-1", source),
+        AssetSourceIdentity.create(source),
+        signals,
+        None,
+        generation=3,
+    )
+
+    worker.run()
+
+    assert len(prepared) == 1
+    assert prepared[0].source_identity.has_stable_revision
+    assert prepared[0].source_identity.revision[0] == "mtime"
 
 
 def _request(source: Path, adjustments: dict | None = None) -> DetailRenderRequest:


### PR DESCRIPTION
## Summary

This bug-only follow-up addresses the confirmed correctness and lifecycle findings from the PR #890 review. It intentionally keeps the current startup/Detail architecture intact and does not split the original PR.

## Review finding mapping

- **1 — CI branch filtering:** keep pull-request coverage for `codex/startup-chain-optimization`, add that branch to `push`, and add the normal-shutdown smoke to the bounded cross-platform startup contract.
- **2 — Live Photo terminal state:** separate transaction completion from surface presentation. Motion first-frame and restored still now share the original transaction/generation while producing distinct, idempotent surface events; restored still delivery continues to overlay and neighbor-prefetch work.
- **3 — Library rebind races:** add a monotonic `library_epoch` and complete playback async tokens (`library_epoch`, asset generation/id, source path/revision). Running old video-preparation and deferred-geocode results are rejected after a rebind.
- **4 — Edit render handle invalidation:** same-library tree refreshes no longer clear render sessions; user-initiated cross-library switches are blocked while Edit is active; unexpected session changes safely leave Edit before Detail caches are cleared.
- **5 — Startup GUI-thread contract:** route importer settlement through a QObject `@Slot(int)` with explicit queued delivery and assert the queue's owner thread in `wake()`/`_run_one()`.
- **6 — Startup shutdown blocking:** use daemon importer workers and one bounded close deadline, report lingering workers, and reject late publication.
- **9 — Source identity:** repair missing revisions with worker-thread stat before decode/cache-key creation; unstable identities decode without reusable memory/disk caching.
- **10 — Normal exit coverage:** retain the existing native-finalizer-safe test runner and add a real application startup/shutdown subprocess test that exits through normal interpreter shutdown.

## Out of scope

- Finding 7: disk-cache performance redesign.
- Finding 8: unified render-session/RAW memory ownership and budget redesign.
- Splitting PR #890 or changing the later `edit-base`/`main` merge trigger strategy.
- Automatic merge of this PR.

## Validation

- `2869 passed, 16 skipped` via the CI pytest runner.
- Targeted startup/Detail/library/Edit/source-identity regressions passed.
- Real normal-interpreter application shutdown smoke passed independently of `tools/run_pytest_ci.py`.
- Architecture checks passed.
- `compileall` passed for `src` and `tools`.
- Ruff F/E9 passed for every changed Python file.
- `git diff --check` passed.

Full-repository Ruff F/E9 still reports 104 pre-existing findings outside the files changed here; those were intentionally not folded into this bug-only PR.
