### PR TITLE
Index neutral surface cache metadata for TD-890-01

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,14 +290,17 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           mkdir -p metrics
-          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 16 --output metrics/baseline-16.json
-          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 16 --output metrics/candidate-16.json
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 16 --defer-fresh-probes --output metrics/baseline-16.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 16 --defer-fresh-probes --output metrics/candidate-16.json
+          python candidate/tools/detail_surface_cache_benchmark.py pair-fresh --baseline metrics/baseline-16.json --candidate metrics/candidate-16.json --baseline-repo baseline --candidate-repo candidate --size-mib 16
           python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline-16.json --candidate metrics/candidate-16.json --output metrics/comparison-16.json
-          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 64 --output metrics/candidate-64.json
-          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 64 --output metrics/baseline-64.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 64 --defer-fresh-probes --output metrics/candidate-64.json
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 64 --defer-fresh-probes --output metrics/baseline-64.json
+          python candidate/tools/detail_surface_cache_benchmark.py pair-fresh --baseline metrics/baseline-64.json --candidate metrics/candidate-64.json --baseline-repo baseline --candidate-repo candidate --size-mib 64
           python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline-64.json --candidate metrics/candidate-64.json --output metrics/comparison-64.json
-          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 180 --output metrics/baseline-180.json
-          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 180 --output metrics/candidate-180.json
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 180 --defer-fresh-probes --output metrics/baseline-180.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 180 --defer-fresh-probes --output metrics/candidate-180.json
+          python candidate/tools/detail_surface_cache_benchmark.py pair-fresh --baseline metrics/baseline-180.json --candidate metrics/candidate-180.json --baseline-repo baseline --candidate-repo candidate --size-mib 180
           python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline-180.json --candidate metrics/candidate-180.json --output metrics/comparison-180.json
 
       - name: Upload cache benchmark metrics

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,14 +232,71 @@ jobs:
           tests/gui/test_detail_decode_backend.py
           tests/gui/test_detail_request_scheduler.py
           tests/gui/test_detail_surface_cache.py
+          tests/gui/test_detail_surface_residency.py
           tests/gui/test_detail_render_session.py
           tests/ui/controllers/test_player_view_controller_adjustments.py
           tests/ui/widgets/test_still_texture_residency.py
           tests/test_detail_benchmark.py
+          tests/test_detail_surface_cache_benchmark.py
 
       - name: Run static gates
         run: |
           python tools/check_architecture.py
           python -m compileall -q src tools
-          python -m ruff check --select F,E9 src/iPhoto/gui/detail_pipeline.py src/iPhoto/gui/detail_render_coordinator.py src/iPhoto/gui/detail_decode_backend.py src/iPhoto/gui/detail_decode_macos.py src/iPhoto/gui/detail_decode_windows.py src/iPhoto/gui/detail_benchmark_harness.py tools/detail_benchmark.py tools/run_detail_packaged_benchmark.py
+          python -m ruff check --select F,E9 src/iPhoto/gui/detail_pipeline.py src/iPhoto/gui/detail_render_coordinator.py src/iPhoto/gui/detail_decode_backend.py src/iPhoto/gui/detail_decode_macos.py src/iPhoto/gui/detail_decode_windows.py src/iPhoto/gui/detail_benchmark_harness.py src/iPhoto/gui/detail_surface_cache.py src/iPhoto/gui/detail_surface_cache_index.py src/iPhoto/gui/detail_surface_residency.py tools/detail_benchmark.py tools/detail_surface_cache_benchmark.py tools/run_detail_packaged_benchmark.py
           git diff --check
+
+  detail-surface-cache-contract:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out candidate
+        uses: actions/checkout@v4
+        with:
+          path: candidate
+
+      - name: Check out fixed v2 baseline
+        uses: actions/checkout@v4
+        with:
+          ref: fe623e68d101048751fd9acb85ddb5d08c564c83
+          path: baseline
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: candidate/pyproject.toml
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libegl1 libgl1 libxkbcommon0 libpulse0
+
+      - name: Install benchmark dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "candidate[test]"
+
+      - name: Run fixed baseline and candidate cache benchmarks
+        shell: bash
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          mkdir -p metrics
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --output metrics/baseline.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --output metrics/candidate.json
+          python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline.json --candidate metrics/candidate.json --output metrics/comparison.json
+
+      - name: Upload cache benchmark metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detail-surface-cache-${{ matrix.os }}
+          path: metrics/*.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,9 +290,15 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           mkdir -p metrics
-          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --output metrics/baseline.json
-          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --output metrics/candidate.json
-          python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline.json --candidate metrics/candidate.json --output metrics/comparison.json
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 16 --output metrics/baseline-16.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 16 --output metrics/candidate-16.json
+          python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline-16.json --candidate metrics/candidate-16.json --output metrics/comparison-16.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 64 --output metrics/candidate-64.json
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 64 --output metrics/baseline-64.json
+          python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline-64.json --candidate metrics/candidate-64.json --output metrics/comparison-64.json
+          PYTHONPATH="${{ github.workspace }}/baseline/src" python candidate/tools/detail_surface_cache_benchmark.py run --label baseline --repo-root baseline --sizes-mib 180 --output metrics/baseline-180.json
+          PYTHONPATH="${{ github.workspace }}/candidate/src" python candidate/tools/detail_surface_cache_benchmark.py run --label candidate --repo-root candidate --sizes-mib 180 --output metrics/candidate-180.json
+          python candidate/tools/detail_surface_cache_benchmark.py compare --baseline metrics/baseline-180.json --candidate metrics/candidate-180.json --output metrics/comparison-180.json
 
       - name: Upload cache benchmark metrics
         if: always()

--- a/AGENT.md
+++ b/AGENT.md
@@ -99,7 +99,7 @@ Library workspace:
   global_index.db       # SQLite index and current asset/state repository store
   links.json            # Live Photo compatibility materialization
   cache/thumbs/         # Rebuildable thumbnail cache
-  cache/detail-surfaces/v2/ # Rebuildable neutral RGBA8/sRGB Detail surfaces
+  cache/detail-surfaces/v3/ # SQLite-indexed rebuildable neutral RGBA8/sRGB surfaces
   faces/
     face_index.db       # Rebuildable People runtime snapshot
     face_state.db       # Durable People user decisions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -370,7 +370,7 @@ Each library root owns a `.iPhoto/` workspace.
 | `.iPhoto/global_index.db` | Current SQLite asset index and repository-backed state store for scan rows, pagination, Live Photo roles, trash/favorite/hidden state, independent `face_status`/`pet_status`, and related library state. |
 | `.iPhoto/links.json` | Derived Live Photo compatibility materialization; repository/session Live Photo role state remains authoritative for runtime behavior. |
 | `.iPhoto/cache/thumbs/` | Rebuildable thumbnail cache. |
-| `.iPhoto/cache/detail-surfaces/v2/` | Rebuildable, versioned neutral RGBA8/sRGB Detail surfaces keyed by source identity, orientation, and LOD; sidecar revision is excluded. |
+| `.iPhoto/cache/detail-surfaces/v3/` | SQLite-indexed, rebuildable neutral RGBA8/sRGB Detail surfaces keyed by source identity, decoder contract, orientation, and LOD; trusted hits validate indexed header/stat metadata without scanning the full payload, and sidecar revision is excluded. |
 | `.iPhoto/faces/face_index.db` | Rebuildable People runtime snapshot. |
 | `.iPhoto/faces/face_state.db` | Durable People user state: names, covers, hidden flags, order, groups, pinned state, group covers, and manual faces. |
 | `.iPhoto/faces/thumbnails/` | Rebuildable cropped face thumbnails. |

--- a/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
+++ b/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
@@ -73,7 +73,7 @@ Phase 3 追加四组互斥采样，每组、每格式、每平台至少 30 次�
 
 - cold decode：清空 Detail surface/GPU cache 后打开，必须出现 `surface_cache_miss` 和
   `backend_selected`。
-- hot disk/mapped surface：保留 `<library>/.iPhoto/cache/detail-surfaces/v2`，重启或清空内存层；
+- hot disk/mapped surface：保留 `<library>/.iPhoto/cache/detail-surfaces/v3` 及其 `index.sqlite3`，重启或清空内存层；
   必须出现 tier=`disk`/`memory` 的 `surface_cache_hit`。
 - hot GPU：不离开当前图库并重访 current/previous/next；必须出现 `gpu_cache_hit`，同 key 不得新增
   `gpu_upload`。
@@ -96,7 +96,7 @@ Phase 4 增加共享 render session 采样。每张静态照片在已完成首�
 - Edit crop/rotate/perspective/zoom：若需要更高 LOD，应记录 `lod_upgrade_requested/presented`，旧层保持显示，
   stale/failed upgrade 不得替换 current texture。
 
-同时保留 `render_session_created/acquired/released` 和 `edit_state_updated`。ColorStats 从 surface cache v2 header
+同时保留 `render_session_created/acquired/released`、`edit_state_updated` 和 `surface_owner_*` 诊断事件。ColorStats 从 surface cache v3 header
 复用；同 source revision 跨 LOD 的统计计算次数必须为 1。packaged 日志只能证明实际运行结果，不能以
 session 单测或 shader compile 代替三平台数据。
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 SQLite 运行期 fail-open/recovery 修复正在验证 | `in_progress` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 已完成 SQLite 运行期 fail-open/rebuild/recovery，并通过最终实现 head 的完整门禁 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -80,12 +80,13 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 - 写入改为 4 MiB buffer 分块、增量 xxhash、fsync 和原子 replace，不再创建完整
   Python payload 副本；last-access、异常恢复、抽样审计和低水位 prune 均有独立合同。
 - `detail-surface-cache-contract` 在同一 runner checkout 固定 `fe623e68` 基线与候选
-  head，覆盖 16/64/180 MiB 并上传原始 JSON。edge-case 实现 SHA `0a9f7d1a` 的
-  [Actions run 31363902491](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31363902491)
-  已在 Ubuntu、macOS 和 Windows 通过该合同；同一 run 的三平台 GPU-first、startup
-  合同及完整 `test` job 也已通过。记录证据时该 run 仍在执行归属 TD-890-03 的
-  macOS/Windows Pets production-shape job，因此这里不把整个 workflow 提前描述为
-  全部完成。
+  head，覆盖 16/64/180 MiB 并上传原始 JSON。edge-case 文档 head `0d7b9331` 的
+  [Actions run 31364282777](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31364282777)
+  已完整成功；SQLite 运行期故障实现 SHA `a744fde2` 的
+  [Actions run 31368415703](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31368415703)
+  也已完整成功，15 个 job 包括三平台 surface-cache、GPU-first、startup、Pets
+  production-shape 和完整 `test`。后一个 run 的 Ubuntu、macOS、Windows 原始
+  surface-cache JSON artifacts 均已确认存在。
 - 磁盘容量查询失败现在会跳过 prune 并保留维护水位，显式零预算仍保持清空语义；
   跨库 generation retire/swap 与 shared memory-cache clear 已在同一 backend lock 内
   原子执行；closed store 拒绝重新 bind，且三项均有独立回归合同。
@@ -93,6 +94,12 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
   CPU 消费门禁均已纳入自动测试；本地同 runner 的 `fe623e68`/candidate
   16/64/180 MiB comparison 也已通过。该指标只证明完整 CPU payload 消费，不声明
   等价于真实 GPU upload；renderer 路径继续由现有三平台 GPU-first 合同覆盖。
+- 任意运行期 SQLite `DatabaseError` 现在统一关闭当前 connection，并将 index 标记为
+  `needs_recovery`/`rebuild_required`；lookup 和 checksum-state 故障在 cache 边界转为
+  miss，图片请求回退 delegate decode。maintenance/recovery 故障不会删除健康 payload
+  或提交 clean 状态，后续恢复会先隔离损坏数据库、重建 metadata、扫描 payload、重算
+  字节和提交维护状态，最后才标记 recovered。真实 connection fault-injection 已覆盖
+  lookup、checksum、upsert、LRU 和 recovery 枚举失败。
 - 最后用户版本 v6.6.8 不包含 neutral-surface 持久化格式；兼容路径为“无旧 cache →
   初始化 v3”，不读取或迁移开发阶段 v2。
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 正在收口跨进程 cache namespace ownership | `in_progress` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 已完成跨进程 cache namespace ownership，并通过全部非 Windows 长尾门禁 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -114,8 +114,11 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
   以 30 秒 monotonic cooldown 自动重试；clean owner handoff 不扫描目录，crashed owner
   则沿既有 dirty recovery 扫描。实现/合同 SHA 为 `b839950a`、`f1aac226`、`50b46215`；
   本地 cache+benchmark 59 项、Detail/GPU-first 137 项、startup 108 项、完整 pytest
-  2928 项以及架构、compileall、Ruff、diff check 已通过，TD 状态暂保持 `in_progress`
-  等待该实现 head 的三平台证据。
+  2928 项以及架构、compileall、Ruff、diff check 已通过。实现/验证 head `6bb3bdbc` 的
+  [Actions run 31379327676](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31379327676)
+  已通过三平台 surface-cache、GPU-first、startup、完整 `test` 等全部 14 个非 Windows
+  长尾 job，并确认 Ubuntu、macOS、Windows 三份原始 cache JSON artifacts 均存在；归属
+  TD-890-03 的 Windows Pets production-shape 在记录时仍运行，不作为本轮阻塞项。
 - 最后用户版本 v6.6.8 不包含 neutral-surface 持久化格式；兼容路径为“无旧 cache →
   初始化 v3”，不读取或迁移开发阶段 v2。
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 multi-generation clean-marker lease ownership 正在验证 | `in_progress` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 已完成 multi-generation clean-marker lease ownership，并通过全部非 Windows 长尾门禁 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -100,6 +100,14 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
   或提交 clean 状态，后续恢复会先隔离损坏数据库、重建 metadata、扫描 payload、重算
   字节和提交维护状态，最后才标记 recovered。真实 connection fault-injection 已覆盖
   lookup、checksum、upsert、LRU 和 recovery 枚举失败。
+- 同 root 的多 generation 现在以 SQLite `owner_session`、`active_leases` 和
+  `recovery_required` 管理 clean marker；同进程 A→B→A 不会假触发 payload scan，旧 A1
+  close 只释放自身 lease，最终 A2 clean close 才能写 `clean_shutdown=1`。实现 SHA
+  `15b15653` 的
+  [Actions run 31374649564](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31374649564)
+  已通过三平台 surface-cache、GPU-first、startup、完整 `test` 等共 14 个非 Windows
+  长尾 job，三平台原始 cache JSON artifacts 均存在；归属 TD-890-03 的 Windows Pets
+  production-shape 在记录时仍运行，不作为本轮自动通过判定的阻塞项。
 - 最后用户版本 v6.6.8 不包含 neutral-surface 持久化格式；兼容路径为“无旧 cache →
   初始化 v3”，不读取或迁移开发阶段 v2。
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 recovery/lifecycle、三平台 cache benchmark 与既有 renderer/startup 合同均已通过 | `automated_pass` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 最新 edge-case 审查修复正在验证，最终 head 三平台证据待补 | `in_progress` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,8 +21,8 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | 大 surface 命中仍完整扫描 payload；每次写入复制整块 RGBA 并全目录排序 | `not_started` |
-| TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | LRU 淘汰不能释放 session 强引用；RAW 中间数组不受最终 surface 预算约束 | `not_started` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | v3/SQLite 实现与三平台 benchmark 门禁已提交，等待 PR head CI 证据 | `in_progress` |
+| TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
 | TD-890-05 | P3 | 大型跨子系统 PR 的回滚和归因边界不足 | 历史 PR 无法安全追溯拆分；未来同类变更仍可能形成不可独立回滚的组合 | `process_debt` |
@@ -72,6 +72,17 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 - Detail cold/warm benchmark 不退化，跨平台 shutdown 不遗留 cache executor 或
   打开的 mmap/file owner。
 
+### 当前实施证据
+
+- `codex/td-890-surface-cache-index` 将 namespace 提升到 v3，并以 SQLite
+  `index.sqlite3` 持久化 entry、LRU、checksum trust 和维护水位；可信命中不再调用
+  payload checksum。
+- 写入改为 4 MiB buffer 分块、增量 xxhash、fsync 和原子 replace，不再创建完整
+  Python payload 副本；last-access、异常恢复、抽样审计和低水位 prune 均有独立合同。
+- `detail-surface-cache-contract` 在同一 runner checkout 固定 `fe623e68` 基线与候选
+  head，覆盖 16/64/180 MiB 并上传原始 JSON。三平台 head run 成功前本项保持
+  `in_progress`，不得提前改为 `automated_pass`。
+
 ## TD-890-02：统一 surface/RAW 内存所有权
 
 ### 当前证据
@@ -116,6 +127,11 @@ presentation、pending upload 或 GPU staging 间接保留。当前 `budget_byte
 
 不要把四个阶段压入一个不可回滚提交。每个阶段都必须保持现有 generation、
 library epoch、source identity 和 Edit handle 生命周期合同。
+
+当前首批只完成观测阶段：`SurfaceResidencyTracker` 区分唯一资源和 owner 引用，记录
+CPU heap、mmap、upload staging、GPU estimated 与 RAW intermediate 字节；它不拥有资源、
+不拒绝分配，也不改变现有 LRU/session/GPU 行为。后续 CPU/session PR 才引入
+`SurfaceOwner`/`SurfaceLease` 执行合同。
 
 ### 验收门禁
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 recovery/lifecycle 收口已完成本地验证，最终 head 三平台证据待补 | `in_progress` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 recovery/lifecycle、三平台 cache benchmark 与既有 renderer/startup 合同均已通过 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -80,13 +80,15 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 - 写入改为 4 MiB buffer 分块、增量 xxhash、fsync 和原子 replace，不再创建完整
   Python payload 副本；last-access、异常恢复、抽样审计和低水位 prune 均有独立合同。
 - `detail-surface-cache-contract` 在同一 runner checkout 固定 `fe623e68` 基线与候选
-  head，覆盖 16/64/180 MiB 并上传原始 JSON。此前实现 SHA `034df643` 的
-  [Actions run 31339926157](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31339926157)
-  已在 Ubuntu、macOS 和 Windows 通过；PR #903 当前 head 新增了 generation close
-  barrier、失败恢复合同，以及 fresh-process/warm 的完整 mmap payload CPU 消费门禁。
-- 本地同 runner 的 `fe623e68`/candidate 16/64/180 MiB comparison 已通过；该指标只
-  证明完整 CPU payload 消费，不声明等价于真实 GPU upload。最终 head 三平台 artifact
-  与 GPU-first 合同完成前，本项暂为 `in_progress`。
+  head，覆盖 16/64/180 MiB 并上传原始 JSON。实现 SHA `a0e9ca97` 的
+  [Actions run 31342634841](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31342634841)
+  已在 Ubuntu、macOS 和 Windows 通过该合同；同一 run 的三平台 GPU-first、startup
+  合同及完整 `test` job 也已通过。该 run 当时仍在执行归属 TD-890-03 的 Windows
+  Pets production-shape job，因此这里不把整个 workflow 提前描述为全部完成。
+- generation close barrier、失败恢复合同，以及 fresh-process/warm 的完整 mmap payload
+  CPU 消费门禁均已纳入自动测试；本地同 runner 的 `fe623e68`/candidate
+  16/64/180 MiB comparison 也已通过。该指标只证明完整 CPU payload 消费，不声明
+  等价于真实 GPU upload；renderer 路径继续由现有三平台 GPU-first 合同覆盖。
 - 最后用户版本 v6.6.8 不包含 neutral-surface 持久化格式；兼容路径为“无旧 cache →
   初始化 v3”，不读取或迁移开发阶段 v2。
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 最新 edge-case 审查修复正在验证，最终 head 三平台证据待补 | `in_progress` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 recovery/lifecycle、edge-case 修复与三平台自动证据均已通过 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -80,11 +80,15 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 - 写入改为 4 MiB buffer 分块、增量 xxhash、fsync 和原子 replace，不再创建完整
   Python payload 副本；last-access、异常恢复、抽样审计和低水位 prune 均有独立合同。
 - `detail-surface-cache-contract` 在同一 runner checkout 固定 `fe623e68` 基线与候选
-  head，覆盖 16/64/180 MiB 并上传原始 JSON。实现 SHA `a0e9ca97` 的
-  [Actions run 31342634841](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31342634841)
+  head，覆盖 16/64/180 MiB 并上传原始 JSON。edge-case 实现 SHA `0a9f7d1a` 的
+  [Actions run 31363902491](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31363902491)
   已在 Ubuntu、macOS 和 Windows 通过该合同；同一 run 的三平台 GPU-first、startup
-  合同及完整 `test` job 也已通过。该 run 当时仍在执行归属 TD-890-03 的 Windows
-  Pets production-shape job，因此这里不把整个 workflow 提前描述为全部完成。
+  合同及完整 `test` job 也已通过。记录证据时该 run 仍在执行归属 TD-890-03 的
+  macOS/Windows Pets production-shape job，因此这里不把整个 workflow 提前描述为
+  全部完成。
+- 磁盘容量查询失败现在会跳过 prune 并保留维护水位，显式零预算仍保持清空语义；
+  跨库 generation retire/swap 与 shared memory-cache clear 已在同一 backend lock 内
+  原子执行；closed store 拒绝重新 bind，且三项均有独立回归合同。
 - generation close barrier、失败恢复合同，以及 fresh-process/warm 的完整 mmap payload
   CPU 消费门禁均已纳入自动测试；本地同 runner 的 `fe623e68`/candidate
   16/64/180 MiB comparison 也已通过。该指标只证明完整 CPU payload 消费，不声明

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 已完成 multi-generation clean-marker lease ownership，并通过全部非 Windows 长尾门禁 | `automated_pass` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 正在收口跨进程 cache namespace ownership | `in_progress` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -108,6 +108,14 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
   已通过三平台 surface-cache、GPU-first、startup、完整 `test` 等共 14 个非 Windows
   长尾 job，三平台原始 cache JSON artifacts 均存在；归属 TD-890-03 的 Windows Pets
   production-shape 在记录时仍运行，不作为本轮自动通过判定的阻塞项。
+- 跨进程 ownership 收口在 cache namespace 上增加 canonical `QLockFile` 独占锁；第二个
+  进程无法取得锁时只禁用该图库的 surface disk tier，lookup/write/maintenance 均在
+  SQLite 和 payload 边界前 fail-open，原图 decode 与 memory cache 继续可用。锁释放后
+  以 30 秒 monotonic cooldown 自动重试；clean owner handoff 不扫描目录，crashed owner
+  则沿既有 dirty recovery 扫描。实现/合同 SHA 为 `b839950a`、`f1aac226`、`50b46215`；
+  本地 cache+benchmark 59 项、Detail/GPU-first 137 项、startup 108 项、完整 pytest
+  2928 项以及架构、compileall、Ruff、diff check 已通过，TD 状态暂保持 `in_progress`
+  等待该实现 head 的三平台证据。
 - 最后用户版本 v6.6.8 不包含 neutral-surface 持久化格式；兼容路径为“无旧 cache →
   初始化 v3”，不读取或迁移开发阶段 v2。
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 recovery/lifecycle、edge-case 修复与三平台自动证据均已通过 | `automated_pass` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 SQLite 运行期 fail-open/recovery 修复正在验证 | `in_progress` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | v3/SQLite 实现与三平台 benchmark 门禁已提交，等待 PR head CI 证据 | `in_progress` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | v3/SQLite 与固定基线 benchmark 已在三平台通过 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -80,8 +80,9 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 - 写入改为 4 MiB buffer 分块、增量 xxhash、fsync 和原子 replace，不再创建完整
   Python payload 副本；last-access、异常恢复、抽样审计和低水位 prune 均有独立合同。
 - `detail-surface-cache-contract` 在同一 runner checkout 固定 `fe623e68` 基线与候选
-  head，覆盖 16/64/180 MiB 并上传原始 JSON。三平台 head run 成功前本项保持
-  `in_progress`，不得提前改为 `automated_pass`。
+  head，覆盖 16/64/180 MiB 并上传原始 JSON。[Actions run 31339926157](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31339926157)
+  已对实现 SHA `034df643` 在 Ubuntu、macOS 和 Windows 全部通过，因此本项更新为
+  `automated_pass`。
 
 ## TD-890-02：统一 surface/RAW 内存所有权
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 已完成 SQLite 运行期 fail-open/rebuild/recovery，并通过最终实现 head 的完整门禁 | `automated_pass` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 multi-generation clean-marker lease ownership 正在验证 | `in_progress` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -1,6 +1,6 @@
 # PR #890 延期技术债务台账
 
-更新日期：2026-08-09
+更新日期：2026-08-10
 
 ## 状态与范围
 
@@ -21,7 +21,7 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 
 | ID | 优先级 | 债务 | 当前风险 | 状态 |
 | --- | --- | --- | --- | --- |
-| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | v3/SQLite 与固定基线 benchmark 已在三平台通过 | `automated_pass` |
+| TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 recovery/lifecycle 收口已完成本地验证，最终 head 三平台证据待补 | `in_progress` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
 | TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
 | TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
@@ -80,9 +80,15 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 - 写入改为 4 MiB buffer 分块、增量 xxhash、fsync 和原子 replace，不再创建完整
   Python payload 副本；last-access、异常恢复、抽样审计和低水位 prune 均有独立合同。
 - `detail-surface-cache-contract` 在同一 runner checkout 固定 `fe623e68` 基线与候选
-  head，覆盖 16/64/180 MiB 并上传原始 JSON。[Actions run 31339926157](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31339926157)
-  已对实现 SHA `034df643` 在 Ubuntu、macOS 和 Windows 全部通过，因此本项更新为
-  `automated_pass`。
+  head，覆盖 16/64/180 MiB 并上传原始 JSON。此前实现 SHA `034df643` 的
+  [Actions run 31339926157](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31339926157)
+  已在 Ubuntu、macOS 和 Windows 通过；PR #903 当前 head 新增了 generation close
+  barrier、失败恢复合同，以及 fresh-process/warm 的完整 mmap payload CPU 消费门禁。
+- 本地同 runner 的 `fe623e68`/candidate 16/64/180 MiB comparison 已通过；该指标只
+  证明完整 CPU payload 消费，不声明等价于真实 GPU upload。最终 head 三平台 artifact
+  与 GPU-first 合同完成前，本项暂为 `in_progress`。
+- 最后用户版本 v6.6.8 不包含 neutral-surface 持久化格式；兼容路径为“无旧 cache →
+  初始化 v3”，不读取或迁移开发阶段 v2。
 
 ## TD-890-02：统一 surface/RAW 内存所有权
 

--- a/src/iPhoto/gui/detail_decode_backend.py
+++ b/src/iPhoto/gui/detail_decode_backend.py
@@ -20,6 +20,10 @@ from iPhoto.gui.detail_pipeline import (
     DetailRenderRequest,
 )
 from iPhoto.gui.detail_profile import emit_detail_event
+from iPhoto.gui.detail_surface_residency import (
+    SurfaceByteBreakdown,
+    SurfaceResidencyTracker,
+)
 from iPhoto.utils.deps import load_pillow
 
 _MAX_DETAIL_SURFACE_BYTES = 192 * 1024 * 1024
@@ -52,10 +56,13 @@ class StillDecodeBackendRegistry:
         windows_backend: StillDecodeBackend | None = None,
         qt_backend: StillDecodeBackend | None = None,
         raw_backend: StillDecodeBackend | None = None,
+        residency_tracker: SurfaceResidencyTracker | None = None,
     ) -> None:
         self._platform = sys.platform if platform is None else platform
         self._qt = qt_backend or QtStillDecodeBackend()
-        self._raw = raw_backend or RawStillDecodeBackend()
+        self._raw = raw_backend or RawStillDecodeBackend(
+            residency_tracker=residency_tracker
+        )
         self._macos = macos_backend or (
             _load_macos_imageio_backend() if self._platform == "darwin" else None
         )
@@ -278,6 +285,13 @@ class RawStillDecodeBackend:
 
     name = "rawpy"
 
+    def __init__(
+        self,
+        *,
+        residency_tracker: SurfaceResidencyTracker | None = None,
+    ) -> None:
+        self._residency_tracker = residency_tracker
+
     def decode(
         self,
         request: DetailRenderRequest,
@@ -361,7 +375,32 @@ class RawStillDecodeBackend:
                 )
                 _check_cancelled(cancellation)
                 started = time.perf_counter()
-                image = _qimage_from_array(rgb)
+                raw_resource_id = (
+                    "raw-intermediate",
+                    prepared.asset_id,
+                    prepared.generation,
+                    id(rgb),
+                )
+                raw_owner_id = f"raw-decoder:{prepared.generation}:{prepared.asset_id}"
+                if self._residency_tracker is not None:
+                    self._residency_tracker.retain(
+                        raw_owner_id,
+                        "raw_decoder",
+                        raw_resource_id,
+                        SurfaceByteBreakdown(
+                            raw_intermediate=max(0, int(getattr(rgb, "nbytes", 0)))
+                        ),
+                        generation=prepared.generation,
+                    )
+                try:
+                    image = _qimage_from_array(rgb)
+                finally:
+                    if self._residency_tracker is not None:
+                        self._residency_tracker.release(
+                            raw_owner_id,
+                            raw_resource_id,
+                            generation=prepared.generation,
+                        )
                 emit_detail_event(
                     "raw_surface_convert",
                     generation=prepared.generation,
@@ -406,8 +445,15 @@ class RawStillDecodeBackend:
 class DefaultStillDecodeBackend:
     """Route RAW formats to rawpy and all other stills to Qt."""
 
-    def __init__(self, registry: StillDecodeBackendRegistry | None = None) -> None:
-        self._registry = registry or StillDecodeBackendRegistry()
+    def __init__(
+        self,
+        registry: StillDecodeBackendRegistry | None = None,
+        *,
+        residency_tracker: SurfaceResidencyTracker | None = None,
+    ) -> None:
+        self._registry = registry or StillDecodeBackendRegistry(
+            residency_tracker=residency_tracker
+        )
 
     def decode(
         self,

--- a/src/iPhoto/gui/detail_render_session.py
+++ b/src/iPhoto/gui/detail_render_session.py
@@ -12,7 +12,10 @@ from iPhoto.core.adjustment_mapping import resolve_adjustment_mapping
 from iPhoto.core.color_resolver import ColorStats
 from iPhoto.gui.detail_decode_backend import DecodedSurface
 from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailDecodeKey
-
+from iPhoto.gui.detail_surface_residency import (
+    SurfaceResidencyTracker,
+    surface_resource_id,
+)
 
 EditRevisionKind = Literal["index", "session", "commit"]
 
@@ -72,12 +75,19 @@ class PhotoRenderSessionHandle:
     baseline_state: EditRenderState
     available_lods: set[int | str] = field(default_factory=set)
     edit_references: int = 0
+    residency_tracker: SurfaceResidencyTracker | None = None
     _revision_counter: int = 0
     _surfaces_by_key: dict[DetailDecodeKey, DecodedSurface] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.available_lods.add(self.current_surface.decode_level)
         self._surfaces_by_key[self.current_surface.decode_key] = self.current_surface
+        if self.residency_tracker is not None:
+            self.residency_tracker.retain_surface(
+                self._residency_owner_id,
+                "render_session",
+                self.current_surface,
+            )
         self._revision_counter = max(
             int(self.source_identity.index_revision),
             int(self.edit_state.revision[1]),
@@ -98,8 +108,20 @@ class PhotoRenderSessionHandle:
     def retain_surface(self, surface: DecodedSurface) -> None:
         """Retain a decoded LOD without making it the presented surface."""
 
+        previous = self._surfaces_by_key.get(surface.decode_key)
+        if previous is not None and self.residency_tracker is not None:
+            self.residency_tracker.release(
+                self._residency_owner_id,
+                surface_resource_id(previous),
+            )
         self._surfaces_by_key[surface.decode_key] = surface
         self.available_lods.add(surface.decode_level)
+        if self.residency_tracker is not None:
+            self.residency_tracker.retain_surface(
+                self._residency_owner_id,
+                "render_session",
+                surface,
+            )
 
     def activate_surface(self, key: DetailDecodeKey) -> bool:
         surface = self._surfaces_by_key.get(key)
@@ -112,6 +134,16 @@ class PhotoRenderSessionHandle:
         """Return a retained LOD surface without changing session state."""
 
         return self._surfaces_by_key.get(key)
+
+    @property
+    def _residency_owner_id(self) -> str:
+        return f"render-session:{self.session_id}"
+
+    def release_residency_observations(self) -> None:
+        """Drop diagnostic owner references without changing surface lifetime."""
+
+        if self.residency_tracker is not None:
+            self.residency_tracker.release(self._residency_owner_id)
 
     def next_state(
         self,

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -471,7 +471,10 @@ class NeutralSurfaceStore:
         index = self._index_for_root()
         if index is None or not index.ensure_open():
             return False
+        digest = _key_digest(request)
         temporary: Path | None = None
+        replaced = False
+        metadata_committed = False
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
             payload = memoryview(image.constBits())[:payload_size]
@@ -511,11 +514,13 @@ class NeutralSurfaceStore:
                 stream.flush()
                 os.fsync(stream.fileno())
             os.replace(temporary, path)
+            replaced = True
+            temporary = None
             stat = path.stat()
             now = time.time_ns()
             indexed = index.upsert(
                 SurfaceCacheIndexEntry(
-                    digest=_key_digest(request),
+                    digest=digest,
                     relative_path=path.relative_to(index.root).as_posix(),
                     container_schema=_SCHEMA,
                     decoder_contract=_DECODE_SEMANTICS_CONTRACT,
@@ -530,7 +535,9 @@ class NeutralSurfaceStore:
                 )
             )
             if not indexed:
+                self._cleanup_failed_write(index, digest, path)
                 return False
+            metadata_committed = True
             if index.maintenance_due(
                 self._budget_bytes(),
                 byte_interval=_MAINTENANCE_WRITE_BYTES,
@@ -540,12 +547,29 @@ class NeutralSurfaceStore:
             self._cleanup_legacy_cache()
             return True
         except (BufferError, OSError, ValueError):
-            try:
-                if temporary is not None:
+            if replaced and not metadata_committed:
+                self._cleanup_failed_write(index, digest, path)
+            elif temporary is not None:
+                try:
                     temporary.unlink(missing_ok=True)
-            except OSError:
-                pass
+                except OSError:
+                    index.mark_recovery_required()
             return False
+
+    @staticmethod
+    def _cleanup_failed_write(
+        index: SurfaceCacheIndex,
+        digest: str,
+        path: Path,
+    ) -> None:
+        payload_removed = True
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            payload_removed = False
+        row_removed = index.remove(digest)
+        if not payload_removed or not row_removed:
+            index.mark_recovery_required()
 
     def discard(self, request: DetailRenderRequest) -> None:
         path = self.entry_path(request)
@@ -601,6 +625,8 @@ class NeutralSurfaceStore:
                 return
             if recover or index.needs_recovery:
                 self._recover_index(index)
+                if index.needs_recovery:
+                    return
             index.flush_accesses(force=True)
             budget = self._budget_bytes()
             due = force_prune or index.maintenance_due(
@@ -611,9 +637,11 @@ class NeutralSurfaceStore:
             if not due:
                 return
             target = int(budget * 0.9)
+            maintenance_failed = False
             while index.indexed_bytes > target:
                 victims = index.lru_victims(limit=_PRUNE_BATCH)
                 if not victims:
+                    maintenance_failed = True
                     break
                 removed = 0
                 for victim in victims:
@@ -621,18 +649,30 @@ class NeutralSurfaceStore:
                         break
                     path = self._indexed_path(index, victim.relative_path)
                     if path is None:
-                        index.remove(victim.digest)
+                        if not index.remove(victim.digest):
+                            index.mark_recovery_required()
+                            maintenance_failed = True
+                            break
                         removed += 1
                         continue
                     try:
                         path.unlink(missing_ok=True)
                     except OSError:
+                        index.mark_recovery_required()
+                        maintenance_failed = True
                         continue
-                    index.remove(victim.digest)
+                    if not index.remove(victim.digest):
+                        index.mark_recovery_required()
+                        maintenance_failed = True
+                        break
                     removed += 1
-                if removed == 0:
+                if maintenance_failed:
                     break
-            index.finish_maintenance()
+                if removed == 0:
+                    maintenance_failed = True
+                    break
+            if not maintenance_failed:
+                index.finish_maintenance()
 
     def close(self) -> None:
         with self._lock:
@@ -660,11 +700,12 @@ class NeutralSurfaceStore:
     def _recover_index(self, index: SurfaceCacheIndex) -> None:
         indexed = {entry.digest: entry for entry in index.all_entries()}
         seen: set[str] = set()
+        recovered = True
         for temporary in index.root.glob("*/*.tmp"):
             try:
                 temporary.unlink(missing_ok=True)
             except OSError:
-                pass
+                recovered = False
         for path in index.root.glob("*/*.ipsurface"):
             mapping: mmap.mmap | None = None
             file = None
@@ -679,7 +720,7 @@ class NeutralSurfaceStore:
                 now = time.time_ns()
                 previous = indexed.get(digest)
                 seen.add(digest)
-                index.upsert(
+                if not index.upsert(
                     SurfaceCacheIndexEntry(
                         digest=digest,
                         relative_path=path.relative_to(index.root).as_posix(),
@@ -694,12 +735,13 @@ class NeutralSurfaceStore:
                         last_access_ns=previous.last_access_ns if previous is not None else now,
                         last_verified_ns=0,
                     )
-                )
+                ):
+                    recovered = False
             except (KeyError, OSError, SurfaceCacheCorruptError, ValueError):
                 try:
                     path.unlink(missing_ok=True)
                 except OSError:
-                    pass
+                    recovered = False
             finally:
                 try:
                     if mapping is not None:
@@ -710,10 +752,13 @@ class NeutralSurfaceStore:
                     file.close()
         for digest in indexed:
             if digest not in seen:
-                index.remove(digest)
+                recovered = index.remove(digest) and recovered
         index.recalculate_indexed_bytes()
-        index.mark_recovered()
-        index.finish_maintenance()
+        if recovered:
+            index.mark_recovered()
+            index.finish_maintenance()
+        else:
+            index.mark_recovery_required()
 
     @staticmethod
     def _read_header(mapping: mmap.mmap) -> tuple[dict, int, int]:
@@ -771,13 +816,15 @@ class NeutralSurfaceStore:
                 file.close()
 
     def _discard_digest(self, digest: str, path: Path) -> None:
+        index = self._index_for_root()
         try:
             path.unlink(missing_ok=True)
         except OSError:
+            if index is not None:
+                index.mark_recovery_required()
             return
-        index = self._index_for_root()
-        if index is not None:
-            index.remove(digest)
+        if index is not None and not index.remove(digest):
+            index.mark_recovery_required()
 
     @staticmethod
     def _indexed_path(index: SurfaceCacheIndex, relative_path: str) -> Path | None:

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -921,12 +921,12 @@ class CachedStillDecodeBackend:
                 height=surface.decoded_size[1],
             )
 
-    def _submit(self, fn, *args) -> None:
+    def _submit(self, fn, *args, **kwargs) -> None:
         with self._lock:
             if self._shutting_down:
                 return
             try:
-                future = self._io.submit(fn, *args)
+                future = self._io.submit(fn, *args, **kwargs)
             except RuntimeError:
                 return
             self._futures.add(future)

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -317,8 +317,8 @@ class NeutralSurfaceStore:
                 return None
         try:
             library_root = root.parents[3]
-            request.source_identity.path.relative_to(library_root)
-        except (IndexError, ValueError):
+            request.source_identity.path.resolve(strict=False).relative_to(library_root)
+        except (IndexError, OSError, ValueError):
             # A request that outlived a library rebind must never populate the
             # newly active library's cache namespace.
             return None

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -485,10 +485,13 @@ class NeutralSurfaceStore:
         index = self._index_for_root()
         if index is None or not index.ensure_open():
             return False
-        if index.needs_recovery:
-            self.maintenance(recover=True)
+        try:
             if index.needs_recovery:
-                return False
+                self.maintenance(recover=True)
+                if index.needs_recovery:
+                    return False
+        except SurfaceCacheIndexUnavailableError:
+            return False
         digest = _key_digest(request)
         temporary: Path | None = None
         replaced = False

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -260,10 +260,13 @@ class NeutralSurfaceStore:
                 / "v3"
             )
         with self._lock:
+            if self._closed:
+                raise RuntimeError(
+                    "NeutralSurfaceStore is closed; create a new store generation"
+                )
             previous = self._index
             self._index = None
             self._root = root
-            self._closed = False
             self._disk_hit_count = 0
             self._pending_audits.clear()
             self._legacy_cleanup_done = False

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -538,8 +538,9 @@ class NeutralSurfaceStore:
                 self._cleanup_failed_write(index, digest, path)
                 return False
             metadata_committed = True
-            if index.maintenance_due(
-                self._budget_bytes(),
+            budget = self._budget_bytes()
+            if budget is not None and index.maintenance_due(
+                budget,
                 byte_interval=_MAINTENANCE_WRITE_BYTES,
                 time_interval_ns=_MAINTENANCE_INTERVAL_NS,
             ):
@@ -629,6 +630,8 @@ class NeutralSurfaceStore:
                     return
             index.flush_accesses(force=True)
             budget = self._budget_bytes()
+            if budget is None:
+                return
             due = force_prune or index.maintenance_due(
                 budget,
                 byte_interval=_MAINTENANCE_WRITE_BYTES,
@@ -685,17 +688,17 @@ class NeutralSurfaceStore:
         if index is not None:
             index.close(clean=True)
 
-    def _budget_bytes(self) -> int:
+    def _budget_bytes(self) -> int | None:
         if self._budget_override is not None:
             return self._budget_override
         root = self.root
         if root is None:
-            return 0
+            return None
         try:
             probe = root if root.exists() else root.parents[3]
             return min(2 * _GIB, max(0, int(shutil.disk_usage(probe).free * 0.02)))
         except (IndexError, OSError):
-            return 0
+            return None
 
     def _recover_index(self, index: SurfaceCacheIndex) -> None:
         indexed = {entry.digest: entry for entry in index.all_entries()}

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -8,6 +8,7 @@ import mmap
 import os
 import shutil
 import struct
+import tempfile
 import time
 from collections import OrderedDict
 from concurrent.futures import Future, ThreadPoolExecutor, wait
@@ -27,6 +28,14 @@ from iPhoto.gui.detail_decode_backend import (
 )
 from iPhoto.gui.detail_pipeline import DetailDecodeKey, DetailRenderRequest
 from iPhoto.gui.detail_profile import emit_detail_event
+from iPhoto.gui.detail_surface_cache_index import (
+    SurfaceCacheIndex,
+    SurfaceCacheIndexEntry,
+)
+from iPhoto.gui.detail_surface_residency import (
+    SurfaceResidencyTracker,
+    surface_resource_id,
+)
 from iPhoto.infrastructure.services.thumbnail_runtime_policy import (
     resolve_physical_memory_bytes,
 )
@@ -39,7 +48,7 @@ except ImportError:  # pragma: no cover - declared production dependency
 _MIB: Final = 1024 * 1024
 _GIB: Final = 1024 * _MIB
 _MAGIC: Final = b"IPHSURF\0"
-_SCHEMA: Final = 2
+_SCHEMA: Final = 3
 # Bump this when decoder semantics can change the pixels for an otherwise
 # identical source identity.  This is intentionally separate from _SCHEMA:
 # the on-disk container remains readable, but surfaces produced by the old
@@ -49,6 +58,12 @@ _SCHEMA: Final = 2
 # oriented and the old pipeline rotated a second time.
 _DECODE_SEMANTICS_CONTRACT: Final = 2
 _HEADER_SIZE: Final = 4096
+_WRITE_CHUNK_BYTES: Final = 4 * _MIB
+_ACCESS_AUDIT_INTERVAL: Final = 128
+_AUDIT_MAX_AGE_NS: Final = 30 * 24 * 60 * 60 * 1_000_000_000
+_MAINTENANCE_WRITE_BYTES: Final = 256 * _MIB
+_MAINTENANCE_INTERVAL_NS: Final = 10 * 60 * 1_000_000_000
+_PRUNE_BATCH: Final = 128
 _PREFIX = struct.Struct("<8sIIIQQ")
 
 
@@ -80,11 +95,22 @@ def _surface_bytes(surface: DecodedSurface) -> int:
 class MappedSurfaceCache:
     """Thread-safe byte-budgeted LRU for heap and mmap-backed surfaces."""
 
-    def __init__(self, budget_bytes: int | None = None) -> None:
+    _OWNER_ID: Final = "detail-memory-cache"
+
+    def __init__(
+        self,
+        budget_bytes: int | None = None,
+        *,
+        residency_tracker: SurfaceResidencyTracker | None = None,
+    ) -> None:
         self._budget_bytes = max(1, int(budget_bytes or surface_memory_budget_bytes()))
-        self._entries: OrderedDict[DetailDecodeKey, tuple[DecodedSurface, int]] = OrderedDict()
+        self._entries: OrderedDict[
+            DetailDecodeKey,
+            tuple[DecodedSurface, int, object],
+        ] = OrderedDict()
         self._used_bytes = 0
         self._lock = RLock()
+        self._residency_tracker = residency_tracker
 
     @property
     def budget_bytes(self) -> int:
@@ -103,7 +129,7 @@ class MappedSurfaceCache:
             if value is None:
                 return None
             self._entries[key] = value
-            surface, _size = value
+            surface, _size, _resource_id = value
             return replace(surface, cache_tier="memory")
 
     def put(self, surface: DecodedSurface) -> bool:
@@ -119,11 +145,22 @@ class MappedSurfaceCache:
             previous = self._entries.pop(surface.decode_key, None)
             if previous is not None:
                 self._used_bytes -= previous[1]
-            self._entries[surface.decode_key] = (surface, size)
+                if self._residency_tracker is not None:
+                    self._residency_tracker.release(self._OWNER_ID, previous[2])
+            resource_id = surface_resource_id(surface)
+            self._entries[surface.decode_key] = (surface, size, resource_id)
             self._used_bytes += size
+            if self._residency_tracker is not None:
+                self._residency_tracker.retain_surface(
+                    self._OWNER_ID,
+                    "memory_cache",
+                    surface,
+                )
             while self._used_bytes > self._budget_bytes and self._entries:
-                _key, (_old, old_size) = self._entries.popitem(last=False)
+                _key, (_old, old_size, old_resource_id) = self._entries.popitem(last=False)
                 self._used_bytes -= old_size
+                if self._residency_tracker is not None:
+                    self._residency_tracker.release(self._OWNER_ID, old_resource_id)
         return True
 
     def invalidate_asset(self, asset_id: str) -> None:
@@ -131,13 +168,17 @@ class MappedSurfaceCache:
             for key in tuple(self._entries):
                 if key.asset_id != asset_id:
                     continue
-                _surface, size = self._entries.pop(key)
+                _surface, size, resource_id = self._entries.pop(key)
                 self._used_bytes -= size
+                if self._residency_tracker is not None:
+                    self._residency_tracker.release(self._OWNER_ID, resource_id)
 
     def clear(self) -> None:
         with self._lock:
             self._entries.clear()
             self._used_bytes = 0
+            if self._residency_tracker is not None:
+                self._residency_tracker.release(self._OWNER_ID)
 
 
 def _canonical_key(request: DetailRenderRequest) -> bytes:
@@ -168,9 +209,22 @@ def _checksum(payload: memoryview | bytes) -> int:
 class NeutralSurfaceStore:
     """Library-scoped, versioned, mmap-readable disk surface store."""
 
-    def __init__(self, library_root: Path | None = None) -> None:
+    def __init__(
+        self,
+        library_root: Path | None = None,
+        *,
+        budget_bytes: int | None = None,
+    ) -> None:
         self._root: Path | None = None
+        self._index: SurfaceCacheIndex | None = None
+        self._budget_override = (
+            max(0, int(budget_bytes)) if budget_bytes is not None else None
+        )
         self._lock = RLock()
+        self._maintenance_lock = RLock()
+        self._disk_hit_count = 0
+        self._pending_audits: set[str] = set()
+        self._legacy_cleanup_done = False
         self.bind_library(library_root)
 
     @property
@@ -181,9 +235,33 @@ class NeutralSurfaceStore:
     def bind_library(self, library_root: Path | None) -> None:
         root = None
         if library_root is not None:
-            root = Path(library_root).expanduser().absolute() / ".iPhoto" / "cache" / "detail-surfaces" / "v2"
+            root = (
+                Path(library_root).expanduser().absolute()
+                / ".iPhoto"
+                / "cache"
+                / "detail-surfaces"
+                / "v3"
+            )
         with self._lock:
+            previous = self._index
+            self._index = None
             self._root = root
+            self._disk_hit_count = 0
+            self._pending_audits.clear()
+            self._legacy_cleanup_done = False
+        if previous is not None:
+            previous.close(clean=True)
+
+    def _index_for_root(self) -> SurfaceCacheIndex | None:
+        root = self.root
+        if root is None:
+            return None
+        with self._lock:
+            index = self._index
+            if index is None or index.root != root:
+                index = SurfaceCacheIndex(root)
+                self._index = index
+            return index
 
     def entry_path(self, request: DetailRenderRequest) -> Path | None:
         if not request.source_identity.has_stable_revision:
@@ -205,18 +283,43 @@ class NeutralSurfaceStore:
         path = self.entry_path(request)
         if path is None:
             return None
+        index = self._index_for_root()
+        if index is None or not index.ensure_open():
+            return None
+        if index.needs_recovery:
+            self.maintenance(recover=True)
+        digest = _key_digest(request)
+        entry = index.get(digest)
+        if entry is None:
+            return None
+        if (
+            entry.container_schema != _SCHEMA
+            or entry.decoder_contract != _DECODE_SEMANTICS_CONTRACT
+            or Path(entry.relative_path).as_posix() != path.relative_to(index.root).as_posix()
+        ):
+            raise SurfaceCacheCorruptError("surface cache index contract mismatch")
         try:
             file = path.open("rb")
         except FileNotFoundError:
+            index.remove(digest)
             return None
         except OSError as exc:
             raise SurfaceCacheCorruptError(str(exc)) from exc
 
+        mapping: mmap.mmap | None = None
+        payload: memoryview | None = None
         try:
             mapping = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
             if len(mapping) < _HEADER_SIZE:
                 raise SurfaceCacheCorruptError("surface cache entry is truncated")
-            magic, schema, header_size, metadata_size, payload_size, checksum = _PREFIX.unpack_from(mapping)
+            (
+                magic,
+                schema,
+                header_size,
+                metadata_size,
+                payload_size,
+                checksum,
+            ) = _PREFIX.unpack_from(mapping)
             if magic != _MAGIC or schema != _SCHEMA or header_size != _HEADER_SIZE:
                 raise SurfaceCacheCorruptError("surface cache header/version mismatch")
             if metadata_size <= 0 or _PREFIX.size + metadata_size > _HEADER_SIZE:
@@ -224,22 +327,51 @@ class NeutralSurfaceStore:
             if payload_size <= 0 or _HEADER_SIZE + payload_size != len(mapping):
                 raise SurfaceCacheCorruptError("surface cache payload size is invalid")
             metadata = json.loads(bytes(mapping[_PREFIX.size:_PREFIX.size + metadata_size]))
-            if metadata.get("key_digest") != _key_digest(request):
+            if metadata.get("key_digest") != digest:
                 raise SurfaceCacheCorruptError("surface cache key mismatch")
+            if int(metadata.get("decoder_contract", -1)) != _DECODE_SEMANTICS_CONTRACT:
+                raise SurfaceCacheCorruptError("surface cache decoder contract mismatch")
             width = int(metadata["width"])
             height = int(metadata["height"])
             stride = int(metadata["stride"])
             if width <= 0 or height <= 0 or stride < width * 4 or stride * height != payload_size:
                 raise SurfaceCacheCorruptError("surface cache geometry is invalid")
+            stat = path.stat()
+            if (
+                int(stat.st_size) != entry.file_bytes
+                or int(stat.st_mtime_ns) != entry.file_mtime_ns
+                or int(payload_size) != entry.payload_bytes
+                or int(checksum) != entry.checksum
+            ):
+                raise SurfaceCacheCorruptError("surface cache file metadata mismatch")
             payload = memoryview(mapping)[_HEADER_SIZE:_HEADER_SIZE + payload_size]
-            # Validation also pre-faults mapped pages on this worker before the
-            # render thread consumes them for a texture upload.
-            if _checksum(payload) != checksum:
-                raise SurfaceCacheCorruptError("surface cache checksum mismatch")
-            try:
-                os.utime(path, None)
-            except OSError:
-                pass
+            last_verified_ns = entry.last_verified_ns
+            if entry.checksum_state != "trusted":
+                if _checksum(payload) != checksum:
+                    raise SurfaceCacheCorruptError("surface cache checksum mismatch")
+                last_verified_ns = time.time_ns()
+                index.mark_checksum_state(
+                    digest,
+                    "trusted",
+                    verified_ns=last_verified_ns,
+                )
+            now = time.time_ns()
+            flush_due = index.queue_access(digest, accessed_ns=now)
+            with self._lock:
+                self._disk_hit_count += 1
+                if (
+                    self._disk_hit_count % _ACCESS_AUDIT_INTERVAL == 0
+                    or now - last_verified_ns >= _AUDIT_MAX_AGE_NS
+                ):
+                    self._pending_audits.add(digest)
+            if flush_due:
+                # The cache backend schedules the actual transaction on its
+                # I/O lane. Direct store users may call flush_accesses_if_due().
+                emit_detail_event(
+                    "surface_cache_access_flush_due",
+                    generation=request.generation,
+                    asset_id=request.asset_id,
+                )
             owner = MappedSurfaceOwner(file, mapping, payload)
             image = QImage(payload, width, height, stride, QImage.Format.Format_RGBA8888)
             if image.isNull():
@@ -260,9 +392,15 @@ class NeutralSurfaceStore:
                 backing_owner=owner,
             )
         except Exception as exc:
+            if payload is not None:
+                try:
+                    payload.release()
+                except (BufferError, ValueError):
+                    pass
             try:
-                mapping.close()  # type: ignore[possibly-undefined]
-            except (BufferError, NameError, OSError):
+                if mapping is not None:
+                    mapping.close()
+            except (BufferError, OSError):
                 pass
             file.close()
             if isinstance(exc, SurfaceCacheCorruptError):
@@ -276,10 +414,11 @@ class NeutralSurfaceStore:
         image = surface.image
         if image.format() != QImage.Format.Format_RGBA8888:
             image = image.convertToFormat(QImage.Format.Format_RGBA8888)
-        payload = bytes(image.constBits()[: image.sizeInBytes()])
         metadata = json.dumps(
             {
                 "key_digest": _key_digest(request),
+                "container_schema": _SCHEMA,
+                "decoder_contract": _DECODE_SEMANTICS_CONTRACT,
                 "width": image.width(),
                 "height": image.height(),
                 "stride": image.bytesPerLine(),
@@ -303,67 +442,345 @@ class NeutralSurfaceStore:
         ).encode("utf-8")
         if _PREFIX.size + len(metadata) > _HEADER_SIZE:
             return False
-        header = bytearray(_HEADER_SIZE)
-        _PREFIX.pack_into(
-            header,
-            0,
-            _MAGIC,
-            _SCHEMA,
-            _HEADER_SIZE,
-            len(metadata),
-            len(payload),
-            _checksum(payload),
-        )
-        header[_PREFIX.size:_PREFIX.size + len(metadata)] = metadata
+        payload_size = int(image.sizeInBytes())
+        if payload_size <= 0:
+            return False
+        index = self._index_for_root()
+        if index is None or not index.ensure_open():
+            return False
+        temporary: Path | None = None
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-            with temporary.open("wb") as stream:
+            payload = memoryview(image.constBits())[:payload_size]
+            hasher = xxhash.xxh64() if xxhash is not None else hashlib.blake2b(digest_size=8)
+            with tempfile.NamedTemporaryFile(
+                mode="w+b",
+                prefix=f".{path.name}.{os.getpid()}.",
+                suffix=".tmp",
+                dir=path.parent,
+                delete=False,
+            ) as stream:
+                temporary = Path(stream.name)
+                stream.write(b"\0" * _HEADER_SIZE)
+                for offset in range(0, payload_size, _WRITE_CHUNK_BYTES):
+                    chunk = payload[offset:min(payload_size, offset + _WRITE_CHUNK_BYTES)]
+                    hasher.update(chunk)
+                    stream.write(chunk)
+                checksum = (
+                    int(hasher.intdigest())
+                    if xxhash is not None
+                    else int.from_bytes(hasher.digest(), "little")
+                )
+                header = bytearray(_HEADER_SIZE)
+                _PREFIX.pack_into(
+                    header,
+                    0,
+                    _MAGIC,
+                    _SCHEMA,
+                    _HEADER_SIZE,
+                    len(metadata),
+                    payload_size,
+                    checksum,
+                )
+                header[_PREFIX.size:_PREFIX.size + len(metadata)] = metadata
+                stream.seek(0)
                 stream.write(header)
-                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
             os.replace(temporary, path)
-            self.prune()
+            stat = path.stat()
+            now = time.time_ns()
+            indexed = index.upsert(
+                SurfaceCacheIndexEntry(
+                    digest=_key_digest(request),
+                    relative_path=path.relative_to(index.root).as_posix(),
+                    container_schema=_SCHEMA,
+                    decoder_contract=_DECODE_SEMANTICS_CONTRACT,
+                    payload_bytes=payload_size,
+                    file_bytes=int(stat.st_size),
+                    checksum=checksum,
+                    checksum_state="trusted",
+                    file_mtime_ns=int(stat.st_mtime_ns),
+                    created_ns=now,
+                    last_access_ns=now,
+                    last_verified_ns=now,
+                )
+            )
+            if not indexed:
+                return False
+            if index.maintenance_due(
+                self._budget_bytes(),
+                byte_interval=_MAINTENANCE_WRITE_BYTES,
+                time_interval_ns=_MAINTENANCE_INTERVAL_NS,
+            ):
+                self.maintenance()
+            self._cleanup_legacy_cache()
             return True
-        except OSError:
+        except (BufferError, OSError, ValueError):
             try:
-                temporary.unlink(missing_ok=True)  # type: ignore[possibly-undefined]
-            except (NameError, OSError):
+                if temporary is not None:
+                    temporary.unlink(missing_ok=True)
+            except OSError:
                 pass
             return False
 
     def discard(self, request: DetailRenderRequest) -> None:
         path = self.entry_path(request)
-        if path is not None:
-            try:
-                path.unlink(missing_ok=True)
-            except OSError:
-                pass
+        if path is None:
+            return
+        self._discard_digest(_key_digest(request), path)
 
     def prune(self) -> None:
-        root = self.root
-        if root is None or not root.exists():
+        """Compatibility entry point for an explicitly forced indexed prune."""
+
+        self.maintenance(force_prune=True)
+
+    def flush_accesses_if_due(self, *, force: bool = False) -> bool:
+        index = self._index_for_root()
+        return bool(index is not None and index.flush_accesses(force=force))
+
+    def run_pending_audits(self) -> None:
+        with self._lock:
+            digests = tuple(self._pending_audits)
+            self._pending_audits.clear()
+        index = self._index_for_root()
+        if index is None:
             return
-        try:
-            budget = min(2 * _GIB, max(0, int(shutil.disk_usage(root).free * 0.02)))
-            entries = []
-            total = 0
-            for path in root.glob("*/*.ipsurface"):
-                try:
-                    stat = path.stat()
-                except OSError:
-                    continue
-                total += int(stat.st_size)
-                entries.append((int(stat.st_mtime_ns), path, int(stat.st_size)))
-            for _mtime, path, size in sorted(entries):
-                if total <= budget:
+        for digest in digests:
+            entry = index.get(digest)
+            if entry is None:
+                continue
+            path = self._indexed_path(index, entry.relative_path)
+            if path is None:
+                index.remove(digest)
+                continue
+            if self._entry_checksum_is_valid(entry, path):
+                index.mark_checksum_state(digest, "trusted", verified_ns=time.time_ns())
+                continue
+            self._discard_digest(digest, path)
+            emit_detail_event(
+                "surface_cache_audit_failed",
+                generation=0,
+                digest_prefix=digest[:12],
+            )
+
+    def maintenance(
+        self,
+        *,
+        recover: bool = False,
+        force_prune: bool = False,
+    ) -> None:
+        """Recover if needed, flush access metadata, and prune from the SQL LRU."""
+
+        with self._maintenance_lock:
+            index = self._index_for_root()
+            if index is None or not index.ensure_open():
+                return
+            if recover or index.needs_recovery:
+                self._recover_index(index)
+            index.flush_accesses(force=True)
+            budget = self._budget_bytes()
+            due = force_prune or index.maintenance_due(
+                budget,
+                byte_interval=_MAINTENANCE_WRITE_BYTES,
+                time_interval_ns=_MAINTENANCE_INTERVAL_NS,
+            )
+            if not due:
+                return
+            target = int(budget * 0.9)
+            while index.indexed_bytes > target:
+                victims = index.lru_victims(limit=_PRUNE_BATCH)
+                if not victims:
                     break
+                removed = 0
+                for victim in victims:
+                    if index.indexed_bytes <= target:
+                        break
+                    path = self._indexed_path(index, victim.relative_path)
+                    if path is None:
+                        index.remove(victim.digest)
+                        removed += 1
+                        continue
+                    try:
+                        path.unlink(missing_ok=True)
+                    except OSError:
+                        continue
+                    index.remove(victim.digest)
+                    removed += 1
+                if removed == 0:
+                    break
+            index.finish_maintenance()
+
+    def close(self) -> None:
+        with self._lock:
+            index = self._index
+            self._index = None
+            self._pending_audits.clear()
+        if index is not None:
+            index.close(clean=True)
+
+    def _budget_bytes(self) -> int:
+        if self._budget_override is not None:
+            return self._budget_override
+        root = self.root
+        if root is None:
+            return 0
+        try:
+            probe = root if root.exists() else root.parents[3]
+            return min(2 * _GIB, max(0, int(shutil.disk_usage(probe).free * 0.02)))
+        except (IndexError, OSError):
+            return 0
+
+    def _recover_index(self, index: SurfaceCacheIndex) -> None:
+        indexed = {entry.digest: entry for entry in index.all_entries()}
+        seen: set[str] = set()
+        for temporary in index.root.glob("*/*.tmp"):
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+        for path in index.root.glob("*/*.ipsurface"):
+            mapping: mmap.mmap | None = None
+            file = None
+            try:
+                file = path.open("rb")
+                mapping = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
+                metadata, payload_size, checksum = self._read_header(mapping)
+                digest = str(metadata["key_digest"])
+                if path.name != f"{digest}.ipsurface":
+                    raise SurfaceCacheCorruptError("recovered cache filename mismatch")
+                stat = path.stat()
+                now = time.time_ns()
+                previous = indexed.get(digest)
+                seen.add(digest)
+                index.upsert(
+                    SurfaceCacheIndexEntry(
+                        digest=digest,
+                        relative_path=path.relative_to(index.root).as_posix(),
+                        container_schema=int(metadata.get("container_schema", _SCHEMA)),
+                        decoder_contract=int(metadata.get("decoder_contract", -1)),
+                        payload_bytes=payload_size,
+                        file_bytes=int(stat.st_size),
+                        checksum=checksum,
+                        checksum_state="untrusted",
+                        file_mtime_ns=int(stat.st_mtime_ns),
+                        created_ns=previous.created_ns if previous is not None else now,
+                        last_access_ns=previous.last_access_ns if previous is not None else now,
+                        last_verified_ns=0,
+                    )
+                )
+            except (KeyError, OSError, SurfaceCacheCorruptError, ValueError):
                 try:
-                    path.unlink()
-                    total -= size
+                    path.unlink(missing_ok=True)
                 except OSError:
-                    continue
+                    pass
+            finally:
+                try:
+                    if mapping is not None:
+                        mapping.close()
+                except (BufferError, OSError):
+                    pass
+                if file is not None:
+                    file.close()
+        for digest in indexed:
+            if digest not in seen:
+                index.remove(digest)
+        index.recalculate_indexed_bytes()
+        index.mark_recovered()
+        index.finish_maintenance()
+
+    @staticmethod
+    def _read_header(mapping: mmap.mmap) -> tuple[dict, int, int]:
+        if len(mapping) < _HEADER_SIZE:
+            raise SurfaceCacheCorruptError("surface cache entry is truncated")
+        magic, schema, header_size, metadata_size, payload_size, checksum = _PREFIX.unpack_from(
+            mapping
+        )
+        if magic != _MAGIC or schema != _SCHEMA or header_size != _HEADER_SIZE:
+            raise SurfaceCacheCorruptError("surface cache header/version mismatch")
+        if metadata_size <= 0 or _PREFIX.size + metadata_size > _HEADER_SIZE:
+            raise SurfaceCacheCorruptError("surface cache metadata size is invalid")
+        if payload_size <= 0 or _HEADER_SIZE + payload_size != len(mapping):
+            raise SurfaceCacheCorruptError("surface cache payload size is invalid")
+        try:
+            metadata = json.loads(bytes(mapping[_PREFIX.size:_PREFIX.size + metadata_size]))
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise SurfaceCacheCorruptError("surface cache metadata is invalid") from exc
+        return metadata, int(payload_size), int(checksum)
+
+    def _entry_checksum_is_valid(
+        self,
+        entry: SurfaceCacheIndexEntry,
+        path: Path,
+    ) -> bool:
+        file = None
+        mapping: mmap.mmap | None = None
+        payload: memoryview | None = None
+        try:
+            file = path.open("rb")
+            mapping = mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ)
+            metadata, payload_size, checksum = self._read_header(mapping)
+            if (
+                str(metadata.get("key_digest")) != entry.digest
+                or payload_size != entry.payload_bytes
+                or checksum != entry.checksum
+            ):
+                return False
+            payload = memoryview(mapping)[_HEADER_SIZE:_HEADER_SIZE + payload_size]
+            return _checksum(payload) == checksum
+        except (OSError, SurfaceCacheCorruptError, ValueError):
+            return False
+        finally:
+            if payload is not None:
+                try:
+                    payload.release()
+                except (BufferError, ValueError):
+                    pass
+            if mapping is not None:
+                try:
+                    mapping.close()
+                except (BufferError, OSError):
+                    pass
+            if file is not None:
+                file.close()
+
+    def _discard_digest(self, digest: str, path: Path) -> None:
+        try:
+            path.unlink(missing_ok=True)
         except OSError:
             return
+        index = self._index_for_root()
+        if index is not None:
+            index.remove(digest)
+
+    @staticmethod
+    def _indexed_path(index: SurfaceCacheIndex, relative_path: str) -> Path | None:
+        try:
+            root = index.root.resolve()
+            candidate = (root / str(relative_path)).resolve()
+            candidate.relative_to(root)
+        except (OSError, ValueError):
+            return None
+        return candidate
+
+    def _cleanup_legacy_cache(self) -> None:
+        with self._lock:
+            if self._legacy_cleanup_done:
+                return
+            self._legacy_cleanup_done = True
+        root = self.root
+        if root is None:
+            return
+        legacy = root.parent / "v2"
+        if legacy.name != "v2" or legacy.parent != root.parent:
+            return
+        try:
+            shutil.rmtree(legacy)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            with self._lock:
+                self._legacy_cleanup_done = False
 
 
 class CachedStillDecodeBackend:
@@ -375,9 +792,13 @@ class CachedStillDecodeBackend:
         *,
         memory_cache: MappedSurfaceCache | None = None,
         store: NeutralSurfaceStore | None = None,
+        residency_tracker: SurfaceResidencyTracker | None = None,
     ) -> None:
         self._delegate = delegate
-        self.memory_cache = memory_cache or MappedSurfaceCache()
+        self.residency_tracker = residency_tracker or SurfaceResidencyTracker()
+        self.memory_cache = memory_cache or MappedSurfaceCache(
+            residency_tracker=self.residency_tracker
+        )
         self.store = store or NeutralSurfaceStore()
         self._io = ThreadPoolExecutor(max_workers=1, thread_name_prefix="iPhoto-surface-cache")
         self._futures: set[Future] = set()
@@ -390,6 +811,7 @@ class CachedStillDecodeBackend:
         with self._lock:
             self._color_stats_by_source.clear()
         self.store.bind_library(library_root)
+        self._submit(self.store.maintenance, recover=True)
 
     @staticmethod
     def _source_stats_key(request: DetailRenderRequest) -> tuple:
@@ -418,7 +840,11 @@ class CachedStillDecodeBackend:
                 self._color_stats_by_source[key] = stats
             return stats
 
-    def decode(self, request: DetailRenderRequest, cancellation: CancellationToken) -> DecodedSurface:
+    def decode(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+    ) -> DecodedSurface:
         prepared = request.with_decode_level()
         key = DetailDecodeKey.from_request(prepared)
         cacheable = prepared.source_identity.has_stable_revision
@@ -427,13 +853,22 @@ class CachedStillDecodeBackend:
         surface = self.memory_cache.get(key) if cacheable else None
         if surface is not None:
             self._remember_color_stats(prepared, surface.color_stats)
-            emit_detail_event("surface_cache_hit", generation=prepared.generation, asset_id=key.asset_id, tier="memory")
+            emit_detail_event(
+                "surface_cache_hit",
+                generation=prepared.generation,
+                asset_id=key.asset_id,
+                tier="memory",
+            )
             return surface
         if cacheable:
             try:
                 surface = self.store.load(prepared)
             except SurfaceCacheCorruptError:
-                emit_detail_event("surface_cache_corrupt", generation=prepared.generation, asset_id=key.asset_id)
+                emit_detail_event(
+                    "surface_cache_corrupt",
+                    generation=prepared.generation,
+                    asset_id=key.asset_id,
+                )
                 self._submit(self.store.discard, prepared)
                 surface = None
         if surface is not None:
@@ -441,9 +876,20 @@ class CachedStillDecodeBackend:
                 raise DecodeCancelledError("Still-image decode cancelled")
             self.memory_cache.put(surface)
             self._remember_color_stats(prepared, surface.color_stats)
-            emit_detail_event("surface_cache_hit", generation=prepared.generation, asset_id=key.asset_id, tier="disk")
+            self._submit(self.store.flush_accesses_if_due)
+            self._submit(self.store.run_pending_audits)
+            emit_detail_event(
+                "surface_cache_hit",
+                generation=prepared.generation,
+                asset_id=key.asset_id,
+                tier="disk",
+            )
             return surface
-        emit_detail_event("surface_cache_miss", generation=prepared.generation, asset_id=key.asset_id)
+        emit_detail_event(
+            "surface_cache_miss",
+            generation=prepared.generation,
+            asset_id=key.asset_id,
+        )
         surface = self._delegate.decode(prepared, cancellation)
         stats = self._cached_color_stats(prepared) if cacheable else None
         if stats is None:
@@ -496,6 +942,10 @@ class CachedStillDecodeBackend:
             futures = tuple(self._futures)
         if futures:
             wait(futures, timeout=max(0, int(timeout_ms)) / 1000.0)
+        self.memory_cache.clear()
+        close_store = getattr(self.store, "close", None)
+        if callable(close_store):
+            close_store()
         self._io.shutdown(wait=False, cancel_futures=True)
 
 

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -32,6 +32,7 @@ from iPhoto.gui.detail_profile import emit_detail_event
 from iPhoto.gui.detail_surface_cache_index import (
     SurfaceCacheIndex,
     SurfaceCacheIndexEntry,
+    SurfaceCacheIndexUnavailableError,
 )
 from iPhoto.gui.detail_surface_residency import (
     SurfaceResidencyTracker,
@@ -312,10 +313,15 @@ class NeutralSurfaceStore:
         index = self._index_for_root()
         if index is None or not index.ensure_open():
             return None
-        if index.needs_recovery:
-            self.maintenance(recover=True)
         digest = _key_digest(request)
-        entry = index.get(digest)
+        try:
+            if index.needs_recovery:
+                self.maintenance(recover=True)
+                if index.needs_recovery:
+                    return None
+            entry = index.get(digest)
+        except SurfaceCacheIndexUnavailableError:
+            return None
         if entry is None:
             return None
         if (
@@ -327,7 +333,10 @@ class NeutralSurfaceStore:
         try:
             file = path.open("rb")
         except FileNotFoundError:
-            index.remove(digest)
+            try:
+                index.remove(digest)
+            except SurfaceCacheIndexUnavailableError:
+                pass
             return None
         except OSError as exc:
             raise SurfaceCacheCorruptError(str(exc)) from exc
@@ -429,6 +438,8 @@ class NeutralSurfaceStore:
             except (BufferError, OSError):
                 pass
             file.close()
+            if isinstance(exc, SurfaceCacheIndexUnavailableError):
+                return None
             if isinstance(exc, SurfaceCacheCorruptError):
                 raise
             raise SurfaceCacheCorruptError(str(exc)) from exc
@@ -474,6 +485,10 @@ class NeutralSurfaceStore:
         index = self._index_for_root()
         if index is None or not index.ensure_open():
             return False
+        if index.needs_recovery:
+            self.maintenance(recover=True)
+            if index.needs_recovery:
+                return False
         digest = _key_digest(request)
         temporary: Path | None = None
         replaced = False
@@ -550,6 +565,15 @@ class NeutralSurfaceStore:
                 self.maintenance()
             self._cleanup_legacy_cache()
             return True
+        except SurfaceCacheIndexUnavailableError:
+            if replaced and not metadata_committed:
+                self._cleanup_failed_write(index, digest, path)
+            elif temporary is not None:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    index.mark_recovery_required()
+            return metadata_committed
         except (BufferError, OSError, ValueError):
             if replaced and not metadata_committed:
                 self._cleanup_failed_write(index, digest, path)
@@ -571,7 +595,10 @@ class NeutralSurfaceStore:
             path.unlink(missing_ok=True)
         except OSError:
             payload_removed = False
-        row_removed = index.remove(digest)
+        try:
+            row_removed = index.remove(digest)
+        except SurfaceCacheIndexUnavailableError:
+            row_removed = False
         if not payload_removed or not row_removed:
             index.mark_recovery_required()
 
@@ -588,7 +615,10 @@ class NeutralSurfaceStore:
 
     def flush_accesses_if_due(self, *, force: bool = False) -> bool:
         index = self._index_for_root()
-        return bool(index is not None and index.flush_accesses(force=force))
+        try:
+            return bool(index is not None and index.flush_accesses(force=force))
+        except SurfaceCacheIndexUnavailableError:
+            return False
 
     def run_pending_audits(self) -> None:
         with self._lock:

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -11,10 +11,11 @@ import struct
 import tempfile
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, wait
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
-from threading import RLock
+from threading import Event, RLock
 from typing import Final
 
 from PySide6.QtGui import QColorSpace, QImage
@@ -217,6 +218,7 @@ class NeutralSurfaceStore:
     ) -> None:
         self._root: Path | None = None
         self._index: SurfaceCacheIndex | None = None
+        self._closed = False
         self._budget_override = (
             max(0, int(budget_bytes)) if budget_bytes is not None else None
         )
@@ -232,6 +234,21 @@ class NeutralSurfaceStore:
         with self._lock:
             return self._root
 
+    @property
+    def library_root(self) -> Path | None:
+        root = self.root
+        if root is None:
+            return None
+        try:
+            return root.parents[3]
+        except IndexError:
+            return None
+
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
     def bind_library(self, library_root: Path | None) -> None:
         root = None
         if library_root is not None:
@@ -246,6 +263,7 @@ class NeutralSurfaceStore:
             previous = self._index
             self._index = None
             self._root = root
+            self._closed = False
             self._disk_hit_count = 0
             self._pending_audits.clear()
             self._legacy_cleanup_done = False
@@ -257,6 +275,8 @@ class NeutralSurfaceStore:
         if root is None:
             return None
         with self._lock:
+            if self._closed:
+                return None
             index = self._index
             if index is None or index.root != root:
                 index = SurfaceCacheIndex(root)
@@ -266,9 +286,12 @@ class NeutralSurfaceStore:
     def entry_path(self, request: DetailRenderRequest) -> Path | None:
         if not request.source_identity.has_stable_revision:
             return None
-        root = self.root
-        if root is None:
-            return None
+        with self._lock:
+            if self._closed:
+                return None
+            root = self._root
+            if root is None:
+                return None
         try:
             library_root = root.parents[3]
             request.source_identity.path.relative_to(library_root)
@@ -613,6 +636,9 @@ class NeutralSurfaceStore:
 
     def close(self) -> None:
         with self._lock:
+            if self._closed:
+                return
+            self._closed = True
             index = self._index
             self._index = None
             self._pending_audits.clear()
@@ -783,6 +809,26 @@ class NeutralSurfaceStore:
                 self._legacy_cleanup_done = False
 
 
+@dataclass(slots=True)
+class _SurfaceStoreGeneration:
+    epoch: int
+    library_root: Path | None
+    store: NeutralSurfaceStore
+    retired: bool = False
+    close_submitted: bool = False
+    active_calls: int = 0
+    drained: Event = field(default_factory=Event)
+
+    def __post_init__(self) -> None:
+        self.drained.set()
+
+
+def _normalise_library_root(library_root: Path | None) -> Path | None:
+    if library_root is None:
+        return None
+    return Path(library_root).expanduser().absolute()
+
+
 class CachedStillDecodeBackend:
     """Memory/disk/decode lookup chain with asynchronous persistence."""
 
@@ -792,6 +838,7 @@ class CachedStillDecodeBackend:
         *,
         memory_cache: MappedSurfaceCache | None = None,
         store: NeutralSurfaceStore | None = None,
+        store_factory: Callable[[Path | None], NeutralSurfaceStore] | None = None,
         residency_tracker: SurfaceResidencyTracker | None = None,
     ) -> None:
         self._delegate = delegate
@@ -799,19 +846,52 @@ class CachedStillDecodeBackend:
         self.memory_cache = memory_cache or MappedSurfaceCache(
             residency_tracker=self.residency_tracker
         )
-        self.store = store or NeutralSurfaceStore()
+        self._store_factory = store_factory or NeutralSurfaceStore
+        initial_store = store or self._store_factory(None)
+        initial_root = getattr(initial_store, "library_root", None)
+        if not isinstance(initial_root, Path):
+            initial_root = None
+        self._store_epoch = 0
+        self._active_store_generation = _SurfaceStoreGeneration(
+            epoch=self._store_epoch,
+            library_root=initial_root,
+            store=initial_store,
+        )
         self._io = ThreadPoolExecutor(max_workers=1, thread_name_prefix="iPhoto-surface-cache")
         self._futures: set[Future] = set()
         self._lock = RLock()
         self._shutting_down = False
+        self._shutdown_barrier: Future | None = None
+        self._executor_shutdown = False
         self._color_stats_by_source: OrderedDict[tuple, ColorStats] = OrderedDict()
+
+    @property
+    def store(self) -> NeutralSurfaceStore:
+        with self._lock:
+            return self._active_store_generation.store
 
     def bind_library(self, library_root: Path | None) -> None:
         self.memory_cache.clear()
+        normalised_root = _normalise_library_root(library_root)
         with self._lock:
+            if self._shutting_down:
+                return
             self._color_stats_by_source.clear()
-        self.store.bind_library(library_root)
-        self._submit(self.store.maintenance)
+            current = self._active_store_generation
+            if current.library_root == normalised_root:
+                self._submit_generation_locked(current, current.store.maintenance)
+                return
+            replacement = self._store_factory(normalised_root)
+            self._store_epoch += 1
+            generation = _SurfaceStoreGeneration(
+                epoch=self._store_epoch,
+                library_root=normalised_root,
+                store=replacement,
+            )
+            current.retired = True
+            self._active_store_generation = generation
+            self._queue_store_close_locked(current)
+            self._submit_generation_locked(generation, replacement.maintenance)
 
     @staticmethod
     def _source_stats_key(request: DetailRenderRequest) -> tuple:
@@ -845,6 +925,18 @@ class CachedStillDecodeBackend:
         request: DetailRenderRequest,
         cancellation: CancellationToken,
     ) -> DecodedSurface:
+        generation = self._acquire_store_generation(cancellation)
+        try:
+            return self._decode_for_generation(request, cancellation, generation)
+        finally:
+            self._release_store_generation(generation)
+
+    def _decode_for_generation(
+        self,
+        request: DetailRenderRequest,
+        cancellation: CancellationToken,
+        generation: _SurfaceStoreGeneration,
+    ) -> DecodedSurface:
         prepared = request.with_decode_level()
         key = DetailDecodeKey.from_request(prepared)
         cacheable = prepared.source_identity.has_stable_revision
@@ -852,7 +944,9 @@ class CachedStillDecodeBackend:
             raise DecodeCancelledError("Still-image decode cancelled")
         surface = self.memory_cache.get(key) if cacheable else None
         if surface is not None:
-            self._remember_color_stats(prepared, surface.color_stats)
+            with self._lock:
+                self._raise_if_generation_stale_locked(generation, cancellation)
+                self._remember_color_stats(prepared, surface.color_stats)
             emit_detail_event(
                 "surface_cache_hit",
                 generation=prepared.generation,
@@ -862,22 +956,32 @@ class CachedStillDecodeBackend:
             return surface
         if cacheable:
             try:
-                surface = self.store.load(prepared)
+                surface = generation.store.load(prepared)
             except SurfaceCacheCorruptError:
                 emit_detail_event(
                     "surface_cache_corrupt",
                     generation=prepared.generation,
                     asset_id=key.asset_id,
                 )
-                self._submit(self.store.discard, prepared)
+                self._submit_for_generation(
+                    generation,
+                    generation.store.discard,
+                    prepared,
+                )
                 surface = None
         if surface is not None:
-            if cancellation.is_cancelled():
-                raise DecodeCancelledError("Still-image decode cancelled")
-            self.memory_cache.put(surface)
-            self._remember_color_stats(prepared, surface.color_stats)
-            self._submit(self.store.flush_accesses_if_due)
-            self._submit(self.store.run_pending_audits)
+            with self._lock:
+                self._raise_if_generation_stale_locked(generation, cancellation)
+                self.memory_cache.put(surface)
+                self._remember_color_stats(prepared, surface.color_stats)
+                self._submit_generation_locked(
+                    generation,
+                    generation.store.flush_accesses_if_due,
+                )
+                self._submit_generation_locked(
+                    generation,
+                    generation.store.run_pending_audits,
+                )
             emit_detail_event(
                 "surface_cache_hit",
                 generation=prepared.generation,
@@ -885,13 +989,17 @@ class CachedStillDecodeBackend:
                 tier="disk",
             )
             return surface
+        with self._lock:
+            self._raise_if_generation_stale_locked(generation, cancellation)
         emit_detail_event(
             "surface_cache_miss",
             generation=prepared.generation,
             asset_id=key.asset_id,
         )
         surface = self._delegate.decode(prepared, cancellation)
-        stats = self._cached_color_stats(prepared) if cacheable else None
+        with self._lock:
+            self._raise_if_generation_stale_locked(generation, cancellation)
+            stats = self._cached_color_stats(prepared) if cacheable else None
         if stats is None:
             started = time.perf_counter()
             stats = compute_color_statistics(surface.image)
@@ -903,16 +1011,51 @@ class CachedStillDecodeBackend:
                 width=surface.decoded_size[0],
                 height=surface.decoded_size[1],
             )
-        if cacheable:
-            stats = self._remember_color_stats(prepared, stats)
         surface = replace(surface, color_stats=stats)
-        if cacheable:
-            self.memory_cache.put(surface)
-            self._submit(self._write_surface, prepared, surface)
+        with self._lock:
+            self._raise_if_generation_stale_locked(generation, cancellation)
+            if cacheable:
+                stats = self._remember_color_stats(prepared, stats)
+                surface = replace(surface, color_stats=stats)
+                self.memory_cache.put(surface)
+                self._submit_generation_locked(
+                    generation,
+                    self._write_surface,
+                    generation,
+                    prepared,
+                    surface,
+                )
         return surface
 
-    def _write_surface(self, request: DetailRenderRequest, surface: DecodedSurface) -> None:
-        if self.store.write(request, surface) and not self._shutting_down:
+    def _acquire_store_generation(
+        self,
+        cancellation: CancellationToken,
+    ) -> _SurfaceStoreGeneration:
+        with self._lock:
+            generation = self._active_store_generation
+            self._raise_if_generation_stale_locked(generation, cancellation)
+            generation.active_calls += 1
+            generation.drained.clear()
+            return generation
+
+    def _release_store_generation(
+        self,
+        generation: _SurfaceStoreGeneration,
+    ) -> None:
+        with self._lock:
+            generation.active_calls = max(0, generation.active_calls - 1)
+            if generation.active_calls == 0:
+                generation.drained.set()
+
+    def _write_surface(
+        self,
+        generation: _SurfaceStoreGeneration,
+        request: DetailRenderRequest,
+        surface: DecodedSurface,
+    ) -> None:
+        if generation.store.write(request, surface) and self._generation_is_current(
+            generation
+        ):
             emit_detail_event(
                 "surface_cache_write",
                 generation=request.generation,
@@ -921,16 +1064,93 @@ class CachedStillDecodeBackend:
                 height=surface.decoded_size[1],
             )
 
-    def _submit(self, fn, *args, **kwargs) -> None:
+    def _raise_if_generation_stale_locked(
+        self,
+        generation: _SurfaceStoreGeneration,
+        cancellation: CancellationToken,
+    ) -> None:
+        if (
+            cancellation.is_cancelled()
+            or self._shutting_down
+            or generation.retired
+            or generation is not self._active_store_generation
+        ):
+            raise DecodeCancelledError("Still-image decode generation was retired")
+
+    def _generation_is_current(self, generation: _SurfaceStoreGeneration) -> bool:
         with self._lock:
-            if self._shutting_down:
-                return
-            try:
-                future = self._io.submit(fn, *args, **kwargs)
-            except RuntimeError:
-                return
-            self._futures.add(future)
-            future.add_done_callback(self._forget_future)
+            return bool(
+                not self._shutting_down
+                and not generation.retired
+                and generation is self._active_store_generation
+            )
+
+    def _submit_for_generation(
+        self,
+        generation: _SurfaceStoreGeneration,
+        fn,
+        *args,
+        **kwargs,
+    ) -> Future | None:
+        with self._lock:
+            return self._submit_generation_locked(generation, fn, *args, **kwargs)
+
+    def _submit_generation_locked(
+        self,
+        generation: _SurfaceStoreGeneration,
+        fn,
+        *args,
+        **kwargs,
+    ) -> Future | None:
+        if (
+            self._shutting_down
+            or generation.retired
+            or generation is not self._active_store_generation
+        ):
+            return None
+        return self._submit_raw_locked(
+            self._run_generation_task,
+            generation,
+            fn,
+            args,
+            kwargs,
+        )
+
+    def _run_generation_task(
+        self,
+        generation: _SurfaceStoreGeneration,
+        fn,
+        args: tuple,
+        kwargs: dict,
+    ):
+        # Submission is the ownership boundary. Once accepted, work remains
+        # ordered ahead of that generation's close barrier even if a rebind or
+        # shutdown retires the generation before the worker reaches it.
+        _ = generation
+        return fn(*args, **kwargs)
+
+    def _queue_store_close_locked(
+        self,
+        generation: _SurfaceStoreGeneration,
+    ) -> Future | None:
+        if generation.close_submitted:
+            return None
+        generation.close_submitted = True
+        return self._submit_raw_locked(self._close_generation_store, generation)
+
+    @staticmethod
+    def _close_generation_store(generation: _SurfaceStoreGeneration) -> None:
+        generation.drained.wait()
+        generation.store.close()
+
+    def _submit_raw_locked(self, fn, *args, **kwargs) -> Future | None:
+        try:
+            future = self._io.submit(fn, *args, **kwargs)
+        except RuntimeError:
+            return None
+        self._futures.add(future)
+        future.add_done_callback(self._forget_future)
+        return future
 
     def _forget_future(self, future: Future) -> None:
         with self._lock:
@@ -938,15 +1158,34 @@ class CachedStillDecodeBackend:
 
     def shutdown(self, *, timeout_ms: int = 1000) -> None:
         with self._lock:
-            self._shutting_down = True
-            futures = tuple(self._futures)
-        if futures:
-            wait(futures, timeout=max(0, int(timeout_ms)) / 1000.0)
+            if not self._shutting_down:
+                self._shutting_down = True
+                generation = self._active_store_generation
+                generation.retired = True
+                self._queue_store_close_locked(generation)
+                self._shutdown_barrier = self._submit_raw_locked(lambda: None)
+            barrier = self._shutdown_barrier
+        completed = not bool(barrier)
+        if barrier is not None:
+            done, _pending = wait(
+                (barrier,),
+                timeout=max(0, int(timeout_ms)) / 1000.0,
+            )
+            completed = barrier in done
+        if not completed:
+            with self._lock:
+                pending_count = len(self._futures)
+            emit_detail_event(
+                "surface_cache_shutdown_timeout",
+                generation=0,
+                pending=pending_count,
+            )
         self.memory_cache.clear()
-        close_store = getattr(self.store, "close", None)
-        if callable(close_store):
-            close_store()
-        self._io.shutdown(wait=False, cancel_futures=True)
+        with self._lock:
+            if self._executor_shutdown:
+                return
+            self._executor_shutdown = True
+        self._io.shutdown(wait=False, cancel_futures=False)
 
 
 __all__ = [

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -627,23 +627,30 @@ class NeutralSurfaceStore:
         index = self._index_for_root()
         if index is None:
             return
-        for digest in digests:
-            entry = index.get(digest)
-            if entry is None:
-                continue
-            path = self._indexed_path(index, entry.relative_path)
-            if path is None:
-                index.remove(digest)
-                continue
-            if self._entry_checksum_is_valid(entry, path):
-                index.mark_checksum_state(digest, "trusted", verified_ns=time.time_ns())
-                continue
-            self._discard_digest(digest, path)
-            emit_detail_event(
-                "surface_cache_audit_failed",
-                generation=0,
-                digest_prefix=digest[:12],
-            )
+        try:
+            for digest in digests:
+                entry = index.get(digest)
+                if entry is None:
+                    continue
+                path = self._indexed_path(index, entry.relative_path)
+                if path is None:
+                    index.remove(digest)
+                    continue
+                if self._entry_checksum_is_valid(entry, path):
+                    index.mark_checksum_state(
+                        digest,
+                        "trusted",
+                        verified_ns=time.time_ns(),
+                    )
+                    continue
+                self._discard_digest(digest, path)
+                emit_detail_event(
+                    "surface_cache_audit_failed",
+                    generation=0,
+                    digest_prefix=digest[:12],
+                )
+        except SurfaceCacheIndexUnavailableError:
+            return
 
     def maintenance(
         self,
@@ -654,61 +661,67 @@ class NeutralSurfaceStore:
         """Recover if needed, flush access metadata, and prune from the SQL LRU."""
 
         with self._maintenance_lock:
-            index = self._index_for_root()
-            if index is None or not index.ensure_open():
+            try:
+                self._maintain_index(recover=recover, force_prune=force_prune)
+            except SurfaceCacheIndexUnavailableError:
                 return
-            if recover or index.needs_recovery:
-                self._recover_index(index)
-                if index.needs_recovery:
-                    return
-            index.flush_accesses(force=True)
-            budget = self._budget_bytes()
-            if budget is None:
+
+    def _maintain_index(self, *, recover: bool, force_prune: bool) -> None:
+        index = self._index_for_root()
+        if index is None or not index.ensure_open():
+            return
+        if recover or index.needs_recovery:
+            self._recover_index(index)
+            if index.needs_recovery:
                 return
-            due = force_prune or index.maintenance_due(
-                budget,
-                byte_interval=_MAINTENANCE_WRITE_BYTES,
-                time_interval_ns=_MAINTENANCE_INTERVAL_NS,
-            )
-            if not due:
-                return
-            target = int(budget * 0.9)
-            maintenance_failed = False
-            while index.indexed_bytes > target:
-                victims = index.lru_victims(limit=_PRUNE_BATCH)
-                if not victims:
-                    maintenance_failed = True
+        index.flush_accesses(force=True)
+        budget = self._budget_bytes()
+        if budget is None:
+            return
+        due = force_prune or index.maintenance_due(
+            budget,
+            byte_interval=_MAINTENANCE_WRITE_BYTES,
+            time_interval_ns=_MAINTENANCE_INTERVAL_NS,
+        )
+        if not due:
+            return
+        target = int(budget * 0.9)
+        maintenance_failed = False
+        while index.indexed_bytes > target:
+            victims = index.lru_victims(limit=_PRUNE_BATCH)
+            if not victims:
+                maintenance_failed = True
+                break
+            removed = 0
+            for victim in victims:
+                if index.indexed_bytes <= target:
                     break
-                removed = 0
-                for victim in victims:
-                    if index.indexed_bytes <= target:
-                        break
-                    path = self._indexed_path(index, victim.relative_path)
-                    if path is None:
-                        if not index.remove(victim.digest):
-                            index.mark_recovery_required()
-                            maintenance_failed = True
-                            break
-                        removed += 1
-                        continue
-                    try:
-                        path.unlink(missing_ok=True)
-                    except OSError:
-                        index.mark_recovery_required()
-                        maintenance_failed = True
-                        continue
+                path = self._indexed_path(index, victim.relative_path)
+                if path is None:
                     if not index.remove(victim.digest):
                         index.mark_recovery_required()
                         maintenance_failed = True
                         break
                     removed += 1
-                if maintenance_failed:
-                    break
-                if removed == 0:
+                    continue
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError:
+                    index.mark_recovery_required()
+                    maintenance_failed = True
+                    continue
+                if not index.remove(victim.digest):
+                    index.mark_recovery_required()
                     maintenance_failed = True
                     break
-            if not maintenance_failed:
-                index.finish_maintenance()
+                removed += 1
+            if maintenance_failed:
+                break
+            if removed == 0:
+                maintenance_failed = True
+                break
+        if not maintenance_failed:
+            index.finish_maintenance()
 
     def close(self) -> None:
         with self._lock:
@@ -791,8 +804,8 @@ class NeutralSurfaceStore:
                 recovered = index.remove(digest) and recovered
         index.recalculate_indexed_bytes()
         if recovered:
-            index.mark_recovered()
             index.finish_maintenance()
+            index.mark_recovered()
         else:
             index.mark_recovery_required()
 
@@ -859,8 +872,13 @@ class NeutralSurfaceStore:
             if index is not None:
                 index.mark_recovery_required()
             return
-        if index is not None and not index.remove(digest):
-            index.mark_recovery_required()
+        if index is not None:
+            try:
+                removed = index.remove(digest)
+            except SurfaceCacheIndexUnavailableError:
+                removed = False
+            if not removed:
+                index.mark_recovery_required()
 
     @staticmethod
     def _indexed_path(index: SurfaceCacheIndex, relative_path: str) -> Path | None:

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -227,6 +227,7 @@ class NeutralSurfaceStore:
         self._maintenance_lock = RLock()
         self._disk_hit_count = 0
         self._pending_audits: set[str] = set()
+        self._reported_index_unavailable: set[str] = set()
         self._legacy_cleanup_done = False
         self.bind_library(library_root)
 
@@ -254,7 +255,7 @@ class NeutralSurfaceStore:
         root = None
         if library_root is not None:
             root = (
-                Path(library_root).expanduser().absolute()
+                Path(library_root).expanduser().resolve(strict=False)
                 / ".iPhoto"
                 / "cache"
                 / "detail-surfaces"
@@ -270,6 +271,7 @@ class NeutralSurfaceStore:
             self._root = root
             self._disk_hit_count = 0
             self._pending_audits.clear()
+            self._reported_index_unavailable.clear()
             self._legacy_cleanup_done = False
         if previous is not None:
             previous.close(clean=True)
@@ -286,6 +288,23 @@ class NeutralSurfaceStore:
                 index = SurfaceCacheIndex(root)
                 self._index = index
             return index
+
+    def _ensure_index_open(self, index: SurfaceCacheIndex) -> bool:
+        if index.ensure_open():
+            return True
+        reason = index.open_unavailable_reason
+        if reason is None:
+            return False
+        with self._lock:
+            if reason in self._reported_index_unavailable:
+                return False
+            self._reported_index_unavailable.add(reason)
+        emit_detail_event(
+            "surface_cache_disk_unavailable",
+            generation=0,
+            reason=reason,
+        )
+        return False
 
     def entry_path(self, request: DetailRenderRequest) -> Path | None:
         if not request.source_identity.has_stable_revision:
@@ -311,7 +330,7 @@ class NeutralSurfaceStore:
         if path is None:
             return None
         index = self._index_for_root()
-        if index is None or not index.ensure_open():
+        if index is None or not self._ensure_index_open(index):
             return None
         digest = _key_digest(request)
         try:
@@ -483,7 +502,7 @@ class NeutralSurfaceStore:
         if payload_size <= 0:
             return False
         index = self._index_for_root()
-        if index is None or not index.ensure_open():
+        if index is None or not self._ensure_index_open(index):
             return False
         try:
             if index.needs_recovery:
@@ -624,12 +643,12 @@ class NeutralSurfaceStore:
             return False
 
     def run_pending_audits(self) -> None:
+        index = self._index_for_root()
+        if index is None or not self._ensure_index_open(index):
+            return
         with self._lock:
             digests = tuple(self._pending_audits)
             self._pending_audits.clear()
-        index = self._index_for_root()
-        if index is None:
-            return
         try:
             for digest in digests:
                 entry = index.get(digest)
@@ -671,7 +690,7 @@ class NeutralSurfaceStore:
 
     def _maintain_index(self, *, recover: bool, force_prune: bool) -> None:
         index = self._index_for_root()
-        if index is None or not index.ensure_open():
+        if index is None or not self._ensure_index_open(index):
             return
         if recover or index.needs_recovery:
             self._recover_index(index)
@@ -930,7 +949,7 @@ class _SurfaceStoreGeneration:
 def _normalise_library_root(library_root: Path | None) -> Path | None:
     if library_root is None:
         return None
-    return Path(library_root).expanduser().absolute()
+    return Path(library_root).expanduser().resolve(strict=False)
 
 
 class CachedStillDecodeBackend:

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -811,7 +811,7 @@ class CachedStillDecodeBackend:
         with self._lock:
             self._color_stats_by_source.clear()
         self.store.bind_library(library_root)
-        self._submit(self.store.maintenance, recover=True)
+        self._submit(self.store.maintenance)
 
     @staticmethod
     def _source_stats_key(request: DetailRenderRequest) -> tuple:

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -921,14 +921,14 @@ class CachedStillDecodeBackend:
             return self._active_store_generation.store
 
     def bind_library(self, library_root: Path | None) -> None:
-        self.memory_cache.clear()
         normalised_root = _normalise_library_root(library_root)
         with self._lock:
             if self._shutting_down:
                 return
-            self._color_stats_by_source.clear()
             current = self._active_store_generation
             if current.library_root == normalised_root:
+                self._color_stats_by_source.clear()
+                self.memory_cache.clear()
                 self._submit_generation_locked(current, current.store.maintenance)
                 return
             replacement = self._store_factory(normalised_root)
@@ -940,6 +940,8 @@ class CachedStillDecodeBackend:
             )
             current.retired = True
             self._active_store_generation = generation
+            self._color_stats_by_source.clear()
+            self.memory_cache.clear()
             self._queue_store_close_locked(current)
             self._submit_generation_locked(generation, replacement.maintenance)
 

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -14,6 +14,10 @@ _ACCESS_BATCH: Final = 128
 _ACCESS_INTERVAL_NS: Final = 30 * 1_000_000_000
 
 
+class SurfaceCacheIndexUnavailableError(RuntimeError):
+    """Raised internally after a runtime SQLite control-plane failure."""
+
+
 @dataclass(frozen=True, slots=True)
 class SurfaceCacheIndexEntry:
     digest: str
@@ -41,6 +45,7 @@ class SurfaceCacheIndex:
         self._pending_access: dict[str, int] = {}
         self._last_access_flush_ns = time.time_ns()
         self._needs_recovery = False
+        self._rebuild_required = False
         self._closed = False
 
     @property
@@ -59,57 +64,58 @@ class SurfaceCacheIndex:
                 return False
             if self._connection is not None:
                 return True
+            rebuilding = self._rebuild_required
+            if rebuilding:
+                self._discard_broken_index_locked()
             try:
-                self.root.mkdir(parents=True, exist_ok=True)
-                self._connection = self._connect()
-                self._create_schema(self._connection)
-            except (OSError, sqlite3.DatabaseError):
+                self._open_connection_locked()
+            except (OSError, sqlite3.DatabaseError) as first_error:
                 self._discard_broken_index_locked()
                 try:
-                    self.root.mkdir(parents=True, exist_ok=True)
-                    self._connection = self._connect()
-                    self._create_schema(self._connection)
+                    self._open_connection_locked()
                     self._needs_recovery = True
-                except (OSError, sqlite3.DatabaseError):
-                    self._close_connection_locked()
+                except (OSError, sqlite3.DatabaseError) as second_error:
+                    self._database_failure_locked(second_error or first_error)
                     return False
-            connection = self._connection
-            if connection is None:
-                return False
-            prior_clean = self._meta_int_locked("clean_shutdown", default=1)
-            self._needs_recovery = self._needs_recovery or prior_clean != 1
-            self._set_meta_locked("clean_shutdown", 0)
-            connection.commit()
+            if rebuilding:
+                self._needs_recovery = True
+            self._rebuild_required = False
             return True
 
     def get(self, digest: str) -> SurfaceCacheIndexEntry | None:
         with self._lock:
             if not self.ensure_open():
                 return None
-            row = self._connection.execute(  # type: ignore[union-attr]
-                """
-                SELECT digest, relative_path, container_schema, decoder_contract,
-                       payload_bytes, file_bytes, checksum, checksum_state,
-                       file_mtime_ns, created_ns, last_access_ns, last_verified_ns
-                FROM entries
-                WHERE digest = ?
-                """,
-                (str(digest),),
-            ).fetchone()
+            try:
+                row = self._connection.execute(  # type: ignore[union-attr]
+                    """
+                    SELECT digest, relative_path, container_schema, decoder_contract,
+                           payload_bytes, file_bytes, checksum, checksum_state,
+                           file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                    FROM entries
+                    WHERE digest = ?
+                    """,
+                    (str(digest),),
+                ).fetchone()
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
             return self._entry_from_row(row) if row is not None else None
 
     def all_entries(self) -> tuple[SurfaceCacheIndexEntry, ...]:
         with self._lock:
             if not self.ensure_open():
                 return ()
-            rows = self._connection.execute(  # type: ignore[union-attr]
-                """
-                SELECT digest, relative_path, container_schema, decoder_contract,
-                       payload_bytes, file_bytes, checksum, checksum_state,
-                       file_mtime_ns, created_ns, last_access_ns, last_verified_ns
-                FROM entries
-                """
-            ).fetchall()
+            try:
+                rows = self._connection.execute(  # type: ignore[union-attr]
+                    """
+                    SELECT digest, relative_path, container_schema, decoder_contract,
+                           payload_bytes, file_bytes, checksum, checksum_state,
+                           file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                    FROM entries
+                    """
+                ).fetchall()
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
             return tuple(self._entry_from_row(row) for row in rows)
 
     def upsert(self, entry: SurfaceCacheIndexEntry) -> bool:
@@ -168,9 +174,9 @@ class SurfaceCacheIndex:
                 )
                 connection.commit()  # type: ignore[union-attr]
                 return True
-            except sqlite3.DatabaseError:
-                connection.rollback()  # type: ignore[union-attr]
-                return False
+            except sqlite3.DatabaseError as exc:
+                self._rollback_quietly(connection)
+                raise self._database_failure_locked(exc) from exc
 
     def remove(self, digest: str) -> bool:
         with self._lock:
@@ -191,10 +197,9 @@ class SurfaceCacheIndex:
                 )
                 connection.commit()  # type: ignore[union-attr]
                 return True
-            except sqlite3.DatabaseError:
-                connection.rollback()  # type: ignore[union-attr]
-                self._mark_recovery_required_locked()
-                return False
+            except sqlite3.DatabaseError as exc:
+                self._rollback_quietly(connection)
+                raise self._database_failure_locked(exc) from exc
 
     def mark_checksum_state(
         self,
@@ -207,16 +212,19 @@ class SurfaceCacheIndex:
             if not self.ensure_open():
                 return
             when = int(verified_ns or 0)
-            self._connection.execute(  # type: ignore[union-attr]
-                """
-                UPDATE entries
-                SET checksum_state = ?,
-                    last_verified_ns = CASE WHEN ? > 0 THEN ? ELSE last_verified_ns END
-                WHERE digest = ?
-                """,
-                (str(state), when, when, str(digest)),
-            )
-            self._connection.commit()  # type: ignore[union-attr]
+            try:
+                self._connection.execute(  # type: ignore[union-attr]
+                    """
+                    UPDATE entries
+                    SET checksum_state = ?,
+                        last_verified_ns = CASE WHEN ? > 0 THEN ? ELSE last_verified_ns END
+                    WHERE digest = ?
+                    """,
+                    (str(state), when, when, str(digest)),
+                )
+                self._connection.commit()  # type: ignore[union-attr]
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
 
     def queue_access(self, digest: str, *, accessed_ns: int | None = None) -> bool:
         now = int(accessed_ns or time.time_ns())
@@ -251,9 +259,9 @@ class SurfaceCacheIndex:
                     ((accessed_ns, digest) for digest, accessed_ns in pending),
                 )
                 self._connection.commit()  # type: ignore[union-attr]
-            except sqlite3.DatabaseError:
-                self._connection.rollback()  # type: ignore[union-attr]
-                return False
+            except sqlite3.DatabaseError as exc:
+                self._rollback_quietly(self._connection)
+                raise self._database_failure_locked(exc) from exc
             for digest, accessed_ns in pending:
                 if self._pending_access.get(digest) == accessed_ns:
                     self._pending_access.pop(digest, None)
@@ -271,28 +279,35 @@ class SurfaceCacheIndex:
             if not self.ensure_open():
                 return False
             now = time.time_ns()
-            return (
-                self._meta_int_locked("indexed_bytes") > max(0, int(budget_bytes))
-                or self._meta_int_locked("bytes_since_maintenance") >= int(byte_interval)
-                or now - self._meta_int_locked("last_maintenance_ns", default=now)
-                >= int(time_interval_ns)
-            )
+            try:
+                return (
+                    self._needs_recovery
+                    or self._meta_int_locked("indexed_bytes") > max(0, int(budget_bytes))
+                    or self._meta_int_locked("bytes_since_maintenance") >= int(byte_interval)
+                    or now - self._meta_int_locked("last_maintenance_ns", default=now)
+                    >= int(time_interval_ns)
+                )
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
 
     def lru_victims(self, *, limit: int) -> tuple[SurfaceCacheIndexEntry, ...]:
         with self._lock:
             if not self.ensure_open():
                 return ()
-            rows = self._connection.execute(  # type: ignore[union-attr]
-                """
-                SELECT digest, relative_path, container_schema, decoder_contract,
-                       payload_bytes, file_bytes, checksum, checksum_state,
-                       file_mtime_ns, created_ns, last_access_ns, last_verified_ns
-                FROM entries
-                ORDER BY last_access_ns ASC, created_ns ASC, digest ASC
-                LIMIT ?
-                """,
-                (max(1, int(limit)),),
-            ).fetchall()
+            try:
+                rows = self._connection.execute(  # type: ignore[union-attr]
+                    """
+                    SELECT digest, relative_path, container_schema, decoder_contract,
+                           payload_bytes, file_bytes, checksum, checksum_state,
+                           file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                    FROM entries
+                    ORDER BY last_access_ns ASC, created_ns ASC, digest ASC
+                    LIMIT ?
+                    """,
+                    (max(1, int(limit)),),
+                ).fetchall()
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
             return tuple(self._entry_from_row(row) for row in rows)
 
     @property
@@ -300,15 +315,21 @@ class SurfaceCacheIndex:
         with self._lock:
             if not self.ensure_open():
                 return 0
-            return self._meta_int_locked("indexed_bytes")
+            try:
+                return self._meta_int_locked("indexed_bytes")
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
 
     def finish_maintenance(self) -> None:
         with self._lock:
             if not self.ensure_open():
                 return
-            self._set_meta_locked("bytes_since_maintenance", 0)
-            self._set_meta_locked("last_maintenance_ns", time.time_ns())
-            self._connection.commit()  # type: ignore[union-attr]
+            try:
+                self._set_meta_locked("bytes_since_maintenance", 0)
+                self._set_meta_locked("last_maintenance_ns", time.time_ns())
+                self._connection.commit()  # type: ignore[union-attr]
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
 
     def recalculate_indexed_bytes(self) -> int:
         """Repair the cached byte total after an exceptional recovery scan."""
@@ -316,17 +337,21 @@ class SurfaceCacheIndex:
         with self._lock:
             if not self.ensure_open():
                 return 0
-            row = self._connection.execute(  # type: ignore[union-attr]
-                "SELECT COALESCE(SUM(file_bytes), 0) FROM entries"
-            ).fetchone()
-            total = max(0, int(row[0]) if row is not None else 0)
-            self._set_meta_locked("indexed_bytes", total)
-            self._connection.commit()  # type: ignore[union-attr]
+            try:
+                row = self._connection.execute(  # type: ignore[union-attr]
+                    "SELECT COALESCE(SUM(file_bytes), 0) FROM entries"
+                ).fetchone()
+                total = max(0, int(row[0]) if row is not None else 0)
+                self._set_meta_locked("indexed_bytes", total)
+                self._connection.commit()  # type: ignore[union-attr]
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
             return total
 
     def mark_recovered(self) -> None:
         with self._lock:
-            self._needs_recovery = False
+            if self._connection is not None and not self._rebuild_required:
+                self._needs_recovery = False
 
     def mark_recovery_required(self) -> None:
         with self._lock:
@@ -336,15 +361,32 @@ class SurfaceCacheIndex:
         with self._lock:
             if self._closed:
                 return
-            self.flush_accesses(force=True)
+            try:
+                self.flush_accesses(force=True)
+            except SurfaceCacheIndexUnavailableError:
+                pass
             if self._connection is not None and clean and not self._needs_recovery:
                 try:
                     self._set_meta_locked("clean_shutdown", 1)
                     self._connection.commit()
-                except sqlite3.DatabaseError:
-                    self._needs_recovery = True
+                except sqlite3.DatabaseError as exc:
+                    self._database_failure_locked(exc)
             self._close_connection_locked()
             self._closed = True
+
+    def _open_connection_locked(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        connection = self._connect()
+        self._connection = connection
+        try:
+            self._create_schema(connection)
+            prior_clean = self._meta_int_locked("clean_shutdown", default=1)
+            self._needs_recovery = self._needs_recovery or prior_clean != 1
+            self._set_meta_locked("clean_shutdown", 0)
+            connection.commit()
+        except sqlite3.DatabaseError:
+            self._close_connection_locked()
+            raise
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(
@@ -427,11 +469,28 @@ class SurfaceCacheIndex:
         try:
             self._set_meta_locked("clean_shutdown", 0)
             self._connection.commit()
+        except sqlite3.DatabaseError as exc:
+            self._database_failure_locked(exc)
+
+    def _database_failure_locked(
+        self,
+        exc: sqlite3.DatabaseError,
+    ) -> SurfaceCacheIndexUnavailableError:
+        self._needs_recovery = True
+        self._rebuild_required = True
+        self._close_connection_locked()
+        return SurfaceCacheIndexUnavailableError(
+            f"surface cache index unavailable: {exc}"
+        )
+
+    @staticmethod
+    def _rollback_quietly(connection: sqlite3.Connection | None) -> None:
+        if connection is None:
+            return
+        try:
+            connection.rollback()
         except sqlite3.DatabaseError:
-            try:
-                self._connection.rollback()
-            except sqlite3.DatabaseError:
-                pass
+            pass
 
     @staticmethod
     def _entry_from_row(row: sqlite3.Row) -> SurfaceCacheIndexEntry:
@@ -479,4 +538,8 @@ class SurfaceCacheIndex:
                 pass
 
 
-__all__ = ["SurfaceCacheIndex", "SurfaceCacheIndexEntry"]
+__all__ = [
+    "SurfaceCacheIndex",
+    "SurfaceCacheIndexEntry",
+    "SurfaceCacheIndexUnavailableError",
+]

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -232,7 +232,11 @@ class SurfaceCacheIndex:
             pending = tuple(self._pending_access.items())
             try:
                 self._connection.executemany(  # type: ignore[union-attr]
-                    "UPDATE entries SET last_access_ns = ? WHERE digest = ?",
+                    """
+                    UPDATE entries
+                    SET last_access_ns = MAX(last_access_ns + 1, ?)
+                    WHERE digest = ?
+                    """,
                     ((accessed_ns, digest) for digest, accessed_ns in pending),
                 )
                 self._connection.commit()  # type: ignore[union-attr]
@@ -330,10 +334,16 @@ class SurfaceCacheIndex:
             timeout=5.0,
             check_same_thread=False,
         )
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.execute("PRAGMA synchronous=NORMAL")
-        connection.execute("PRAGMA temp_store=MEMORY")
+        try:
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA synchronous=NORMAL")
+            connection.execute("PRAGMA temp_store=MEMORY")
+        except sqlite3.DatabaseError:
+            # On Windows, an unclosed connection keeps the corrupt database
+            # locked and prevents the quarantine rename in ensure_open().
+            connection.close()
+            raise
         return connection
 
     @staticmethod

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 import sqlite3
 import time
 from dataclasses import dataclass
@@ -12,6 +13,9 @@ from typing import Final
 
 _ACCESS_BATCH: Final = 128
 _ACCESS_INTERVAL_NS: Final = 30 * 1_000_000_000
+_PROCESS_SESSION_TOKEN: Final = secrets.randbits(63) or 1
+_LEASE_REGISTRY_LOCK = RLock()
+_ACTIVE_SESSION_LEASES: dict[str, set[int]] = {}
 
 
 class SurfaceCacheIndexUnavailableError(RuntimeError):
@@ -44,6 +48,10 @@ class SurfaceCacheIndex:
         self._lock = RLock()
         self._pending_access: dict[str, int] = {}
         self._last_access_flush_ns = time.time_ns()
+        self._session_token = _PROCESS_SESSION_TOKEN
+        self._lease_token = secrets.randbits(63) or 1
+        self._lease_registry_key = os.path.normcase(str(self.path.absolute()))
+        self._lease_acquired = False
         self._needs_recovery = False
         self._rebuild_required = False
         self._closed = False
@@ -51,6 +59,12 @@ class SurfaceCacheIndex:
     @property
     def needs_recovery(self) -> bool:
         with self._lock:
+            if self._connection is None or self._rebuild_required:
+                return self._needs_recovery or self._rebuild_required
+            try:
+                self._needs_recovery = self._recovery_required_locked()
+            except sqlite3.DatabaseError as exc:
+                raise self._database_failure_locked(exc) from exc
             return self._needs_recovery
 
     @property
@@ -66,19 +80,18 @@ class SurfaceCacheIndex:
                 return True
             rebuilding = self._rebuild_required
             if rebuilding:
+                self._needs_recovery = True
                 self._discard_broken_index_locked()
             try:
                 self._open_connection_locked()
             except (OSError, sqlite3.DatabaseError) as first_error:
                 self._discard_broken_index_locked()
+                self._needs_recovery = True
                 try:
                     self._open_connection_locked()
-                    self._needs_recovery = True
                 except (OSError, sqlite3.DatabaseError) as second_error:
                     self._database_failure_locked(second_error or first_error)
                     return False
-            if rebuilding:
-                self._needs_recovery = True
             self._rebuild_required = False
             return True
 
@@ -281,7 +294,7 @@ class SurfaceCacheIndex:
             now = time.time_ns()
             try:
                 return (
-                    self._needs_recovery
+                    self._recovery_required_locked()
                     or self._meta_int_locked("indexed_bytes") > max(0, int(budget_bytes))
                     or self._meta_int_locked("bytes_since_maintenance") >= int(byte_interval)
                     or now - self._meta_int_locked("last_maintenance_ns", default=now)
@@ -350,8 +363,24 @@ class SurfaceCacheIndex:
 
     def mark_recovered(self) -> None:
         with self._lock:
-            if self._connection is not None and not self._rebuild_required:
+            if (
+                self._connection is None
+                or self._rebuild_required
+                or not self._lease_acquired
+            ):
+                return
+            connection = self._connection
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                if self._meta_int_locked("owner_session") != self._session_token:
+                    connection.rollback()
+                    return
+                self._set_meta_locked("recovery_required", 0)
+                connection.commit()
                 self._needs_recovery = False
+            except sqlite3.DatabaseError as exc:
+                self._rollback_quietly(connection)
+                raise self._database_failure_locked(exc) from exc
 
     def mark_recovery_required(self) -> None:
         with self._lock:
@@ -364,13 +393,12 @@ class SurfaceCacheIndex:
             try:
                 self.flush_accesses(force=True)
             except SurfaceCacheIndexUnavailableError:
-                pass
-            if self._connection is not None and clean and not self._needs_recovery:
+                clean = False
+            if self._connection is not None:
                 try:
-                    self._set_meta_locked("clean_shutdown", 1)
-                    self._connection.commit()
-                except sqlite3.DatabaseError as exc:
-                    self._database_failure_locked(exc)
+                    self._release_lease_locked(clean=clean)
+                except SurfaceCacheIndexUnavailableError:
+                    pass
             self._close_connection_locked()
             self._closed = True
 
@@ -380,11 +408,35 @@ class SurfaceCacheIndex:
         self._connection = connection
         try:
             self._create_schema(connection)
-            prior_clean = self._meta_int_locked("clean_shutdown", default=1)
-            self._needs_recovery = self._needs_recovery or prior_clean != 1
-            self._set_meta_locked("clean_shutdown", 0)
-            connection.commit()
+            with _LEASE_REGISTRY_LOCK:
+                connection.execute("BEGIN IMMEDIATE")
+                prior_clean = self._meta_int_locked("clean_shutdown", default=1)
+                owner_session = self._meta_int_locked("owner_session")
+                live_leases = len(
+                    _ACTIVE_SESSION_LEASES.get(self._lease_registry_key, ())
+                )
+                same_session_active = (
+                    owner_session == self._session_token and live_leases > 0
+                )
+                recovery_required = self._recovery_required_locked()
+                recovery_required = bool(
+                    recovery_required
+                    or self._needs_recovery
+                    or (prior_clean != 1 and not same_session_active)
+                )
+                self._set_meta_locked("owner_session", self._session_token)
+                self._set_meta_locked("active_leases", live_leases + 1)
+                self._set_meta_locked("recovery_required", int(recovery_required))
+                self._set_meta_locked("clean_shutdown", 0)
+                connection.commit()
+                _ACTIVE_SESSION_LEASES.setdefault(
+                    self._lease_registry_key,
+                    set(),
+                ).add(self._lease_token)
+                self._lease_acquired = True
+                self._needs_recovery = recovery_required
         except sqlite3.DatabaseError:
+            self._rollback_quietly(connection)
             self._close_connection_locked()
             raise
 
@@ -439,6 +491,9 @@ class SurfaceCacheIndex:
             ("bytes_since_maintenance", 0),
             ("last_maintenance_ns", now),
             ("clean_shutdown", 1),
+            ("owner_session", 0),
+            ("active_leases", 0),
+            ("recovery_required", 0),
         ):
             connection.execute(
                 "INSERT OR IGNORE INTO metadata(key, value) VALUES (?, ?)",
@@ -466,11 +521,59 @@ class SurfaceCacheIndex:
         self._needs_recovery = True
         if self._connection is None:
             return
+        connection = self._connection
         try:
+            connection.execute("BEGIN IMMEDIATE")
+            self._set_meta_locked("recovery_required", 1)
             self._set_meta_locked("clean_shutdown", 0)
-            self._connection.commit()
+            connection.commit()
         except sqlite3.DatabaseError as exc:
+            self._rollback_quietly(connection)
             self._database_failure_locked(exc)
+
+    def _recovery_required_locked(self) -> bool:
+        return self._meta_int_locked("recovery_required") != 0
+
+    def _release_lease_locked(self, *, clean: bool) -> None:
+        connection = self._connection
+        if connection is None or not self._lease_acquired:
+            return
+        try:
+            with _LEASE_REGISTRY_LOCK:
+                connection.execute("BEGIN IMMEDIATE")
+                if self._meta_int_locked("owner_session") != self._session_token:
+                    connection.rollback()
+                    self._forget_live_lease_locked()
+                    return
+                live_leases = _ACTIVE_SESSION_LEASES.get(
+                    self._lease_registry_key,
+                    set(),
+                )
+                remaining = len(live_leases - {self._lease_token})
+                recovery_required = bool(
+                    self._recovery_required_locked()
+                    or self._needs_recovery
+                    or not clean
+                )
+                self._set_meta_locked("active_leases", remaining)
+                self._set_meta_locked("recovery_required", int(recovery_required))
+                self._set_meta_locked(
+                    "clean_shutdown",
+                    int(remaining == 0 and clean and not recovery_required),
+                )
+                connection.commit()
+                self._forget_live_lease_locked()
+        except sqlite3.DatabaseError as exc:
+            self._rollback_quietly(connection)
+            raise self._database_failure_locked(exc) from exc
+
+    def _forget_live_lease_locked(self) -> None:
+        leases = _ACTIVE_SESSION_LEASES.get(self._lease_registry_key)
+        if leases is not None:
+            leases.discard(self._lease_token)
+            if not leases:
+                _ACTIVE_SESSION_LEASES.pop(self._lease_registry_key, None)
+        self._lease_acquired = False
 
     def _database_failure_locked(
         self,
@@ -478,6 +581,17 @@ class SurfaceCacheIndex:
     ) -> SurfaceCacheIndexUnavailableError:
         self._needs_recovery = True
         self._rebuild_required = True
+        connection = self._connection
+        if connection is not None:
+            self._rollback_quietly(connection)
+            try:
+                with _LEASE_REGISTRY_LOCK:
+                    connection.execute("BEGIN IMMEDIATE")
+                    self._set_meta_locked("recovery_required", 1)
+                    self._set_meta_locked("clean_shutdown", 0)
+                    connection.commit()
+            except sqlite3.DatabaseError:
+                self._rollback_quietly(connection)
         self._close_connection_locked()
         return SurfaceCacheIndexUnavailableError(
             f"surface cache index unavailable: {exc}"
@@ -531,6 +645,8 @@ class SurfaceCacheIndex:
     def _close_connection_locked(self) -> None:
         connection = self._connection
         self._connection = None
+        with _LEASE_REGISTRY_LOCK:
+            self._forget_live_lease_locked()
         if connection is not None:
             try:
                 connection.close()

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -41,14 +41,22 @@ class SurfaceCacheIndex:
         self._pending_access: dict[str, int] = {}
         self._last_access_flush_ns = time.time_ns()
         self._needs_recovery = False
+        self._closed = False
 
     @property
     def needs_recovery(self) -> bool:
         with self._lock:
             return self._needs_recovery
 
+    @property
+    def closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
     def ensure_open(self) -> bool:
         with self._lock:
+            if self._closed:
+                return False
             if self._connection is not None:
                 return True
             try:
@@ -319,6 +327,8 @@ class SurfaceCacheIndex:
 
     def close(self, *, clean: bool = True) -> None:
         with self._lock:
+            if self._closed:
+                return
             self.flush_accesses(force=True)
             if self._connection is not None and clean:
                 try:
@@ -327,6 +337,7 @@ class SurfaceCacheIndex:
                 except sqlite3.DatabaseError:
                     pass
             self._close_connection_locked()
+            self._closed = True
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -11,11 +11,24 @@ from pathlib import Path
 from threading import RLock
 from typing import Final
 
+from PySide6.QtCore import QLockFile
+
 _ACCESS_BATCH: Final = 128
 _ACCESS_INTERVAL_NS: Final = 30 * 1_000_000_000
+_NAMESPACE_LOCK_RETRY_NS: Final = 30 * 1_000_000_000
 _PROCESS_SESSION_TOKEN: Final = secrets.randbits(63) or 1
 _LEASE_REGISTRY_LOCK = RLock()
 _ACTIVE_SESSION_LEASES: dict[str, set[int]] = {}
+
+
+@dataclass(slots=True)
+class _NamespaceLockState:
+    lock_file: QLockFile
+    holders: set[int]
+
+
+_ACTIVE_NAMESPACE_LOCKS: dict[str, _NamespaceLockState] = {}
+_NAMESPACE_LOCK_FILE_FACTORY = QLockFile
 
 
 class SurfaceCacheIndexUnavailableError(RuntimeError):
@@ -42,16 +55,22 @@ class SurfaceCacheIndex:
     """One lock-serialized SQLite connection shared by cache worker threads."""
 
     def __init__(self, root: Path) -> None:
-        self.root = Path(root)
+        self.root = Path(root).expanduser().resolve(strict=False)
         self.path = self.root / "index.sqlite3"
+        self.lock_path = self.root / "index.sqlite3.lock"
         self._connection: sqlite3.Connection | None = None
         self._lock = RLock()
         self._pending_access: dict[str, int] = {}
         self._last_access_flush_ns = time.time_ns()
         self._session_token = _PROCESS_SESSION_TOKEN
         self._lease_token = secrets.randbits(63) or 1
-        self._lease_registry_key = os.path.normcase(str(self.path.absolute()))
+        self._lease_registry_key = os.path.normcase(str(self.path))
         self._lease_acquired = False
+        self._namespace_lock_token = secrets.randbits(63) or 1
+        self._namespace_lock_key = os.path.normcase(str(self.lock_path))
+        self._namespace_lock_acquired = False
+        self._namespace_lock_unavailable_reason: str | None = None
+        self._next_namespace_lock_retry_ns = 0
         self._needs_recovery = False
         self._rebuild_required = False
         self._closed = False
@@ -72,12 +91,21 @@ class SurfaceCacheIndex:
         with self._lock:
             return self._closed
 
+    @property
+    def open_unavailable_reason(self) -> str | None:
+        """Return the latest namespace-lock failure for diagnostics only."""
+
+        with self._lock:
+            return self._namespace_lock_unavailable_reason
+
     def ensure_open(self) -> bool:
         with self._lock:
             if self._closed:
                 return False
             if self._connection is not None:
                 return True
+            if not self._try_acquire_namespace_lock_locked():
+                return False
             rebuilding = self._rebuild_required
             if rebuilding:
                 self._needs_recovery = True
@@ -400,7 +428,69 @@ class SurfaceCacheIndex:
                 except SurfaceCacheIndexUnavailableError:
                     pass
             self._close_connection_locked()
+            self._release_namespace_lock_locked()
             self._closed = True
+
+    def _try_acquire_namespace_lock_locked(self) -> bool:
+        if self._namespace_lock_acquired:
+            return True
+        now = time.monotonic_ns()
+        if now < self._next_namespace_lock_retry_ns:
+            return False
+        try:
+            self.root.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self._record_namespace_lock_failure_locked("lock_io_error", now)
+            return False
+        with _LEASE_REGISTRY_LOCK:
+            shared = _ACTIVE_NAMESPACE_LOCKS.get(self._namespace_lock_key)
+            if shared is not None:
+                shared.holders.add(self._namespace_lock_token)
+                self._namespace_lock_acquired = True
+                self._namespace_lock_unavailable_reason = None
+                self._next_namespace_lock_retry_ns = 0
+                return True
+            try:
+                lock_file = _NAMESPACE_LOCK_FILE_FACTORY(str(self.lock_path))
+                lock_file.setStaleLockTime(0)
+                acquired = bool(lock_file.tryLock(0))
+            except (OSError, RuntimeError):
+                self._record_namespace_lock_failure_locked("lock_io_error", now)
+                return False
+            if not acquired:
+                error = lock_file.error()
+                if error == QLockFile.LockError.LockFailedError:
+                    reason = "owned_by_other_process"
+                elif error == QLockFile.LockError.PermissionError:
+                    reason = "lock_permission_error"
+                else:
+                    reason = "lock_io_error"
+                self._record_namespace_lock_failure_locked(reason, now)
+                return False
+            _ACTIVE_NAMESPACE_LOCKS[self._namespace_lock_key] = _NamespaceLockState(
+                lock_file=lock_file,
+                holders={self._namespace_lock_token},
+            )
+            self._namespace_lock_acquired = True
+            self._namespace_lock_unavailable_reason = None
+            self._next_namespace_lock_retry_ns = 0
+            return True
+
+    def _record_namespace_lock_failure_locked(self, reason: str, now: int) -> None:
+        self._namespace_lock_unavailable_reason = str(reason)
+        self._next_namespace_lock_retry_ns = int(now) + _NAMESPACE_LOCK_RETRY_NS
+
+    def _release_namespace_lock_locked(self) -> None:
+        if not self._namespace_lock_acquired:
+            return
+        with _LEASE_REGISTRY_LOCK:
+            shared = _ACTIVE_NAMESPACE_LOCKS.get(self._namespace_lock_key)
+            if shared is not None:
+                shared.holders.discard(self._namespace_lock_token)
+                if not shared.holders:
+                    shared.lock_file.unlock()
+                    _ACTIVE_NAMESPACE_LOCKS.pop(self._namespace_lock_key, None)
+        self._namespace_lock_acquired = False
 
     def _open_connection_locked(self) -> None:
         self.root.mkdir(parents=True, exist_ok=True)

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -1,0 +1,441 @@
+"""Transactional metadata index for the rebuildable Detail surface cache."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import Final
+
+_ACCESS_BATCH: Final = 128
+_ACCESS_INTERVAL_NS: Final = 30 * 1_000_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceCacheIndexEntry:
+    digest: str
+    relative_path: str
+    container_schema: int
+    decoder_contract: int
+    payload_bytes: int
+    file_bytes: int
+    checksum: int
+    checksum_state: str
+    file_mtime_ns: int
+    created_ns: int
+    last_access_ns: int
+    last_verified_ns: int
+
+
+class SurfaceCacheIndex:
+    """One lock-serialized SQLite connection shared by cache worker threads."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.path = self.root / "index.sqlite3"
+        self._connection: sqlite3.Connection | None = None
+        self._lock = RLock()
+        self._pending_access: dict[str, int] = {}
+        self._last_access_flush_ns = time.time_ns()
+        self._needs_recovery = False
+
+    @property
+    def needs_recovery(self) -> bool:
+        with self._lock:
+            return self._needs_recovery
+
+    def ensure_open(self) -> bool:
+        with self._lock:
+            if self._connection is not None:
+                return True
+            try:
+                self.root.mkdir(parents=True, exist_ok=True)
+                self._connection = self._connect()
+                self._create_schema(self._connection)
+            except (OSError, sqlite3.DatabaseError):
+                self._discard_broken_index_locked()
+                try:
+                    self.root.mkdir(parents=True, exist_ok=True)
+                    self._connection = self._connect()
+                    self._create_schema(self._connection)
+                    self._needs_recovery = True
+                except (OSError, sqlite3.DatabaseError):
+                    self._close_connection_locked()
+                    return False
+            connection = self._connection
+            if connection is None:
+                return False
+            prior_clean = self._meta_int_locked("clean_shutdown", default=1)
+            self._needs_recovery = self._needs_recovery or prior_clean != 1
+            self._set_meta_locked("clean_shutdown", 0)
+            connection.commit()
+            return True
+
+    def get(self, digest: str) -> SurfaceCacheIndexEntry | None:
+        with self._lock:
+            if not self.ensure_open():
+                return None
+            row = self._connection.execute(  # type: ignore[union-attr]
+                """
+                SELECT digest, relative_path, container_schema, decoder_contract,
+                       payload_bytes, file_bytes, checksum, checksum_state,
+                       file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                FROM entries
+                WHERE digest = ?
+                """,
+                (str(digest),),
+            ).fetchone()
+            return self._entry_from_row(row) if row is not None else None
+
+    def all_entries(self) -> tuple[SurfaceCacheIndexEntry, ...]:
+        with self._lock:
+            if not self.ensure_open():
+                return ()
+            rows = self._connection.execute(  # type: ignore[union-attr]
+                """
+                SELECT digest, relative_path, container_schema, decoder_contract,
+                       payload_bytes, file_bytes, checksum, checksum_state,
+                       file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                FROM entries
+                """
+            ).fetchall()
+            return tuple(self._entry_from_row(row) for row in rows)
+
+    def upsert(self, entry: SurfaceCacheIndexEntry) -> bool:
+        with self._lock:
+            if not self.ensure_open():
+                return False
+            connection = self._connection
+            try:
+                previous = connection.execute(  # type: ignore[union-attr]
+                    "SELECT file_bytes FROM entries WHERE digest = ?",
+                    (entry.digest,),
+                ).fetchone()
+                previous_bytes = int(previous[0]) if previous is not None else 0
+                connection.execute(  # type: ignore[union-attr]
+                    """
+                    INSERT INTO entries (
+                        digest, relative_path, container_schema, decoder_contract,
+                        payload_bytes, file_bytes, checksum, checksum_state,
+                        file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(digest) DO UPDATE SET
+                        relative_path = excluded.relative_path,
+                        container_schema = excluded.container_schema,
+                        decoder_contract = excluded.decoder_contract,
+                        payload_bytes = excluded.payload_bytes,
+                        file_bytes = excluded.file_bytes,
+                        checksum = excluded.checksum,
+                        checksum_state = excluded.checksum_state,
+                        file_mtime_ns = excluded.file_mtime_ns,
+                        last_access_ns = excluded.last_access_ns,
+                        last_verified_ns = excluded.last_verified_ns
+                    """,
+                    (
+                        entry.digest,
+                        entry.relative_path,
+                        entry.container_schema,
+                        entry.decoder_contract,
+                        entry.payload_bytes,
+                        entry.file_bytes,
+                        f"{entry.checksum:016x}",
+                        entry.checksum_state,
+                        entry.file_mtime_ns,
+                        entry.created_ns,
+                        entry.last_access_ns,
+                        entry.last_verified_ns,
+                    ),
+                )
+                delta = entry.file_bytes - previous_bytes
+                self._set_meta_locked(
+                    "indexed_bytes",
+                    max(0, self._meta_int_locked("indexed_bytes") + delta),
+                )
+                self._set_meta_locked(
+                    "bytes_since_maintenance",
+                    max(0, self._meta_int_locked("bytes_since_maintenance") + entry.file_bytes),
+                )
+                connection.commit()  # type: ignore[union-attr]
+                return True
+            except sqlite3.DatabaseError:
+                connection.rollback()  # type: ignore[union-attr]
+                return False
+
+    def remove(self, digest: str) -> None:
+        with self._lock:
+            if not self.ensure_open():
+                return
+            connection = self._connection
+            try:
+                row = connection.execute(  # type: ignore[union-attr]
+                    "SELECT file_bytes FROM entries WHERE digest = ?",
+                    (str(digest),),
+                ).fetchone()
+                if row is None:
+                    return
+                connection.execute("DELETE FROM entries WHERE digest = ?", (str(digest),))  # type: ignore[union-attr]
+                self._set_meta_locked(
+                    "indexed_bytes",
+                    max(0, self._meta_int_locked("indexed_bytes") - int(row[0])),
+                )
+                connection.commit()  # type: ignore[union-attr]
+            except sqlite3.DatabaseError:
+                connection.rollback()  # type: ignore[union-attr]
+
+    def mark_checksum_state(
+        self,
+        digest: str,
+        state: str,
+        *,
+        verified_ns: int | None = None,
+    ) -> None:
+        with self._lock:
+            if not self.ensure_open():
+                return
+            when = int(verified_ns or 0)
+            self._connection.execute(  # type: ignore[union-attr]
+                """
+                UPDATE entries
+                SET checksum_state = ?,
+                    last_verified_ns = CASE WHEN ? > 0 THEN ? ELSE last_verified_ns END
+                WHERE digest = ?
+                """,
+                (str(state), when, when, str(digest)),
+            )
+            self._connection.commit()  # type: ignore[union-attr]
+
+    def queue_access(self, digest: str, *, accessed_ns: int | None = None) -> bool:
+        now = int(accessed_ns or time.time_ns())
+        with self._lock:
+            self._pending_access[str(digest)] = now
+            return (
+                len(self._pending_access) >= _ACCESS_BATCH
+                or now - self._last_access_flush_ns >= _ACCESS_INTERVAL_NS
+            )
+
+    def flush_accesses(self, *, force: bool = False) -> bool:
+        with self._lock:
+            now = time.time_ns()
+            if not self._pending_access:
+                return False
+            if (
+                not force
+                and len(self._pending_access) < _ACCESS_BATCH
+                and now - self._last_access_flush_ns < _ACCESS_INTERVAL_NS
+            ):
+                return False
+            if not self.ensure_open():
+                return False
+            pending = tuple(self._pending_access.items())
+            try:
+                self._connection.executemany(  # type: ignore[union-attr]
+                    "UPDATE entries SET last_access_ns = ? WHERE digest = ?",
+                    ((accessed_ns, digest) for digest, accessed_ns in pending),
+                )
+                self._connection.commit()  # type: ignore[union-attr]
+            except sqlite3.DatabaseError:
+                self._connection.rollback()  # type: ignore[union-attr]
+                return False
+            for digest, accessed_ns in pending:
+                if self._pending_access.get(digest) == accessed_ns:
+                    self._pending_access.pop(digest, None)
+            self._last_access_flush_ns = now
+            return True
+
+    def maintenance_due(
+        self,
+        budget_bytes: int,
+        *,
+        byte_interval: int,
+        time_interval_ns: int,
+    ) -> bool:
+        with self._lock:
+            if not self.ensure_open():
+                return False
+            now = time.time_ns()
+            return (
+                self._meta_int_locked("indexed_bytes") > max(0, int(budget_bytes))
+                or self._meta_int_locked("bytes_since_maintenance") >= int(byte_interval)
+                or now - self._meta_int_locked("last_maintenance_ns", default=now)
+                >= int(time_interval_ns)
+            )
+
+    def lru_victims(self, *, limit: int) -> tuple[SurfaceCacheIndexEntry, ...]:
+        with self._lock:
+            if not self.ensure_open():
+                return ()
+            rows = self._connection.execute(  # type: ignore[union-attr]
+                """
+                SELECT digest, relative_path, container_schema, decoder_contract,
+                       payload_bytes, file_bytes, checksum, checksum_state,
+                       file_mtime_ns, created_ns, last_access_ns, last_verified_ns
+                FROM entries
+                ORDER BY last_access_ns ASC, created_ns ASC, digest ASC
+                LIMIT ?
+                """,
+                (max(1, int(limit)),),
+            ).fetchall()
+            return tuple(self._entry_from_row(row) for row in rows)
+
+    @property
+    def indexed_bytes(self) -> int:
+        with self._lock:
+            if not self.ensure_open():
+                return 0
+            return self._meta_int_locked("indexed_bytes")
+
+    def finish_maintenance(self) -> None:
+        with self._lock:
+            if not self.ensure_open():
+                return
+            self._set_meta_locked("bytes_since_maintenance", 0)
+            self._set_meta_locked("last_maintenance_ns", time.time_ns())
+            self._connection.commit()  # type: ignore[union-attr]
+
+    def recalculate_indexed_bytes(self) -> int:
+        """Repair the cached byte total after an exceptional recovery scan."""
+
+        with self._lock:
+            if not self.ensure_open():
+                return 0
+            row = self._connection.execute(  # type: ignore[union-attr]
+                "SELECT COALESCE(SUM(file_bytes), 0) FROM entries"
+            ).fetchone()
+            total = max(0, int(row[0]) if row is not None else 0)
+            self._set_meta_locked("indexed_bytes", total)
+            self._connection.commit()  # type: ignore[union-attr]
+            return total
+
+    def mark_recovered(self) -> None:
+        with self._lock:
+            self._needs_recovery = False
+
+    def close(self, *, clean: bool = True) -> None:
+        with self._lock:
+            self.flush_accesses(force=True)
+            if self._connection is not None and clean:
+                try:
+                    self._set_meta_locked("clean_shutdown", 1)
+                    self._connection.commit()
+                except sqlite3.DatabaseError:
+                    pass
+            self._close_connection_locked()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            self.path,
+            timeout=5.0,
+            check_same_thread=False,
+        )
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=NORMAL")
+        connection.execute("PRAGMA temp_store=MEMORY")
+        return connection
+
+    @staticmethod
+    def _create_schema(connection: sqlite3.Connection) -> None:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS entries (
+                digest TEXT PRIMARY KEY,
+                relative_path TEXT NOT NULL,
+                container_schema INTEGER NOT NULL,
+                decoder_contract INTEGER NOT NULL,
+                payload_bytes INTEGER NOT NULL,
+                file_bytes INTEGER NOT NULL,
+                checksum TEXT NOT NULL,
+                checksum_state TEXT NOT NULL,
+                file_mtime_ns INTEGER NOT NULL,
+                created_ns INTEGER NOT NULL,
+                last_access_ns INTEGER NOT NULL,
+                last_verified_ns INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS entries_lru
+                ON entries(last_access_ns, created_ns, digest);
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value INTEGER NOT NULL
+            );
+            """
+        )
+        now = time.time_ns()
+        for key, value in (
+            ("index_schema", 1),
+            ("indexed_bytes", 0),
+            ("bytes_since_maintenance", 0),
+            ("last_maintenance_ns", now),
+            ("clean_shutdown", 1),
+        ):
+            connection.execute(
+                "INSERT OR IGNORE INTO metadata(key, value) VALUES (?, ?)",
+                (key, value),
+            )
+        connection.commit()
+
+    def _meta_int_locked(self, key: str, *, default: int = 0) -> int:
+        row = self._connection.execute(  # type: ignore[union-attr]
+            "SELECT value FROM metadata WHERE key = ?",
+            (str(key),),
+        ).fetchone()
+        return int(row[0]) if row is not None else int(default)
+
+    def _set_meta_locked(self, key: str, value: int) -> None:
+        self._connection.execute(  # type: ignore[union-attr]
+            """
+            INSERT INTO metadata(key, value) VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (str(key), int(value)),
+        )
+
+    @staticmethod
+    def _entry_from_row(row: sqlite3.Row) -> SurfaceCacheIndexEntry:
+        return SurfaceCacheIndexEntry(
+            digest=str(row["digest"]),
+            relative_path=str(row["relative_path"]),
+            container_schema=int(row["container_schema"]),
+            decoder_contract=int(row["decoder_contract"]),
+            payload_bytes=int(row["payload_bytes"]),
+            file_bytes=int(row["file_bytes"]),
+            checksum=int(str(row["checksum"]), 16),
+            checksum_state=str(row["checksum_state"]),
+            file_mtime_ns=int(row["file_mtime_ns"]),
+            created_ns=int(row["created_ns"]),
+            last_access_ns=int(row["last_access_ns"]),
+            last_verified_ns=int(row["last_verified_ns"]),
+        )
+
+    def _discard_broken_index_locked(self) -> None:
+        self._close_connection_locked()
+        if self.path.exists():
+            destination = self.path.with_name(
+                f"{self.path.name}.corrupt-{time.time_ns()}"
+            )
+            try:
+                os.replace(self.path, destination)
+            except OSError:
+                try:
+                    self.path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+        for suffix in ("-wal", "-shm"):
+            try:
+                Path(f"{self.path}{suffix}").unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def _close_connection_locked(self) -> None:
+        connection = self._connection
+        self._connection = None
+        if connection is not None:
+            try:
+                connection.close()
+            except sqlite3.DatabaseError:
+                pass
+
+
+__all__ = ["SurfaceCacheIndex", "SurfaceCacheIndexEntry"]

--- a/src/iPhoto/gui/detail_surface_cache_index.py
+++ b/src/iPhoto/gui/detail_surface_cache_index.py
@@ -172,10 +172,10 @@ class SurfaceCacheIndex:
                 connection.rollback()  # type: ignore[union-attr]
                 return False
 
-    def remove(self, digest: str) -> None:
+    def remove(self, digest: str) -> bool:
         with self._lock:
             if not self.ensure_open():
-                return
+                return False
             connection = self._connection
             try:
                 row = connection.execute(  # type: ignore[union-attr]
@@ -183,15 +183,18 @@ class SurfaceCacheIndex:
                     (str(digest),),
                 ).fetchone()
                 if row is None:
-                    return
+                    return True
                 connection.execute("DELETE FROM entries WHERE digest = ?", (str(digest),))  # type: ignore[union-attr]
                 self._set_meta_locked(
                     "indexed_bytes",
                     max(0, self._meta_int_locked("indexed_bytes") - int(row[0])),
                 )
                 connection.commit()  # type: ignore[union-attr]
+                return True
             except sqlite3.DatabaseError:
                 connection.rollback()  # type: ignore[union-attr]
+                self._mark_recovery_required_locked()
+                return False
 
     def mark_checksum_state(
         self,
@@ -325,17 +328,21 @@ class SurfaceCacheIndex:
         with self._lock:
             self._needs_recovery = False
 
+    def mark_recovery_required(self) -> None:
+        with self._lock:
+            self._mark_recovery_required_locked()
+
     def close(self, *, clean: bool = True) -> None:
         with self._lock:
             if self._closed:
                 return
             self.flush_accesses(force=True)
-            if self._connection is not None and clean:
+            if self._connection is not None and clean and not self._needs_recovery:
                 try:
                     self._set_meta_locked("clean_shutdown", 1)
                     self._connection.commit()
                 except sqlite3.DatabaseError:
-                    pass
+                    self._needs_recovery = True
             self._close_connection_locked()
             self._closed = True
 
@@ -412,6 +419,19 @@ class SurfaceCacheIndex:
             """,
             (str(key), int(value)),
         )
+
+    def _mark_recovery_required_locked(self) -> None:
+        self._needs_recovery = True
+        if self._connection is None:
+            return
+        try:
+            self._set_meta_locked("clean_shutdown", 0)
+            self._connection.commit()
+        except sqlite3.DatabaseError:
+            try:
+                self._connection.rollback()
+            except sqlite3.DatabaseError:
+                pass
 
     @staticmethod
     def _entry_from_row(row: sqlite3.Row) -> SurfaceCacheIndexEntry:

--- a/src/iPhoto/gui/detail_surface_residency.py
+++ b/src/iPhoto/gui/detail_surface_residency.py
@@ -1,0 +1,239 @@
+"""Diagnostic-only ownership accounting for Detail still-image resources.
+
+The tracker deliberately does not own, pin, evict, or otherwise influence a
+resource.  It is the observation surface used before the later SurfaceLease
+budget migration so that the current retention graph can be measured without
+changing its behaviour.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+from dataclasses import dataclass
+from threading import RLock
+from typing import TYPE_CHECKING
+
+from iPhoto.gui.detail_profile import emit_detail_event
+
+if TYPE_CHECKING:
+    from iPhoto.gui.detail_decode_backend import DecodedSurface
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceByteBreakdown:
+    """Bytes retained by one unique surface resource."""
+
+    cpu_heap: int = 0
+    mmap: int = 0
+    upload_staging: int = 0
+    gpu_estimated: int = 0
+    raw_intermediate: int = 0
+
+    def __post_init__(self) -> None:
+        for name in (
+            "cpu_heap",
+            "mmap",
+            "upload_staging",
+            "gpu_estimated",
+            "raw_intermediate",
+        ):
+            object.__setattr__(self, name, max(0, int(getattr(self, name))))
+
+    @property
+    def total(self) -> int:
+        return (
+            self.cpu_heap
+            + self.mmap
+            + self.upload_staging
+            + self.gpu_estimated
+            + self.raw_intermediate
+        )
+
+    def __add__(self, other: SurfaceByteBreakdown) -> SurfaceByteBreakdown:
+        if not isinstance(other, SurfaceByteBreakdown):
+            return NotImplemented
+        return SurfaceByteBreakdown(
+            cpu_heap=self.cpu_heap + other.cpu_heap,
+            mmap=self.mmap + other.mmap,
+            upload_staging=self.upload_staging + other.upload_staging,
+            gpu_estimated=self.gpu_estimated + other.gpu_estimated,
+            raw_intermediate=self.raw_intermediate + other.raw_intermediate,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceResidencySnapshot:
+    """One immutable diagnostic view of unique resources and their owners."""
+
+    resource_count: int
+    owner_count: int
+    reference_count: int
+    unique_bytes: SurfaceByteBreakdown
+    bytes_by_owner_kind: tuple[tuple[str, int], ...]
+
+
+def surface_resource_id(surface: DecodedSurface, *, stage: str = "surface") -> Hashable:
+    """Return a process-local identity that distinguishes shared QImage storage."""
+
+    try:
+        image_key = int(surface.image.cacheKey())
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        image_key = id(surface.image)
+    return (str(stage), surface.decode_key, image_key)
+
+
+def surface_bytes(surface: DecodedSurface) -> SurfaceByteBreakdown:
+    """Classify one decoded image as heap or mmap-backed resident storage."""
+
+    image = surface.image
+    size = max(0, int(image.bytesPerLine()) * int(image.height()))
+    if surface.backing_owner is not None:
+        return SurfaceByteBreakdown(mmap=size)
+    return SurfaceByteBreakdown(cpu_heap=size)
+
+
+class SurfaceResidencyTracker:
+    """Thread-safe diagnostic registry; never applies allocation policy."""
+
+    def __init__(self) -> None:
+        self._resources: dict[Hashable, SurfaceByteBreakdown] = {}
+        self._resource_owners: dict[Hashable, set[str]] = {}
+        self._owner_resources: dict[str, set[Hashable]] = {}
+        self._owner_kinds: dict[str, str] = {}
+        self._lock = RLock()
+
+    def retain(
+        self,
+        owner_id: str,
+        owner_kind: str,
+        resource_id: Hashable,
+        byte_breakdown: SurfaceByteBreakdown,
+        *,
+        generation: int = 0,
+    ) -> None:
+        """Observe one owner retaining one resource, idempotently."""
+
+        owner = str(owner_id)
+        kind = str(owner_kind)
+        with self._lock:
+            self._resources[resource_id] = byte_breakdown
+            self._resource_owners.setdefault(resource_id, set()).add(owner)
+            self._owner_resources.setdefault(owner, set()).add(resource_id)
+            self._owner_kinds[owner] = kind
+            snapshot = self._snapshot_locked()
+        self._emit_snapshot("surface_owner_retain", generation, kind, snapshot)
+
+    def release(
+        self,
+        owner_id: str,
+        resource_id: Hashable | None = None,
+        *,
+        generation: int = 0,
+    ) -> None:
+        """Observe one resource release, or every resource held by an owner."""
+
+        owner = str(owner_id)
+        with self._lock:
+            resources = self._owner_resources.get(owner)
+            if not resources:
+                return
+            targets = tuple(resources) if resource_id is None else (resource_id,)
+            for target in targets:
+                if target not in resources:
+                    continue
+                resources.discard(target)
+                owners = self._resource_owners.get(target)
+                if owners is None:
+                    continue
+                owners.discard(owner)
+                if not owners:
+                    self._resource_owners.pop(target, None)
+                    self._resources.pop(target, None)
+            if not resources:
+                self._owner_resources.pop(owner, None)
+                kind = self._owner_kinds.pop(owner, "unknown")
+            else:
+                kind = self._owner_kinds.get(owner, "unknown")
+            snapshot = self._snapshot_locked()
+        self._emit_snapshot("surface_owner_release", generation, kind, snapshot)
+
+    def retain_surface(
+        self,
+        owner_id: str,
+        owner_kind: str,
+        surface: DecodedSurface,
+        *,
+        generation: int = 0,
+    ) -> Hashable:
+        resource_id = surface_resource_id(surface)
+        self.retain(
+            owner_id,
+            owner_kind,
+            resource_id,
+            surface_bytes(surface),
+            generation=generation,
+        )
+        return resource_id
+
+    def snapshot(self) -> SurfaceResidencySnapshot:
+        with self._lock:
+            return self._snapshot_locked()
+
+    def clear(self, *, generation: int = 0) -> None:
+        with self._lock:
+            self._resources.clear()
+            self._resource_owners.clear()
+            self._owner_resources.clear()
+            self._owner_kinds.clear()
+            snapshot = self._snapshot_locked()
+        self._emit_snapshot("surface_owner_clear", generation, "all", snapshot)
+
+    def _snapshot_locked(self) -> SurfaceResidencySnapshot:
+        total = SurfaceByteBreakdown()
+        for byte_breakdown in self._resources.values():
+            total += byte_breakdown
+        by_kind: dict[str, int] = {}
+        for owner, resources in self._owner_resources.items():
+            kind = self._owner_kinds.get(owner, "unknown")
+            by_kind[kind] = by_kind.get(kind, 0) + sum(
+                self._resources[resource].total
+                for resource in resources
+                if resource in self._resources
+            )
+        return SurfaceResidencySnapshot(
+            resource_count=len(self._resources),
+            owner_count=len(self._owner_resources),
+            reference_count=sum(len(resources) for resources in self._owner_resources.values()),
+            unique_bytes=total,
+            bytes_by_owner_kind=tuple(sorted(by_kind.items())),
+        )
+
+    @staticmethod
+    def _emit_snapshot(
+        stage: str,
+        generation: int,
+        owner_kind: str,
+        snapshot: SurfaceResidencySnapshot,
+    ) -> None:
+        emit_detail_event(
+            stage,
+            generation=generation,
+            owner_kind=owner_kind,
+            resources=snapshot.resource_count,
+            owners=snapshot.owner_count,
+            references=snapshot.reference_count,
+            cpu_heap_bytes=snapshot.unique_bytes.cpu_heap,
+            mmap_bytes=snapshot.unique_bytes.mmap,
+            upload_staging_bytes=snapshot.unique_bytes.upload_staging,
+            gpu_estimated_bytes=snapshot.unique_bytes.gpu_estimated,
+            raw_intermediate_bytes=snapshot.unique_bytes.raw_intermediate,
+        )
+
+
+__all__ = [
+    "SurfaceByteBreakdown",
+    "SurfaceResidencySnapshot",
+    "SurfaceResidencyTracker",
+    "surface_bytes",
+    "surface_resource_id",
+]

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -46,6 +46,7 @@ from ....gui.detail_profile import (
 from ....gui.detail_render_session import EditRenderState, PhotoRenderSessionHandle
 from ....gui.detail_request_scheduler import DetailStillRequestScheduler
 from ....gui.detail_surface_cache import CachedStillDecodeBackend
+from ....gui.detail_surface_residency import SurfaceResidencyTracker
 from ....gui.i18n import tr
 from ..widgets.gl_image_viewer import GLImageViewer
 from ..widgets.live_badge import LiveBadge
@@ -370,7 +371,20 @@ class PlayerViewController(QObject):
         self._image_viewer_index = player_stack.indexOf(image_viewer)
         self._image_viewer.replayRequested.connect(self.liveReplayRequested)
         self._pool = StillImageDecodeScheduler(self)
-        self._decode_backend = CachedStillDecodeBackend(DefaultStillDecodeBackend())
+        self._surface_residency_tracker = SurfaceResidencyTracker()
+        bind_residency_tracker = getattr(
+            self._image_viewer,
+            "set_surface_residency_tracker",
+            None,
+        )
+        if callable(bind_residency_tracker):
+            bind_residency_tracker(self._surface_residency_tracker)
+        self._decode_backend = CachedStillDecodeBackend(
+            DefaultStillDecodeBackend(
+                residency_tracker=self._surface_residency_tracker
+            ),
+            residency_tracker=self._surface_residency_tracker,
+        )
         if self._library_root_getter is not None:
             self._decode_backend.bind_library(self._library_root_getter())
         self._still_scheduler = DetailStillRequestScheduler(
@@ -1275,6 +1289,13 @@ class PlayerViewController(QObject):
         self._preparation_pool.waitForDone(max(0, int(timeout_ms)))
         self._still_scheduler.shutdown(timeout_ms=timeout_ms)
         self._decode_backend.shutdown(timeout_ms=min(max(0, int(timeout_ms)), 1000))
+        clear_residency = getattr(self._image_viewer, "clear_still_residency", None)
+        if callable(clear_residency):
+            clear_residency()
+        for session in tuple({id(item): item for item in self._render_sessions.values()}.values()):
+            release_observations = getattr(session, "release_residency_observations", None)
+            if callable(release_observations):
+                release_observations()
         shutdown_detail_profile(timeout_ms=min(max(0, int(timeout_ms)), 1000))
 
     def clear_frame_cache(self) -> None:
@@ -1293,6 +1314,10 @@ class PlayerViewController(QObject):
         clear_residency = getattr(self._image_viewer, "clear_still_residency", None)
         if callable(clear_residency):
             clear_residency()
+        for session in tuple({id(item): item for item in self._render_sessions.values()}.values()):
+            release_observations = getattr(session, "release_residency_observations", None)
+            if callable(release_observations):
+                release_observations()
         self._render_sessions.clear()
         self._current_render_session = None
         self._render_session_interaction_depth.clear()
@@ -1308,6 +1333,11 @@ class PlayerViewController(QObject):
         if callable(trim_residency):
             trim_residency()
         current = self._current_render_session
+        for session in tuple({id(item): item for item in self._render_sessions.values()}.values()):
+            if session is not current:
+                release_observations = getattr(session, "release_residency_observations", None)
+                if callable(release_observations):
+                    release_observations()
         self._render_sessions.clear()
         if current is not None:
             self._render_sessions[self._render_session_key_for_surface(current.current_surface)] = current
@@ -1577,6 +1607,7 @@ class PlayerViewController(QObject):
                 current_surface=surface,
                 edit_state=state,
                 baseline_state=state,
+                residency_tracker=self._surface_residency_tracker,
             )
             self._next_render_session_id += 1
             emit_detail_event(
@@ -1607,7 +1638,8 @@ class PlayerViewController(QObject):
                 if all(item.edit_references > 0 or item is self._current_render_session for item in self._render_sessions.values()):
                     break
                 continue
-            self._render_sessions.pop(oldest_key)
+            evicted = self._render_sessions.pop(oldest_key)
+            evicted.release_residency_observations()
         if make_current:
             self._current_render_session = session
         return session

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -37,6 +37,11 @@ except (ModuleNotFoundError, ImportError):  # pragma: no cover
 
 from iPhoto.gui.detail_decode_backend import DecodedSurface
 from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
+from iPhoto.gui.detail_surface_residency import (
+    SurfaceByteBreakdown,
+    SurfaceResidencyTracker,
+    surface_resource_id,
+)
 
 from ..gl_crop_controller import CropInteractionController
 from ..render_backend import is_opengl_api, qrhi_api_name, select_qrhi_widget_api
@@ -164,6 +169,10 @@ class GLImageViewer(QRhiWidget):
 
         # 状态
         self._image: QImage | None = None
+        self._surface_residency_tracker: SurfaceResidencyTracker | None = None
+        self._tracked_surface_resources: dict[object, object] = {}
+        self._tracked_staging_resources: dict[object, object] = {}
+        self._tracked_gpu_resources: dict[object, object] = {}
         self._still_surface_refs: OrderedDict[object, DecodedSurface] = OrderedDict()
         self._pending_warm_surfaces: list[DecodedSurface] = []
         self._still_generation_by_key: dict[object, int] = {}
@@ -541,20 +550,74 @@ class GLImageViewer(QRhiWidget):
         self._pending_resident_activation = None
         self._still_surface_refs.clear()
         self._still_generation_by_key.clear()
+        tracker = self._surface_residency_tracker
+        if tracker is not None:
+            tracker.release("detail-viewer-surfaces")
+            tracker.release("detail-upload-staging")
+        self._tracked_surface_resources.clear()
+        self._tracked_staging_resources.clear()
         self._texture_manager.clear_still_residency()
+        self._sync_gpu_residency()
 
     def trim_still_residency(self) -> None:
         self._pending_warm_surfaces.clear()
         self._texture_manager.trim_still_residency()
+        self._sync_gpu_residency()
 
     def zoom_factor(self) -> float:
         return float(self._transform_controller.get_zoom_factor())
 
     def _remember_still_surface(self, surface: DecodedSurface) -> None:
-        self._still_surface_refs.pop(surface.decode_key, None)
+        previous = self._still_surface_refs.pop(surface.decode_key, None)
+        tracker = self._surface_residency_tracker
+        if previous is not None and tracker is not None:
+            previous_resource = self._tracked_surface_resources.pop(
+                surface.decode_key,
+                surface_resource_id(previous),
+            )
+            tracker.release("detail-viewer-surfaces", previous_resource)
         self._still_surface_refs[surface.decode_key] = surface
+        if tracker is not None:
+            self._tracked_surface_resources[surface.decode_key] = tracker.retain_surface(
+                "detail-viewer-surfaces",
+                "presentation_prefetch",
+                surface,
+                generation=self._still_generation_by_key.get(surface.decode_key, 0),
+            )
         while len(self._still_surface_refs) > 3:
-            self._still_surface_refs.popitem(last=False)
+            evicted_key, evicted = self._still_surface_refs.popitem(last=False)
+            if tracker is not None:
+                evicted_resource = self._tracked_surface_resources.pop(
+                    evicted_key,
+                    surface_resource_id(evicted),
+                )
+                tracker.release("detail-viewer-surfaces", evicted_resource)
+
+    def set_surface_residency_tracker(
+        self,
+        tracker: SurfaceResidencyTracker | None,
+    ) -> None:
+        """Bind the diagnostic-only tracker used by the owning player."""
+
+        previous = self._surface_residency_tracker
+        if previous is tracker:
+            return
+        if previous is not None:
+            previous.release("detail-viewer-surfaces")
+            previous.release("detail-upload-staging")
+            previous.release("detail-gpu-residency")
+        self._surface_residency_tracker = tracker
+        self._tracked_surface_resources.clear()
+        self._tracked_staging_resources.clear()
+        self._tracked_gpu_resources.clear()
+        if tracker is not None:
+            for surface in self._still_surface_refs.values():
+                self._tracked_surface_resources[surface.decode_key] = tracker.retain_surface(
+                    "detail-viewer-surfaces",
+                    "presentation_prefetch",
+                    surface,
+                )
+            self._sync_gpu_residency()
 
     def set_video_frame(
         self,
@@ -1301,6 +1364,11 @@ class GLImageViewer(QRhiWidget):
                 rhi.makeThreadLocalNativeContextCurrent()
             self._renderer.destroy_resources()
         self._texture_manager.mark_texture_lost()
+        self._sync_gpu_residency()
+        tracker = self._surface_residency_tracker
+        if tracker is not None:
+            tracker.release("detail-upload-staging")
+        self._tracked_staging_resources.clear()
         emit_detail_event("context_rebuild", generation=0, state="released")
 
     def render(self, cb) -> None:  # type: ignore[override]
@@ -1417,7 +1485,7 @@ class GLImageViewer(QRhiWidget):
             and self._texture_manager.needs_texture_upload()
         ):
             upload_started = time.perf_counter()
-            self._texture_manager.upload_texture_if_needed(self._image)
+            self._upload_current_still_with_tracking()
             log_detail_profile(
                 "gl_viewer",
                 "still.gpu_upload",
@@ -1435,7 +1503,7 @@ class GLImageViewer(QRhiWidget):
             )
         elif self._pending_warm_surfaces:
             warm = self._pending_warm_surfaces.pop(0)
-            if self._texture_manager.warm_still_texture(warm.decode_key, warm.image):
+            if self._warm_still_with_tracking(warm):
                 emit_detail_event(
                     "gpu_upload",
                     generation=self._still_generation_by_key.get(warm.decode_key, 0),
@@ -1593,7 +1661,7 @@ class GLImageViewer(QRhiWidget):
             and self._texture_manager.needs_texture_upload()
         ):
             upload_started = time.perf_counter()
-            self._texture_manager.upload_texture_if_needed(self._image)
+            self._upload_current_still_with_tracking()
             log_detail_profile(
                 "gl_viewer",
                 "still.gpu_upload",
@@ -1611,7 +1679,7 @@ class GLImageViewer(QRhiWidget):
             )
         elif self._pending_warm_surfaces:
             warm = self._pending_warm_surfaces.pop(0)
-            if self._texture_manager.warm_still_texture(warm.decode_key, warm.image):
+            if self._warm_still_with_tracking(warm):
                 emit_detail_event(
                     "gpu_upload",
                     generation=self._still_generation_by_key.get(warm.decode_key, 0),
@@ -1701,6 +1769,9 @@ class GLImageViewer(QRhiWidget):
         if not callable(take_result):
             return False
         result = take_result()
+        if result is not None:
+            self._release_upload_staging(result.get("key"))
+            self._sync_gpu_residency()
         failed = bool(
             result is not None
             and result.get("activate")
@@ -1716,6 +1787,84 @@ class GLImageViewer(QRhiWidget):
             str(result.get("reason", "allocation_failed")),
         )
         return True
+
+    def _upload_current_still_with_tracking(self) -> None:
+        key = self.current_image_source()
+        image = self._image
+        if image is None:
+            return
+        self._observe_upload_staging(key, image)
+        try:
+            self._texture_manager.upload_texture_if_needed(image)
+        except Exception:
+            self._release_upload_staging(key)
+            raise
+
+    def _warm_still_with_tracking(self, surface: DecodedSurface) -> bool:
+        queued = self._texture_manager.warm_still_texture(
+            surface.decode_key,
+            surface.image,
+        )
+        if queued:
+            self._observe_upload_staging(surface.decode_key, surface.image)
+        return queued
+
+    def _observe_upload_staging(self, key: object, image: QImage) -> None:
+        tracker = self._surface_residency_tracker
+        if tracker is None or key is None or image.isNull():
+            return
+        previous = self._tracked_staging_resources.pop(key, None)
+        if previous is not None:
+            tracker.release("detail-upload-staging", previous)
+        resource_id = ("upload-staging", key, int(image.cacheKey()))
+        self._tracked_staging_resources[key] = resource_id
+        tracker.retain(
+            "detail-upload-staging",
+            "upload_queue",
+            resource_id,
+            SurfaceByteBreakdown(
+                upload_staging=max(
+                    0,
+                    int(image.bytesPerLine()) * int(image.height()),
+                )
+            ),
+            generation=self._still_generation_by_key.get(key, 0),
+        )
+
+    def _release_upload_staging(self, key: object) -> None:
+        tracker = self._surface_residency_tracker
+        resource_id = self._tracked_staging_resources.pop(key, None)
+        if tracker is not None and resource_id is not None:
+            tracker.release(
+                "detail-upload-staging",
+                resource_id,
+                generation=self._still_generation_by_key.get(key, 0),
+            )
+
+    def _sync_gpu_residency(self) -> None:
+        tracker = self._surface_residency_tracker
+        if tracker is None:
+            return
+        getter = getattr(self._renderer, "still_residency_bytes", None)
+        current = dict(getter()) if callable(getter) else {}
+        for key in tuple(self._tracked_gpu_resources):
+            if key in current:
+                continue
+            tracker.release(
+                "detail-gpu-residency",
+                self._tracked_gpu_resources.pop(key),
+                generation=self._still_generation_by_key.get(key, 0),
+            )
+        for key, byte_count in current.items():
+            resource_id = ("gpu-still", key)
+            self._tracked_gpu_resources[key] = resource_id
+            tracker.retain(
+                "detail-gpu-residency",
+                "gpu_residency",
+                resource_id,
+                SurfaceByteBreakdown(gpu_estimated=max(0, int(byte_count))),
+                generation=self._still_generation_by_key.get(key, 0),
+            )
 
     def _emit_first_frame_ready(self) -> None:
         """Notify listeners that the first opaque frame has been rendered."""

--- a/src/iPhoto/gui/ui/widgets/gl_renderer.py
+++ b/src/iPhoto/gui/ui/widgets/gl_renderer.py
@@ -164,6 +164,11 @@ class GLRenderer:
     def has_still_texture(self, key: object) -> bool:
         return self._tex_mgr.has_still_texture(key)
 
+    def still_residency_bytes(self) -> dict[object, int]:
+        """Return diagnostic estimated bytes for resident still textures."""
+
+        return self._tex_mgr.still_residency_bytes()
+
     def texture_uses_mipmaps(self) -> bool:
         return self._tex_mgr.texture_uses_mipmaps()
 

--- a/src/iPhoto/gui/ui/widgets/gl_texture_manager.py
+++ b/src/iPhoto/gui/ui/widgets/gl_texture_manager.py
@@ -455,6 +455,11 @@ class TextureManager:
     def has_still_texture(self, key: object) -> bool:
         return key in self._still_textures
 
+    def still_residency_bytes(self) -> dict[object, int]:
+        """Return diagnostic estimated bytes for resident still textures."""
+
+        return {key: int(entry[3]) for key, entry in self._still_textures.items()}
+
     def texture_uses_mipmaps(self) -> bool:
         return self._texture_uses_mipmaps
 

--- a/src/iPhoto/gui/ui/widgets/rhi_image_renderer.py
+++ b/src/iPhoto/gui/ui/widgets/rhi_image_renderer.py
@@ -407,6 +407,11 @@ class RhiImageRenderer:
     def has_still_texture(self, key: object) -> bool:
         return key in self._still_textures
 
+    def still_residency_bytes(self) -> dict[object, int]:
+        """Return diagnostic estimated bytes for resident still textures."""
+
+        return {key: int(entry[1]) for key, entry in self._still_textures.items()}
+
     def clear_still_residency(self) -> None:
         for texture, _size in self._still_textures.values():
             try:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -350,7 +350,7 @@ def test_unbound_store_is_a_disabled_disk_tier(tmp_path: Path) -> None:
     assert store.write(request, _surface(request)) is False
 
 
-def test_backend_bind_library_schedules_keyword_recovery(tmp_path: Path) -> None:
+def test_backend_bind_library_schedules_normal_maintenance(tmp_path: Path) -> None:
     store = Mock()
     backend = CachedStillDecodeBackend(Mock(), store=store)
 
@@ -358,7 +358,25 @@ def test_backend_bind_library_schedules_keyword_recovery(tmp_path: Path) -> None
     backend.shutdown()
 
     store.bind_library.assert_called_once_with(tmp_path)
-    store.maintenance.assert_called_once_with(recover=True)
+    store.maintenance.assert_called_once_with()
+
+
+def test_clean_library_bind_does_not_traverse_payload_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    populated = NeutralSurfaceStore(tmp_path)
+    assert populated.write(request, _surface(request))
+    populated.close()
+    backend = CachedStillDecodeBackend(Mock(), store=NeutralSurfaceStore(None))
+
+    def fail_glob(_self: Path, _pattern: str):
+        raise AssertionError("clean library bind must not scan cache payloads")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    backend.bind_library(tmp_path)
+    backend.shutdown()
 
 
 def test_bind_library_without_prior_surface_cache_initializes_v3(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -667,6 +667,8 @@ def test_canonical_cache_identity_shares_lock_across_path_aliases(
     assert first_index.lock_path == second_index.lock_path
     assert first_index.ensure_open()
     assert second_index.ensure_open()
+    alias_request = _request(alias / "photo.jpg")
+    assert second.write(alias_request, _surface(alias_request))
     first.close()
 
     metadata = _index_metadata(first_index.root)

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -702,7 +702,8 @@ def test_closed_store_and_index_cannot_reopen(tmp_path: Path) -> None:
     store = NeutralSurfaceStore(tmp_path)
     assert store.write(request, _surface(request))
     index = store._index_for_root()
-    assert index is not None
+    root = store.root
+    assert index is not None and root is not None
 
     store.close()
 
@@ -711,6 +712,11 @@ def test_closed_store_and_index_cannot_reopen(tmp_path: Path) -> None:
     assert not index.ensure_open()
     assert store.load(request) is None
     assert not store.write(request, _surface(request))
+    with pytest.raises(RuntimeError, match="create a new store generation"):
+        store.bind_library(tmp_path / "other")
+    assert store.closed
+    assert store.root == root
+    assert index.closed
 
 
 def test_clean_library_bind_does_not_traverse_payload_directory(

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import os
 import shutil
 import sqlite3
+import subprocess
+import sys
+import textwrap
+import time
 from dataclasses import replace
 from pathlib import Path
 from threading import Event, Thread
 from unittest.mock import Mock, patch
 
 import pytest
+from PySide6.QtCore import QLockFile
 from PySide6.QtGui import QImage
 
 import iPhoto.gui.detail_surface_cache as surface_cache_module
@@ -68,6 +73,67 @@ def _index_metadata(root: Path) -> dict[str, int]:
         }
     finally:
         connection.close()
+
+
+_HOLD_INDEX_SCRIPT = textwrap.dedent(
+    """
+    import sys
+    import time
+    from pathlib import Path
+
+    from iPhoto.gui.detail_surface_cache_index import SurfaceCacheIndex
+
+    index = SurfaceCacheIndex(Path(sys.argv[1]))
+    if not index.ensure_open():
+        raise SystemExit(2)
+    Path(sys.argv[2]).write_text("ready", encoding="utf-8")
+    release = Path(sys.argv[3])
+    while not release.exists():
+        time.sleep(0.01)
+    index.close()
+    """
+)
+
+
+def _start_index_holder(
+    root: Path,
+    ready: Path,
+    release: Path,
+) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    project_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = str(project_root / "src")
+    child = subprocess.Popen(
+        [sys.executable, "-c", _HOLD_INDEX_SCRIPT, str(root), str(ready), str(release)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 10.0
+    while not ready.exists() and time.monotonic() < deadline:
+        if child.poll() is not None:
+            stdout, stderr = child.communicate()
+            pytest.fail(
+                f"surface index holder exited early ({child.returncode}): {stdout}\n{stderr}"
+            )
+        time.sleep(0.01)
+    if not ready.exists():
+        child.kill()
+        stdout, stderr = child.communicate()
+        pytest.fail(f"surface index holder did not become ready: {stdout}\n{stderr}")
+    return child
+
+
+def _release_index_holder(child: subprocess.Popen[str], release: Path) -> None:
+    release.write_text("release", encoding="utf-8")
+    try:
+        stdout, stderr = child.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        stdout, stderr = child.communicate()
+        pytest.fail(f"surface index holder did not close: {stdout}\n{stderr}")
+    assert child.returncode == 0, (stdout, stderr)
 
 
 def _request(source: Path, *, revision: int = 11, level: int = 1024) -> DetailRenderRequest:
@@ -366,6 +432,271 @@ def test_new_process_session_recovers_stale_active_lease(
     assert metadata["active_leases"] == 1
     assert metadata["recovery_required"] == 1
     recovered.close(clean=False)
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    (
+        (QLockFile.LockError.LockFailedError, "owned_by_other_process"),
+        (QLockFile.LockError.PermissionError, "lock_permission_error"),
+        (QLockFile.LockError.UnknownError, "lock_io_error"),
+    ),
+)
+def test_namespace_lock_failure_is_throttled_without_opening_sqlite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: QLockFile.LockError,
+    reason: str,
+) -> None:
+    lock_file = Mock()
+    lock_file.tryLock.return_value = False
+    lock_file.error.return_value = error
+    factory = Mock(return_value=lock_file)
+    monkeypatch.setattr(
+        surface_cache_index_module,
+        "_NAMESPACE_LOCK_FILE_FACTORY",
+        factory,
+    )
+    index = SurfaceCacheIndex(tmp_path / "cache")
+
+    assert not index.ensure_open()
+    assert not index.ensure_open()
+    assert index.open_unavailable_reason == reason
+    assert not index.path.exists()
+    assert not index.needs_recovery
+    factory.assert_called_once_with(str(index.lock_path))
+    lock_file.setStaleLockTime.assert_called_once_with(0)
+    lock_file.tryLock.assert_called_once_with(0)
+
+    index.close()
+    lock_file.unlock.assert_not_called()
+
+
+def test_store_emits_one_namespace_lock_diagnostic_per_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock_file = Mock()
+    lock_file.tryLock.return_value = False
+    lock_file.error.return_value = QLockFile.LockError.LockFailedError
+    monkeypatch.setattr(
+        surface_cache_index_module,
+        "_NAMESPACE_LOCK_FILE_FACTORY",
+        Mock(return_value=lock_file),
+    )
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        surface_cache_module,
+        "emit_detail_event",
+        lambda stage, **details: events.append((stage, details)),
+    )
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+
+    assert store.load(request) is None
+    assert store.load(request) is None
+    assert not store.write(request, _surface(request))
+    store.maintenance(force_prune=True)
+    store.close()
+
+    assert events == [
+        (
+            "surface_cache_disk_unavailable",
+            {"generation": 0, "reason": "owned_by_other_process"},
+        )
+    ]
+
+
+def test_secondary_process_cache_fails_open_without_changing_owner_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    library = tmp_path / "library"
+    request = _request(library / "photo.jpg")
+    populated = NeutralSurfaceStore(library)
+    assert populated.write(request, _surface(request))
+    payload = populated.entry_path(request)
+    index_root = populated.root
+    assert payload is not None and index_root is not None
+    original_payload_mtime_ns = payload.stat().st_mtime_ns
+    populated.close()
+    ready = tmp_path / "holder-ready"
+    release = tmp_path / "holder-release"
+    child = _start_index_holder(index_root, ready, release)
+    original_glob = Path.glob
+
+    def fail_payload_scan(path: Path, pattern: str):
+        if path == index_root:
+            raise AssertionError("secondary process must not scan cache payloads")
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "glob", fail_payload_scan)
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    contender = NeutralSurfaceStore(library)
+    backend = CachedStillDecodeBackend(delegate, store=contender)
+    try:
+        decoded = backend.decode(request, _Token())
+        backend.store.maintenance(force_prune=True)
+        backend.shutdown(timeout_ms=5000)
+
+        assert decoded is not None
+        delegate.decode.assert_called_once()
+        assert payload.exists()
+        assert payload.stat().st_mtime_ns == original_payload_mtime_ns
+        metadata = _index_metadata(index_root)
+        assert metadata["clean_shutdown"] == 0
+        assert metadata["active_leases"] == 1
+        assert metadata["recovery_required"] == 0
+    finally:
+        if not backend.store.closed:
+            backend.shutdown(timeout_ms=5000)
+        _release_index_holder(child, release)
+
+
+def test_secondary_process_retries_after_clean_owner_close_without_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    library = tmp_path / "library"
+    request = _request(library / "photo.jpg")
+    populated = NeutralSurfaceStore(library)
+    assert populated.write(request, _surface(request))
+    index_root = populated.root
+    assert index_root is not None
+    populated.close()
+    ready = tmp_path / "holder-ready"
+    release = tmp_path / "holder-release"
+    child = _start_index_holder(index_root, ready, release)
+    contender = NeutralSurfaceStore(library)
+    contender_index = contender._index_for_root()
+    assert contender_index is not None
+    monotonic_ns = [1]
+    monkeypatch.setattr(
+        surface_cache_index_module.time,
+        "monotonic_ns",
+        lambda: monotonic_ns[0],
+    )
+
+    try:
+        assert contender.load(request) is None
+        assert contender_index.open_unavailable_reason == "owned_by_other_process"
+        _release_index_holder(child, release)
+        monotonic_ns[0] += surface_cache_index_module._NAMESPACE_LOCK_RETRY_NS
+        original_glob = Path.glob
+
+        def fail_payload_scan(path: Path, pattern: str):
+            if path == index_root:
+                raise AssertionError("clean owner handoff must not scan cache payloads")
+            return original_glob(path, pattern)
+
+        monkeypatch.setattr(Path, "glob", fail_payload_scan)
+        loaded = contender.load(request)
+
+        assert loaded is not None
+        assert loaded.cache_tier == "disk"
+        assert contender_index.open_unavailable_reason is None
+        assert not contender_index.needs_recovery
+    finally:
+        if child.poll() is None:
+            _release_index_holder(child, release)
+        contender.close()
+
+    metadata = _index_metadata(index_root)
+    assert metadata["clean_shutdown"] == 1
+    assert metadata["active_leases"] == 0
+    assert metadata["recovery_required"] == 0
+
+
+def test_crashed_namespace_owner_triggers_recovery_before_disk_hit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    library = tmp_path / "library"
+    request = _request(library / "photo.jpg")
+    populated = NeutralSurfaceStore(library)
+    assert populated.write(request, _surface(request))
+    index_root = populated.root
+    assert index_root is not None
+    populated.close()
+    ready = tmp_path / "holder-ready"
+    release = tmp_path / "holder-release"
+    child = _start_index_holder(index_root, ready, release)
+    child.kill()
+    child.communicate(timeout=10)
+    scanned: list[str] = []
+    original_glob = Path.glob
+
+    def count_payload_scan(path: Path, pattern: str):
+        if path == index_root:
+            scanned.append(pattern)
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "glob", count_payload_scan)
+    recovered = NeutralSurfaceStore(library)
+
+    loaded = recovered.load(request)
+
+    assert loaded is not None
+    assert loaded.cache_tier == "disk"
+    assert scanned == ["*/*.tmp", "*/*.ipsurface"]
+    recovered.close()
+    metadata = _index_metadata(index_root)
+    assert metadata["clean_shutdown"] == 1
+    assert metadata["active_leases"] == 0
+    assert metadata["recovery_required"] == 0
+
+
+def test_canonical_cache_identity_shares_lock_across_path_aliases(
+    tmp_path: Path,
+) -> None:
+    library = tmp_path / "library"
+    library.mkdir()
+    alias = tmp_path / "library-alias"
+    try:
+        alias.symlink_to(library, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    first = NeutralSurfaceStore(library)
+    second = NeutralSurfaceStore(alias)
+    first_index = first._index_for_root()
+    second_index = second._index_for_root()
+    assert first_index is not None and second_index is not None
+
+    assert first.root == second.root
+    assert first_index.lock_path == second_index.lock_path
+    assert first_index.ensure_open()
+    assert second_index.ensure_open()
+    first.close()
+
+    metadata = _index_metadata(first_index.root)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["active_leases"] == 1
+
+    second.close()
+    metadata = _index_metadata(first_index.root)
+    assert metadata["clean_shutdown"] == 1
+    assert metadata["active_leases"] == 0
+
+
+def test_runtime_database_failure_keeps_namespace_lock_until_close(
+    tmp_path: Path,
+) -> None:
+    index = SurfaceCacheIndex(tmp_path)
+    _fail_index_execute(index, lambda sql: "FROM entries" in sql)
+
+    with pytest.raises(
+        surface_cache_index_module.SurfaceCacheIndexUnavailableError,
+    ):
+        index.get("missing")
+
+    assert index._namespace_lock_acquired
+    assert index.lock_path.exists()
+    assert index._namespace_lock_key in surface_cache_index_module._ACTIVE_NAMESPACE_LOCKS
+
+    index.close(clean=False)
+    assert not index._namespace_lock_acquired
+    assert index._namespace_lock_key not in surface_cache_index_module._ACTIVE_NAMESPACE_LOCKS
 
 
 def test_missing_payload_removes_stale_metadata_row(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -172,6 +172,43 @@ def test_writes_below_maintenance_watermark_do_not_traverse_payload_directory(
     assert store.write(request, _surface(request))
 
 
+def test_disk_usage_failure_does_not_prune_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    disk_usage = Mock(side_effect=OSError("volume unavailable"))
+    monkeypatch.setattr(shutil, "disk_usage", disk_usage)
+
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    finish_maintenance = Mock(wraps=index.finish_maintenance)
+    monkeypatch.setattr(index, "finish_maintenance", finish_maintenance)
+
+    store.maintenance(force_prune=True)
+
+    assert disk_usage.call_count >= 2
+    assert path.exists()
+    assert index.get(surface_cache_module._key_digest(request)) is not None
+    finish_maintenance.assert_not_called()
+
+
+def test_explicit_zero_budget_prunes_all_indexed_payloads(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=0)
+
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+
+    assert not path.exists()
+    assert index.get(surface_cache_module._key_digest(request)) is None
+
+
 def test_indexed_prune_uses_lru_and_low_watermark(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shutil
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -101,6 +103,155 @@ def test_disk_store_round_trip_returns_mmap_backed_rgba_surface(tmp_path: Path) 
     assert loaded.decoded_size == original.decoded_size
     assert loaded.color_stats == original.color_stats
     assert bytes(loaded.image.constBits()[:4]) == bytes(original.image.constBits()[:4])
+
+
+def test_disk_store_uses_v3_sqlite_index(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+
+    assert store.write(request, _surface(request))
+    assert store.root is not None
+    assert store.root.name == "v3"
+    assert (store.root / "index.sqlite3").is_file()
+
+
+def test_trusted_disk_hit_does_not_scan_payload_checksum(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+
+    def fail_checksum(_payload) -> int:
+        raise AssertionError("trusted cache hit must not hash the payload")
+
+    monkeypatch.setattr(surface_cache_module, "_checksum", fail_checksum)
+    assert store.load(request) is not None
+
+
+def test_sampled_audit_discards_same_size_corruption_with_restored_mtime(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    assert path is not None
+    stat = path.stat()
+    with path.open("r+b") as stream:
+        stream.seek(-1, os.SEEK_END)
+        original = stream.read(1)
+        stream.seek(-1, os.SEEK_END)
+        stream.write(bytes([original[0] ^ 0xFF]))
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    store._disk_hit_count = surface_cache_module._ACCESS_AUDIT_INTERVAL - 1
+
+    assert store.load(request) is not None
+    assert path.exists()
+
+    store.run_pending_audits()
+    assert not path.exists()
+    assert store.load(request) is None
+
+
+def test_writes_below_maintenance_watermark_do_not_traverse_payload_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=64 * 1024 * 1024)
+    request = _request(tmp_path / "photo.jpg")
+
+    def fail_glob(_self: Path, _pattern: str):
+        raise AssertionError("ordinary writes must not traverse the payload directory")
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    assert store.write(request, _surface(request))
+
+
+def test_indexed_prune_uses_lru_and_low_watermark(tmp_path: Path) -> None:
+    first = _request(tmp_path / "first.jpg", revision=1)
+    second = _request(tmp_path / "second.jpg", revision=2)
+    third = _request(tmp_path / "third.jpg", revision=3)
+    probe = NeutralSurfaceStore(tmp_path, budget_bytes=1 << 30)
+    assert probe.write(first, _surface(first))
+    first_path = probe.entry_path(first)
+    assert first_path is not None
+    file_bytes = first_path.stat().st_size
+    probe.close()
+    shutil.rmtree(tmp_path / ".iPhoto")
+
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=1 << 30)
+    assert store.write(first, _surface(first))
+    assert store.write(second, _surface(second))
+    assert store.write(third, _surface(third))
+    assert store.load(first) is not None
+    store._budget_override = file_bytes * 2 + 64
+    store.prune()
+
+    assert store.entry_path(first).exists()  # type: ignore[union-attr]
+    assert not store.entry_path(second).exists()  # type: ignore[union-attr]
+    assert not store.entry_path(third).exists()  # type: ignore[union-attr]
+
+
+def test_dirty_recovery_indexes_orphan_payload_and_removes_temp(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    index.remove(surface_cache_module._key_digest(request))
+    temporary = path.parent / ".orphan.ipsurface.crash.tmp"
+    temporary.write_bytes(b"partial")
+
+    recovered = NeutralSurfaceStore(tmp_path)
+    loaded = recovered.load(request)
+
+    assert loaded is not None
+    assert loaded.cache_tier == "disk"
+    assert not temporary.exists()
+
+
+def test_missing_payload_removes_stale_metadata_row(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    path.unlink()
+
+    assert store.load(request) is None
+    assert index.get(surface_cache_module._key_digest(request)) is None
+
+
+def test_corrupt_sqlite_index_is_rebuilt_from_untrusted_payload(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    root = store.root
+    assert root is not None
+    store.close()
+    (root / "index.sqlite3").write_bytes(b"not a sqlite database")
+
+    recovered = NeutralSurfaceStore(tmp_path)
+    loaded = recovered.load(request)
+
+    assert loaded is not None
+    assert loaded.decoded_size == (8, 4)
+    assert tuple(root.glob("index.sqlite3.corrupt-*"))
+
+
+def test_first_v3_write_removes_rebuildable_v2_namespace(tmp_path: Path) -> None:
+    legacy = tmp_path / ".iPhoto" / "cache" / "detail-surfaces" / "v2"
+    legacy.mkdir(parents=True)
+    (legacy / "stale.cache").write_bytes(b"rebuildable")
+    request = _request(tmp_path / "photo.jpg")
+
+    assert NeutralSurfaceStore(tmp_path).write(request, _surface(request))
+
+    assert not legacy.exists()
 
 
 def test_disk_store_source_revision_changes_key_but_sidecar_is_not_an_input(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -649,6 +649,54 @@ def test_rebind_rejects_old_decode_without_repopulating_memory_cache(
     new_store.close.assert_called_once_with()
 
 
+def test_rebind_retires_generation_before_shared_memory_cache_clear(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    request = _request(old_root / "photo.jpg")
+    old_store = Mock()
+    old_store.library_root = old_root.absolute()
+    old_store.load.return_value = _surface(request)
+    new_store = Mock()
+    new_store.library_root = new_root.absolute()
+    memory_cache = MappedSurfaceCache()
+    backend = CachedStillDecodeBackend(
+        Mock(),
+        memory_cache=memory_cache,
+        store=old_store,
+        store_factory=Mock(return_value=new_store),
+    )
+    old_generation = backend._active_store_generation
+    original_clear = memory_cache.clear
+    interleaved_result: list[str] = []
+    armed = True
+
+    def clear_with_old_decode_completion() -> None:
+        nonlocal armed
+        original_clear()
+        if not armed:
+            return
+        armed = False
+        try:
+            backend._decode_for_generation(request, _Token(), old_generation)
+        except DecodeCancelledError:
+            interleaved_result.append("stale")
+        else:
+            interleaved_result.append("accepted")
+
+    monkeypatch.setattr(memory_cache, "clear", clear_with_old_decode_completion)
+
+    backend.bind_library(new_root)
+
+    assert interleaved_result == ["stale"]
+    assert backend.memory_cache.used_bytes == 0
+    backend.shutdown(timeout_ms=5000)
+    old_store.close.assert_called_once_with()
+    new_store.close.assert_called_once_with()
+
+
 def test_closed_store_and_index_cannot_reopen(tmp_path: Path) -> None:
     request = _request(tmp_path / "photo.jpg")
     store = NeutralSurfaceStore(tmp_path)

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -10,6 +10,7 @@ import pytest
 from PySide6.QtGui import QImage
 
 import iPhoto.gui.detail_surface_cache as surface_cache_module
+import iPhoto.gui.detail_surface_cache_index as surface_cache_index_module
 from iPhoto.core.color_resolver import ColorStats
 from iPhoto.gui.detail_decode_backend import DecodedSurface
 from iPhoto.gui.detail_pipeline import (
@@ -169,7 +170,13 @@ def test_writes_below_maintenance_watermark_do_not_traverse_payload_directory(
     assert store.write(request, _surface(request))
 
 
-def test_indexed_prune_uses_lru_and_low_watermark(tmp_path: Path) -> None:
+def test_indexed_prune_uses_lru_and_low_watermark(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Windows can return the same time_ns() value for adjacent writes. Access
+    # updates must still become strictly newer than the persisted row.
+    monkeypatch.setattr(surface_cache_index_module.time, "time_ns", lambda: 100)
     first = _request(tmp_path / "first.jpg", revision=1)
     second = _request(tmp_path / "second.jpg", revision=2)
     third = _request(tmp_path / "third.jpg", revision=3)

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sqlite3
 from dataclasses import replace
 from pathlib import Path
 from threading import Event, Thread
@@ -33,6 +34,27 @@ from iPhoto.gui.detail_surface_cache_index import SurfaceCacheIndex
 class _Token:
     def is_cancelled(self) -> bool:
         return False
+
+
+class _FailingConnection:
+    def __init__(self, connection: sqlite3.Connection, fail_when) -> None:
+        self._connection = connection
+        self._fail_when = fail_when
+
+    def execute(self, sql: str, parameters=()):
+        if self._fail_when(str(sql)):
+            raise sqlite3.DatabaseError("injected runtime index failure")
+        return self._connection.execute(sql, parameters)
+
+    def __getattr__(self, name: str):
+        return getattr(self._connection, name)
+
+
+def _fail_index_execute(index: SurfaceCacheIndex, fail_when) -> None:
+    assert index.ensure_open()
+    connection = index._connection
+    assert connection is not None
+    index._connection = _FailingConnection(connection, fail_when)  # type: ignore[assignment]
 
 
 def _request(source: Path, *, revision: int = 11, level: int = 1024) -> DetailRenderRequest:
@@ -308,6 +330,80 @@ def test_failed_write_cleanup_marks_recovery_when_row_cannot_be_removed(
     assert index.needs_recovery
 
 
+def test_sqlite_lookup_failure_falls_back_to_delegate_decode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    _fail_index_execute(
+        index,
+        lambda sql: "FROM entries" in sql and "WHERE digest" in sql,
+    )
+    write = Mock(return_value=False)
+    monkeypatch.setattr(store, "write", write)
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    backend = CachedStillDecodeBackend(delegate, store=store)
+
+    decoded = backend.decode(request, _Token())
+
+    assert decoded.backend == "qt"
+    delegate.decode.assert_called_once()
+    assert path.exists()
+    assert index.needs_recovery
+    assert index._connection is None
+    backend.shutdown(timeout_ms=5000)
+
+    reopened = SurfaceCacheIndex(index.root)
+    assert reopened.ensure_open()
+    assert reopened.needs_recovery
+    reopened.close(clean=False)
+
+
+def test_sqlite_checksum_state_failure_does_not_discard_valid_payload(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    digest = surface_cache_module._key_digest(request)
+    index.mark_checksum_state(digest, "untrusted")
+    _fail_index_execute(
+        index,
+        lambda sql: "UPDATE entries" in sql and "checksum_state" in sql,
+    )
+
+    assert store.load(request) is None
+
+    assert path.exists()
+    assert index.needs_recovery
+    assert index._connection is None
+
+
+def test_sqlite_upsert_failure_after_replace_removes_orphan_payload(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    _fail_index_execute(index, lambda sql: "INSERT INTO entries" in sql)
+
+    assert not store.write(request, _surface(request))
+
+    assert not path.exists()
+    assert index.needs_recovery
+
+
 def test_recovery_required_index_does_not_close_clean(tmp_path: Path) -> None:
     index = SurfaceCacheIndex(tmp_path)
     assert index.ensure_open()
@@ -387,6 +483,61 @@ def test_prune_unlink_failure_keeps_row_and_marks_recovery(
     assert path.exists()
     assert index.get(surface_cache_module._key_digest(request)) is not None
     assert index.needs_recovery
+
+
+def test_sqlite_failure_during_maintenance_never_prunes_payloads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=1 << 30)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    finish_maintenance = Mock(wraps=index.finish_maintenance)
+    monkeypatch.setattr(index, "finish_maintenance", finish_maintenance)
+    store._budget_override = 0
+    _fail_index_execute(index, lambda sql: "ORDER BY last_access_ns" in sql)
+
+    store.maintenance(force_prune=True)
+
+    assert path.exists()
+    assert index.needs_recovery
+    assert index._connection is None
+    finish_maintenance.assert_not_called()
+
+
+def test_sqlite_failure_during_recovery_retries_from_payload_scan(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=1 << 30)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    index.mark_recovery_required()
+    _fail_index_execute(
+        index,
+        lambda sql: "FROM entries" in sql
+        and "WHERE digest" not in sql
+        and "ORDER BY" not in sql,
+    )
+
+    store.maintenance(recover=True)
+
+    assert path.exists()
+    assert index.needs_recovery
+    assert index._connection is None
+
+    store.maintenance(recover=True)
+
+    assert not index.needs_recovery
+    loaded = store.load(request)
+    assert loaded is not None
+    assert loaded.cache_tier == "disk"
+    assert tuple(index.root.glob("index.sqlite3.corrupt-*"))
 
 
 def test_first_v3_write_removes_rebuildable_v2_namespace(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from dataclasses import replace
 from pathlib import Path
+from threading import Event, Thread
 from unittest.mock import Mock, patch
 
 import pytest
@@ -12,7 +13,7 @@ from PySide6.QtGui import QImage
 import iPhoto.gui.detail_surface_cache as surface_cache_module
 import iPhoto.gui.detail_surface_cache_index as surface_cache_index_module
 from iPhoto.core.color_resolver import ColorStats
-from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_decode_backend import DecodeCancelledError, DecodedSurface
 from iPhoto.gui.detail_pipeline import (
     AssetSourceIdentity,
     DetailDecodeKey,
@@ -318,7 +319,7 @@ def test_live_photo_decoder_contract_rejects_legacy_wrong_orientation_surface(
     assert decoded.decoded_size == (4, 8)
     assert current_path.exists()
 
-    reloaded = store.load(request)
+    reloaded = NeutralSurfaceStore(tmp_path).load(request)
     assert reloaded is not None
     assert reloaded.cache_tier == "disk"
     assert reloaded.decoded_size == (4, 8)
@@ -352,13 +353,178 @@ def test_unbound_store_is_a_disabled_disk_tier(tmp_path: Path) -> None:
 
 def test_backend_bind_library_schedules_normal_maintenance(tmp_path: Path) -> None:
     store = Mock()
+    store.library_root = tmp_path.absolute()
     backend = CachedStillDecodeBackend(Mock(), store=store)
 
     backend.bind_library(tmp_path)
     backend.shutdown()
 
-    store.bind_library.assert_called_once_with(tmp_path)
     store.maintenance.assert_called_once_with()
+    store.close.assert_called_once_with()
+
+
+def test_cross_library_bind_uses_a_new_store_generation(tmp_path: Path) -> None:
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    old_store = Mock()
+    old_store.library_root = old_root.absolute()
+    new_store = Mock()
+    new_store.library_root = new_root.absolute()
+    factory = Mock(return_value=new_store)
+    backend = CachedStillDecodeBackend(
+        Mock(),
+        store=old_store,
+        store_factory=factory,
+    )
+
+    backend.bind_library(new_root)
+    backend.shutdown()
+
+    factory.assert_called_once_with(new_root.absolute())
+    old_store.bind_library.assert_not_called()
+    old_store.close.assert_called_once_with()
+    new_store.maintenance.assert_called_once_with()
+    new_store.close.assert_called_once_with()
+
+
+def test_rebind_returns_before_old_store_io_drains(tmp_path: Path) -> None:
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    started = Event()
+    release = Event()
+    old_closed = Event()
+    old_store = Mock()
+    old_store.library_root = old_root.absolute()
+    old_store.close.side_effect = old_closed.set
+    new_store = Mock()
+    new_store.library_root = new_root.absolute()
+    backend = CachedStillDecodeBackend(
+        Mock(),
+        store=old_store,
+        store_factory=Mock(return_value=new_store),
+    )
+    generation = backend._active_store_generation
+
+    def slow_io() -> None:
+        started.set()
+        assert release.wait(5)
+
+    backend._submit_for_generation(generation, slow_io)
+    assert started.wait(5)
+
+    backend.bind_library(new_root)
+
+    assert not old_closed.is_set()
+    release.set()
+    backend.shutdown(timeout_ms=5000)
+    assert old_closed.is_set()
+
+
+def test_shutdown_timeout_closes_store_after_active_decode_finishes(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    started = Event()
+    release = Event()
+    closed = Event()
+    store = Mock()
+    store.library_root = tmp_path.absolute()
+
+    def slow_load(_request: DetailRenderRequest) -> None:
+        started.set()
+        assert release.wait(5)
+        return None
+
+    store.load.side_effect = slow_load
+    store.close.side_effect = closed.set
+    delegate = Mock()
+    delegate.decode.side_effect = lambda prepared, _token: _surface(prepared)
+    backend = CachedStillDecodeBackend(delegate, store=store)
+    failures: list[BaseException] = []
+
+    def decode() -> None:
+        try:
+            backend.decode(request, _Token())
+        except DecodeCancelledError as exc:
+            failures.append(exc)
+
+    worker = Thread(target=decode)
+    worker.start()
+    assert started.wait(5)
+
+    backend.shutdown(timeout_ms=1)
+
+    assert not closed.is_set()
+    release.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert closed.wait(5)
+    assert len(failures) == 1
+    assert isinstance(failures[0], DecodeCancelledError)
+
+
+def test_rebind_rejects_old_decode_without_repopulating_memory_cache(
+    tmp_path: Path,
+) -> None:
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    request = _request(old_root / "photo.jpg")
+    started = Event()
+    release = Event()
+    old_store = Mock()
+    old_store.library_root = old_root.absolute()
+
+    def slow_load(_request: DetailRenderRequest) -> DecodedSurface:
+        started.set()
+        assert release.wait(5)
+        return _surface(request)
+
+    old_store.load.side_effect = slow_load
+    new_store = Mock()
+    new_store.library_root = new_root.absolute()
+    backend = CachedStillDecodeBackend(
+        Mock(),
+        store=old_store,
+        store_factory=Mock(return_value=new_store),
+    )
+    failures: list[BaseException] = []
+
+    def decode() -> None:
+        try:
+            backend.decode(request, _Token())
+        except DecodeCancelledError as exc:
+            failures.append(exc)
+
+    worker = Thread(target=decode)
+    worker.start()
+    assert started.wait(5)
+    backend.bind_library(new_root)
+    release.set()
+    worker.join(timeout=5)
+    backend.shutdown(timeout_ms=5000)
+
+    assert not worker.is_alive()
+    assert len(failures) == 1
+    assert isinstance(failures[0], DecodeCancelledError)
+    assert backend.memory_cache.used_bytes == 0
+    old_store.close.assert_called_once_with()
+    new_store.close.assert_called_once_with()
+
+
+def test_closed_store_and_index_cannot_reopen(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    index = store._index_for_root()
+    assert index is not None
+
+    store.close()
+
+    assert store.closed
+    assert index.closed
+    assert not index.ensure_open()
+    assert store.load(request) is None
+    assert not store.write(request, _surface(request))
 
 
 def test_clean_library_bind_does_not_traverse_payload_directory(

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -350,6 +350,33 @@ def test_unbound_store_is_a_disabled_disk_tier(tmp_path: Path) -> None:
     assert store.write(request, _surface(request)) is False
 
 
+def test_backend_bind_library_schedules_keyword_recovery(tmp_path: Path) -> None:
+    store = Mock()
+    backend = CachedStillDecodeBackend(Mock(), store=store)
+
+    backend.bind_library(tmp_path)
+    backend.shutdown()
+
+    store.bind_library.assert_called_once_with(tmp_path)
+    store.maintenance.assert_called_once_with(recover=True)
+
+
+def test_bind_library_without_prior_surface_cache_initializes_v3(tmp_path: Path) -> None:
+    backend = CachedStillDecodeBackend(Mock(), store=NeutralSurfaceStore(None))
+
+    backend.bind_library(tmp_path)
+    backend.shutdown()
+
+    assert (
+        tmp_path
+        / ".iPhoto"
+        / "cache"
+        / "detail-surfaces"
+        / "v3"
+        / "index.sqlite3"
+    ).is_file()
+
+
 def test_unstable_identity_bypasses_reusable_memory_and_disk_cache(
     tmp_path: Path,
 ) -> None:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -57,6 +57,19 @@ def _fail_index_execute(index: SurfaceCacheIndex, fail_when) -> None:
     index._connection = _FailingConnection(connection, fail_when)  # type: ignore[assignment]
 
 
+def _index_metadata(root: Path) -> dict[str, int]:
+    connection = sqlite3.connect(root / "index.sqlite3")
+    try:
+        return {
+            str(key): int(value)
+            for key, value in connection.execute(
+                "SELECT key, value FROM metadata"
+            ).fetchall()
+        }
+    finally:
+        connection.close()
+
+
 def _request(source: Path, *, revision: int = 11, level: int = 1024) -> DetailRenderRequest:
     return DetailRenderRequest(
         generation=1,
@@ -272,6 +285,8 @@ def test_dirty_recovery_indexes_orphan_payload_and_removes_temp(tmp_path: Path) 
     index.remove(surface_cache_module._key_digest(request))
     temporary = path.parent / ".orphan.ipsurface.crash.tmp"
     temporary.write_bytes(b"partial")
+    with index._lock:
+        index._close_connection_locked()
 
     recovered = NeutralSurfaceStore(tmp_path)
     loaded = recovered.load(request)
@@ -279,6 +294,78 @@ def test_dirty_recovery_indexes_orphan_payload_and_removes_temp(tmp_path: Path) 
     assert loaded is not None
     assert loaded.cache_tier == "disk"
     assert not temporary.exists()
+
+
+def test_overlapping_index_leases_keep_marker_dirty_until_last_close(
+    tmp_path: Path,
+) -> None:
+    first = SurfaceCacheIndex(tmp_path)
+    second = SurfaceCacheIndex(tmp_path)
+
+    assert first.ensure_open()
+    assert second.ensure_open()
+    assert not first.needs_recovery
+    assert not second.needs_recovery
+
+    first.close(clean=True)
+
+    metadata = _index_metadata(tmp_path)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["active_leases"] == 1
+    assert metadata["recovery_required"] == 0
+
+    second.close(clean=True)
+
+    metadata = _index_metadata(tmp_path)
+    assert metadata["clean_shutdown"] == 1
+    assert metadata["active_leases"] == 0
+    assert metadata["recovery_required"] == 0
+
+
+def test_recovery_from_one_lease_survives_other_clean_close(tmp_path: Path) -> None:
+    first = SurfaceCacheIndex(tmp_path)
+    second = SurfaceCacheIndex(tmp_path)
+    assert first.ensure_open()
+    assert second.ensure_open()
+
+    first.mark_recovery_required()
+    first.close(clean=True)
+    second.close(clean=True)
+
+    metadata = _index_metadata(tmp_path)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["active_leases"] == 0
+    assert metadata["recovery_required"] == 1
+
+    reopened = SurfaceCacheIndex(tmp_path)
+    assert reopened.ensure_open()
+    assert reopened.needs_recovery
+    reopened.close(clean=False)
+
+
+def test_new_process_session_recovers_stale_active_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    crashed = SurfaceCacheIndex(tmp_path)
+    assert crashed.ensure_open()
+    with crashed._lock:
+        crashed._close_connection_locked()
+    monkeypatch.setattr(
+        surface_cache_index_module,
+        "_PROCESS_SESSION_TOKEN",
+        crashed._session_token % ((1 << 63) - 1) + 1,
+    )
+
+    recovered = SurfaceCacheIndex(tmp_path)
+
+    assert recovered.ensure_open()
+    assert recovered.needs_recovery
+    metadata = _index_metadata(tmp_path)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["active_leases"] == 1
+    assert metadata["recovery_required"] == 1
+    recovered.close(clean=False)
 
 
 def test_missing_payload_removes_stale_metadata_row(tmp_path: Path) -> None:
@@ -357,11 +444,39 @@ def test_sqlite_lookup_failure_falls_back_to_delegate_decode(
     assert path.exists()
     assert index.needs_recovery
     assert index._connection is None
+    metadata = _index_metadata(index.root)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["recovery_required"] == 1
     backend.shutdown(timeout_ms=5000)
 
     reopened = SurfaceCacheIndex(index.root)
     assert reopened.ensure_open()
     assert reopened.needs_recovery
+    reopened.close(clean=False)
+
+
+def test_sqlite_lease_metadata_failure_keeps_index_dirty(tmp_path: Path) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    _fail_index_execute(index, lambda sql: "SELECT value FROM metadata" in sql)
+
+    assert store.load(request) is None
+
+    assert path.exists()
+    assert index._connection is None
+    assert index.needs_recovery
+    metadata = _index_metadata(index.root)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["recovery_required"] == 1
+
+    reopened = SurfaceCacheIndex(index.root)
+    assert reopened.ensure_open()
+    assert reopened.needs_recovery
+    assert _index_metadata(index.root)["active_leases"] == 1
     reopened.close(clean=False)
 
 
@@ -707,6 +822,85 @@ def test_rebind_returns_before_old_store_io_drains(tmp_path: Path) -> None:
     release.set()
     backend.shutdown(timeout_ms=5000)
     assert old_closed.is_set()
+
+
+def test_a_b_a_rebind_keeps_latest_library_lease_dirty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    library_a = tmp_path / "library-a"
+    library_b = tmp_path / "library-b"
+    request = _request(library_a / "photo.jpg")
+    started = Event()
+    release = Event()
+    old_closed = Event()
+    old_store = NeutralSurfaceStore(library_a)
+    original_close = old_store.close
+
+    def close_old_store() -> None:
+        original_close()
+        old_closed.set()
+
+    monkeypatch.setattr(old_store, "close", close_old_store)
+    delegate = Mock()
+
+    def slow_decode(
+        prepared: DetailRenderRequest,
+        _token: _Token,
+    ) -> DecodedSurface:
+        started.set()
+        assert release.wait(5)
+        return _surface(prepared)
+
+    delegate.decode.side_effect = slow_decode
+    backend = CachedStillDecodeBackend(delegate, store=old_store)
+    failures: list[BaseException] = []
+
+    def decode() -> None:
+        try:
+            backend.decode(request, _Token())
+        except DecodeCancelledError as exc:
+            failures.append(exc)
+
+    worker = Thread(target=decode)
+    worker.start()
+    assert started.wait(5)
+
+    backend.bind_library(library_b)
+    backend.bind_library(library_a)
+    current_store = backend.store
+    current_index = current_store._index_for_root()
+    assert current_index is not None
+    original_glob = Path.glob
+
+    def fail_a_payload_scan(path: Path, pattern: str):
+        if path == current_index.root:
+            raise AssertionError("same-session A→B→A must not scan payloads")
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "glob", fail_a_payload_scan)
+
+    current_store.maintenance()
+
+    assert not current_index.needs_recovery
+    release.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+    assert old_closed.wait(5)
+    assert len(failures) == 1
+    assert isinstance(failures[0], DecodeCancelledError)
+    assert backend.memory_cache.used_bytes == 0
+    metadata = _index_metadata(current_index.root)
+    assert metadata["clean_shutdown"] == 0
+    assert metadata["active_leases"] == 1
+    assert metadata["recovery_required"] == 0
+
+    backend.shutdown(timeout_ms=5000)
+
+    metadata = _index_metadata(current_index.root)
+    assert metadata["clean_shutdown"] == 1
+    assert metadata["active_leases"] == 0
+    assert metadata["recovery_required"] == 0
 
 
 def test_shutdown_timeout_closes_store_after_active_decode_finishes(

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -27,6 +27,7 @@ from iPhoto.gui.detail_surface_cache import (
     SurfaceCacheCorruptError,
     surface_memory_budget_bytes,
 )
+from iPhoto.gui.detail_surface_cache_index import SurfaceCacheIndex
 
 
 class _Token:
@@ -234,6 +235,54 @@ def test_missing_payload_removes_stale_metadata_row(tmp_path: Path) -> None:
     assert index.get(surface_cache_module._key_digest(request)) is None
 
 
+def test_replace_followed_by_upsert_failure_removes_orphan_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    monkeypatch.setattr(index, "upsert", lambda _entry: False)
+
+    assert not store.write(request, _surface(request))
+
+    assert not path.exists()
+    assert index.remove(surface_cache_module._key_digest(request))
+    assert not index.needs_recovery
+
+
+def test_failed_write_cleanup_marks_recovery_when_row_cannot_be_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path)
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    monkeypatch.setattr(index, "upsert", lambda _entry: False)
+    monkeypatch.setattr(index, "remove", lambda _digest: False)
+
+    assert not store.write(request, _surface(request))
+
+    assert not path.exists()
+    assert index.needs_recovery
+
+
+def test_recovery_required_index_does_not_close_clean(tmp_path: Path) -> None:
+    index = SurfaceCacheIndex(tmp_path)
+    assert index.ensure_open()
+    index.mark_recovery_required()
+
+    index.close()
+    reopened = SurfaceCacheIndex(tmp_path)
+
+    assert reopened.ensure_open()
+    assert reopened.needs_recovery
+
+
 def test_corrupt_sqlite_index_is_rebuilt_from_untrusted_payload(tmp_path: Path) -> None:
     request = _request(tmp_path / "photo.jpg")
     store = NeutralSurfaceStore(tmp_path)
@@ -249,6 +298,58 @@ def test_corrupt_sqlite_index_is_rebuilt_from_untrusted_payload(tmp_path: Path) 
     assert loaded is not None
     assert loaded.decoded_size == (8, 4)
     assert tuple(root.glob("index.sqlite3.corrupt-*"))
+
+
+def test_prune_remove_failure_is_bounded_and_keeps_maintenance_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=1)
+    store._budget_override = 1 << 30
+    assert store.write(request, _surface(request))
+    index = store._index_for_root()
+    assert index is not None
+    store._budget_override = 1
+    remove = Mock(return_value=False)
+    monkeypatch.setattr(index, "remove", remove)
+
+    store.maintenance(force_prune=True)
+
+    remove.assert_called_once()
+    assert index.needs_recovery
+    assert index.maintenance_due(
+        1,
+        byte_interval=surface_cache_module._MAINTENANCE_WRITE_BYTES,
+        time_interval_ns=surface_cache_module._MAINTENANCE_INTERVAL_NS,
+    )
+
+
+def test_prune_unlink_failure_keeps_row_and_marks_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path / "photo.jpg")
+    store = NeutralSurfaceStore(tmp_path, budget_bytes=1 << 30)
+    assert store.write(request, _surface(request))
+    path = store.entry_path(request)
+    index = store._index_for_root()
+    assert path is not None and index is not None
+    original_unlink = Path.unlink
+
+    def fail_payload_unlink(candidate: Path, *, missing_ok: bool = False) -> None:
+        if candidate == path:
+            raise OSError("injected payload unlink failure")
+        original_unlink(candidate, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_payload_unlink)
+    store._budget_override = 1
+
+    store.maintenance(force_prune=True)
+
+    assert path.exists()
+    assert index.get(surface_cache_module._key_digest(request)) is not None
+    assert index.needs_recovery
 
 
 def test_first_v3_write_removes_rebuildable_v2_namespace(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_surface_residency.py
+++ b/tests/gui/test_detail_surface_residency.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtGui import QImage
+
+from iPhoto.core.color_resolver import ColorStats
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailGeometryState,
+    DetailRenderRequest,
+)
+from iPhoto.gui.detail_render_session import EditRenderState, PhotoRenderSessionHandle
+from iPhoto.gui.detail_surface_cache import MappedSurfaceCache
+from iPhoto.gui.detail_surface_residency import (
+    SurfaceByteBreakdown,
+    SurfaceResidencyTracker,
+    surface_resource_id,
+)
+
+
+def _surface(path: Path, *, level: int = 1024) -> tuple[AssetSourceIdentity, DecodedSurface]:
+    identity = AssetSourceIdentity.create(
+        path,
+        size_bytes=123,
+        source_mtime_ns=456,
+        index_revision=7,
+        width=1600,
+        height=1200,
+    )
+    request = DetailRenderRequest(
+        generation=1,
+        asset_id="asset-1",
+        source_identity=identity,
+        viewport_physical_size=(800, 600),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="initial",
+        decode_level=level,
+    )
+    image = QImage(8, 6, QImage.Format.Format_RGBA8888)
+    image.fill(0xFF123456)
+    return identity, DecodedSurface(
+        image=image,
+        decode_key=DetailDecodeKey.from_request(request),
+        source_size=(1600, 1200),
+        decoded_size=(8, 6),
+        decode_level=level,
+        backend="fake",
+        color_stats=ColorStats(),
+    )
+
+
+def test_tracker_counts_shared_resource_once_across_multiple_owners(tmp_path: Path) -> None:
+    _identity, surface = _surface(tmp_path / "photo.jpg")
+    tracker = SurfaceResidencyTracker()
+    resource_id = surface_resource_id(surface)
+
+    tracker.retain_surface("cache", "memory_cache", surface)
+    tracker.retain_surface("session", "render_session", surface)
+
+    snapshot = tracker.snapshot()
+    assert snapshot.resource_count == 1
+    assert snapshot.owner_count == 2
+    assert snapshot.reference_count == 2
+    assert snapshot.unique_bytes.cpu_heap == surface.image.sizeInBytes()
+    assert dict(snapshot.bytes_by_owner_kind) == {
+        "memory_cache": surface.image.sizeInBytes(),
+        "render_session": surface.image.sizeInBytes(),
+    }
+
+    tracker.release("cache", resource_id)
+    assert tracker.snapshot().unique_bytes.cpu_heap == surface.image.sizeInBytes()
+    tracker.release("session")
+    assert tracker.snapshot().unique_bytes.total == 0
+
+
+def test_tracker_separates_host_staging_gpu_and_raw_bytes() -> None:
+    tracker = SurfaceResidencyTracker()
+    tracker.retain(
+        "owner",
+        "diagnostic",
+        "resource",
+        SurfaceByteBreakdown(
+            cpu_heap=1,
+            mmap=2,
+            upload_staging=3,
+            gpu_estimated=4,
+            raw_intermediate=5,
+        ),
+    )
+
+    snapshot = tracker.snapshot()
+    assert snapshot.unique_bytes.total == 15
+    assert snapshot.unique_bytes == SurfaceByteBreakdown(1, 2, 3, 4, 5)
+
+
+def test_render_session_releases_all_observed_lods(tmp_path: Path) -> None:
+    identity, first = _surface(tmp_path / "photo.jpg", level=1024)
+    _identity, second = _surface(tmp_path / "photo.jpg", level=2048)
+    tracker = SurfaceResidencyTracker()
+    state = EditRenderState.create(
+        {},
+        color_stats=first.color_stats,
+        revision=("index", identity.index_revision),
+    )
+    session = PhotoRenderSessionHandle(
+        session_id=9,
+        asset_id="asset-1",
+        source_identity=identity,
+        current_surface=first,
+        edit_state=state,
+        baseline_state=state,
+        residency_tracker=tracker,
+    )
+
+    session.retain_surface(second)
+    assert tracker.snapshot().resource_count == 2
+
+    session.release_residency_observations()
+    assert tracker.snapshot().owner_count == 0
+    assert tracker.snapshot().unique_bytes.total == 0
+
+
+def test_memory_cache_observes_eviction_and_clear(tmp_path: Path) -> None:
+    _identity, first = _surface(tmp_path / "first.jpg")
+    _identity, second = _surface(tmp_path / "second.jpg")
+    tracker = SurfaceResidencyTracker()
+    cache = MappedSurfaceCache(
+        budget_bytes=first.image.sizeInBytes(),
+        residency_tracker=tracker,
+    )
+
+    assert cache.put(first)
+    assert cache.put(second)
+    snapshot = tracker.snapshot()
+    assert snapshot.resource_count == 1
+    assert snapshot.unique_bytes.cpu_heap == second.image.sizeInBytes()
+
+    cache.clear()
+    assert tracker.snapshot().unique_bytes.total == 0

--- a/tests/test_detail_surface_cache_benchmark.py
+++ b/tests/test_detail_surface_cache_benchmark.py
@@ -2,7 +2,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from tools.detail_surface_cache_benchmark import benchmark, compare
+from tools.detail_surface_cache_benchmark import (
+    _fresh_probe_orders,
+    _replace_fresh_process_samples,
+    benchmark,
+    compare,
+)
+
+
+def _fresh_probe(sample: int) -> dict[str, object]:
+    return {
+        "load_ms": float(sample),
+        "consume_ms": 1.0,
+        "load_to_consumed_ms": float(sample + 1),
+        "store_initialization_ms": 2.0,
+        "page_faults": 3,
+        "rss_delta_bytes": 4,
+        "checksum_calls": 0,
+        "consumption_digest": "digest",
+    }
 
 
 def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> None:
@@ -29,6 +47,39 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
     assert len(row["fresh_process_samples"]) == 40
     assert len(row["warm_process_samples"]) == 40
     assert row["python_peak_bytes"] <= 8 * 1024 * 1024 + 4096
+
+
+def test_surface_cache_fresh_probes_alternate_pair_order() -> None:
+    assert _fresh_probe_orders(4) == [
+        ("baseline", "candidate"),
+        ("candidate", "baseline"),
+        ("baseline", "candidate"),
+        ("candidate", "baseline"),
+    ]
+
+
+def test_surface_cache_replaces_deferred_fresh_metrics() -> None:
+    payload = {
+        "consume_samples": 1,
+        "results": [
+            {
+                "size_mib": 16,
+                "consumption_digest": "digest",
+                "fresh_process_samples": [_fresh_probe(99)],
+            }
+        ],
+    }
+    probes = [_fresh_probe(sample) for sample in range(1, 41)]
+
+    _replace_fresh_process_samples(payload, size_mib=16, probes=probes)
+
+    row = payload["results"][0]
+    assert payload["consume_samples"] == 40
+    assert row["fresh_process_load_p50_ms"] == 20.5
+    assert row["fresh_process_load_p95_ms"] == 38.0
+    assert row["fresh_process_load_to_consumed_p95_ms"] == 39.0
+    assert row["fresh_process_checksum_calls"] == 0
+    assert row["fresh_process_samples"] == probes
 
 
 def test_surface_cache_comparison_applies_memory_and_latency_gates() -> None:

--- a/tests/test_detail_surface_cache_benchmark.py
+++ b/tests/test_detail_surface_cache_benchmark.py
@@ -9,21 +9,34 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
     result = benchmark(
         sizes_mib=(1,),
         warm_samples=2,
+        consume_samples=2,
         repo_root=tmp_path,
         label="test",
     )
 
     row = result["results"][0]
+    assert result["schema"] == 2
     assert row["namespace"] == "v3"
     assert row["payload_bytes"] == 1024 * 1024
     assert row["checksum_calls"] == 0
+    assert row["fresh_process_checksum_calls"] == 0
+    assert row["fresh_process_load_to_consumed_p95_ms"] > 0
+    assert row["warm_load_to_consumed_p95_ms"] > 0
+    assert row["consumption_digest"]
     assert row["python_peak_bytes"] <= 8 * 1024 * 1024 + 4096
 
 
 def test_surface_cache_comparison_applies_memory_and_latency_gates() -> None:
     baseline = {
         "commit_sha": "baseline",
-        "results": [{"size_mib": 16, "warm_hit_p95_ms": 20.0}],
+        "results": [
+            {
+                "size_mib": 16,
+                "warm_hit_p95_ms": 20.0,
+                "fresh_process_load_to_consumed_p95_ms": 30.0,
+                "warm_load_to_consumed_p95_ms": 25.0,
+            }
+        ],
     }
     candidate = {
         "commit_sha": "candidate",
@@ -32,9 +45,12 @@ def test_surface_cache_comparison_applies_memory_and_latency_gates() -> None:
                 "size_mib": 16,
                 "payload_bytes": 16 * 1024 * 1024,
                 "checksum_calls": 0,
+                "fresh_process_checksum_calls": 0,
                 "python_peak_bytes": 1024,
                 "rss_write_delta_bytes": 1024,
                 "warm_hit_p95_ms": 21.0,
+                "fresh_process_load_to_consumed_p95_ms": 31.0,
+                "warm_load_to_consumed_p95_ms": 26.0,
             }
         ],
     }
@@ -42,4 +58,39 @@ def test_surface_cache_comparison_applies_memory_and_latency_gates() -> None:
     result = compare(baseline, candidate)
 
     assert result["passed"] is True
-    assert len(result["checks"]) == 4
+    assert result["schema"] == 2
+    assert len(result["checks"]) == 6
+
+
+def test_surface_cache_comparison_rejects_consumed_latency_regression() -> None:
+    baseline = {
+        "results": [
+            {
+                "size_mib": 16,
+                "warm_hit_p95_ms": 1.0,
+                "fresh_process_load_to_consumed_p95_ms": 10.0,
+                "warm_load_to_consumed_p95_ms": 10.0,
+            }
+        ]
+    }
+    candidate = {
+        "results": [
+            {
+                "size_mib": 16,
+                "payload_bytes": 16 * 1024 * 1024,
+                "checksum_calls": 0,
+                "fresh_process_checksum_calls": 0,
+                "python_peak_bytes": 1024,
+                "rss_write_delta_bytes": 1024,
+                "warm_hit_p95_ms": 1.0,
+                "fresh_process_load_to_consumed_p95_ms": 21.0,
+                "warm_load_to_consumed_p95_ms": 10.0,
+            }
+        ]
+    }
+
+    result = compare(baseline, candidate)
+
+    assert result["passed"] is False
+    failed = [check["name"] for check in result["checks"] if not check["passed"]]
+    assert failed == ["16MiB.fresh_process_load_to_consumed_p95_ms"]

--- a/tests/test_detail_surface_cache_benchmark.py
+++ b/tests/test_detail_surface_cache_benchmark.py
@@ -16,8 +16,8 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
 
     row = result["results"][0]
     assert result["schema"] == 2
-    assert result["warm_samples"] == 20
-    assert result["consume_samples"] == 20
+    assert result["warm_samples"] == 40
+    assert result["consume_samples"] == 40
     assert row["namespace"] == "v3"
     assert row["payload_bytes"] == 1024 * 1024
     assert row["checksum_calls"] == 0
@@ -25,8 +25,8 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
     assert row["fresh_process_load_to_consumed_p95_ms"] > 0
     assert row["warm_load_to_consumed_p95_ms"] > 0
     assert row["consumption_digest"]
-    assert len(row["fresh_process_samples"]) == 20
-    assert len(row["warm_process_samples"]) == 20
+    assert len(row["fresh_process_samples"]) == 40
+    assert len(row["warm_process_samples"]) == 40
     assert row["python_peak_bytes"] <= 8 * 1024 * 1024 + 4096
 
 

--- a/tests/test_detail_surface_cache_benchmark.py
+++ b/tests/test_detail_surface_cache_benchmark.py
@@ -16,6 +16,8 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
 
     row = result["results"][0]
     assert result["schema"] == 2
+    assert result["warm_samples"] == 20
+    assert result["consume_samples"] == 20
     assert row["namespace"] == "v3"
     assert row["payload_bytes"] == 1024 * 1024
     assert row["checksum_calls"] == 0
@@ -23,6 +25,8 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
     assert row["fresh_process_load_to_consumed_p95_ms"] > 0
     assert row["warm_load_to_consumed_p95_ms"] > 0
     assert row["consumption_digest"]
+    assert len(row["fresh_process_samples"]) == 20
+    assert len(row["warm_process_samples"]) == 20
     assert row["python_peak_bytes"] <= 8 * 1024 * 1024 + 4096
 
 

--- a/tests/test_detail_surface_cache_benchmark.py
+++ b/tests/test_detail_surface_cache_benchmark.py
@@ -23,6 +23,7 @@ def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> N
     assert row["checksum_calls"] == 0
     assert row["fresh_process_checksum_calls"] == 0
     assert row["fresh_process_load_to_consumed_p95_ms"] > 0
+    assert row["fresh_process_store_initialization_p95_ms"] > 0
     assert row["warm_load_to_consumed_p95_ms"] > 0
     assert row["consumption_digest"]
     assert len(row["fresh_process_samples"]) == 40

--- a/tests/test_detail_surface_cache_benchmark.py
+++ b/tests/test_detail_surface_cache_benchmark.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.detail_surface_cache_benchmark import benchmark, compare
+
+
+def test_surface_cache_benchmark_records_candidate_contract(tmp_path: Path) -> None:
+    result = benchmark(
+        sizes_mib=(1,),
+        warm_samples=2,
+        repo_root=tmp_path,
+        label="test",
+    )
+
+    row = result["results"][0]
+    assert row["namespace"] == "v3"
+    assert row["payload_bytes"] == 1024 * 1024
+    assert row["checksum_calls"] == 0
+    assert row["python_peak_bytes"] <= 8 * 1024 * 1024 + 4096
+
+
+def test_surface_cache_comparison_applies_memory_and_latency_gates() -> None:
+    baseline = {
+        "commit_sha": "baseline",
+        "results": [{"size_mib": 16, "warm_hit_p95_ms": 20.0}],
+    }
+    candidate = {
+        "commit_sha": "candidate",
+        "results": [
+            {
+                "size_mib": 16,
+                "payload_bytes": 16 * 1024 * 1024,
+                "checksum_calls": 0,
+                "python_peak_bytes": 1024,
+                "rss_write_delta_bytes": 1024,
+                "warm_hit_p95_ms": 21.0,
+            }
+        ],
+    }
+
+    result = compare(baseline, candidate)
+
+    assert result["passed"] is True
+    assert len(result["checks"]) == 4

--- a/tools/detail_surface_cache_benchmark.py
+++ b/tools/detail_surface_cache_benchmark.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import gc
+import hashlib
 import json
 import math
 import os
@@ -38,6 +39,11 @@ from iPhoto.infrastructure.services.thumbnail_runtime_policy import (
 )
 
 _MIB = 1024 * 1024
+
+try:
+    import xxhash as benchmark_xxhash
+except ImportError:  # pragma: no cover - production dependency
+    benchmark_xxhash = None
 
 
 def _percentile(values: list[float], percentile: float) -> float:
@@ -93,7 +99,7 @@ def _store(root: Path) -> NeutralSurfaceStore:
         return NeutralSurfaceStore(root)
 
 
-def _rss_bytes() -> int:
+def _process_metrics() -> tuple[int, int]:
     if sys.platform == "win32":
         import ctypes
         from ctypes import wintypes
@@ -126,22 +132,134 @@ def _rss_bytes() -> int:
         psapi.GetProcessMemoryInfo.restype = wintypes.BOOL
         process = kernel32.GetCurrentProcess()
         if psapi.GetProcessMemoryInfo(process, ctypes.byref(counters), counters.cb):
-            return int(counters.WorkingSetSize)
-        return 0
+            return int(counters.WorkingSetSize), int(counters.PageFaultCount)
+        return 0, 0
+    page_faults = 0
+    try:
+        import resource
+
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        page_faults = int(usage.ru_minflt) + int(usage.ru_majflt)
+    except (ImportError, OSError, ValueError):
+        pass
     if sys.platform.startswith("linux"):
         try:
             for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
                 if line.startswith("VmRSS:"):
-                    return int(line.split()[1]) * 1024
+                    return int(line.split()[1]) * 1024, page_faults
         except (OSError, ValueError):
-            return 0
+            return 0, page_faults
     try:
         import resource
 
         value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
-        return value if sys.platform == "darwin" else value * 1024
+        rss = value if sys.platform == "darwin" else value * 1024
+        return rss, page_faults
     except (ImportError, OSError, ValueError):
-        return 0
+        return 0, page_faults
+
+
+def _rss_bytes() -> int:
+    return _process_metrics()[0]
+
+
+def _consume_image(image: QImage) -> str:
+    """Traverse every mapped pixel without calling the store checksum helper."""
+
+    payload = memoryview(image.constBits())[: int(image.sizeInBytes())]
+    try:
+        if benchmark_xxhash is not None:
+            return str(benchmark_xxhash.xxh64(payload).hexdigest())
+        return hashlib.blake2b(payload, digest_size=8).hexdigest()
+    finally:
+        try:
+            payload.release()
+        except (BufferError, ValueError):
+            pass
+
+
+def _measure_store_hit(
+    store: NeutralSurfaceStore,
+    request: DetailRenderRequest,
+    *,
+    size_mib: int,
+) -> dict[str, Any]:
+    rss_before, faults_before = _process_metrics()
+    total_started = time.perf_counter()
+    load_started = total_started
+    loaded = store.load(request)
+    load_ms = (time.perf_counter() - load_started) * 1000.0
+    if loaded is None:
+        raise RuntimeError(f"surface cache hit failed for {size_mib} MiB")
+    consume_started = time.perf_counter()
+    digest = _consume_image(loaded.image)
+    consume_ms = (time.perf_counter() - consume_started) * 1000.0
+    total_ms = (time.perf_counter() - total_started) * 1000.0
+    rss_after, faults_after = _process_metrics()
+    del loaded
+    gc.collect()
+    return {
+        "load_ms": load_ms,
+        "consume_ms": consume_ms,
+        "load_to_consumed_ms": total_ms,
+        "rss_delta_bytes": max(0, rss_after - rss_before),
+        "page_faults": max(0, faults_after - faults_before),
+        "consumption_digest": digest,
+    }
+
+
+def _load_and_consume(
+    library: Path,
+    *,
+    size_mib: int,
+    revision: int,
+) -> dict[str, Any]:
+    request = _request(library, size_mib=size_mib, revision=revision)
+    store = _store(library)
+    checksum_calls = 0
+    original_checksum = cache_module._checksum
+
+    def counted_checksum(payload, checksum=original_checksum) -> int:
+        nonlocal checksum_calls
+        checksum_calls += 1
+        return checksum(payload)
+
+    cache_module._checksum = counted_checksum
+    try:
+        result = _measure_store_hit(store, request, size_mib=size_mib)
+        result["checksum_calls"] = checksum_calls
+        return result
+    finally:
+        cache_module._checksum = original_checksum
+        close = getattr(store, "close", None)
+        if callable(close):
+            close()
+
+
+def _fresh_process_probe(
+    library: Path,
+    *,
+    size_mib: int,
+    revision: int,
+) -> dict[str, Any]:
+    completed = subprocess.run(  # noqa: S603 - fixed interpreter and local tool
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "probe",
+            "--library",
+            str(library),
+            "--size-mib",
+            str(size_mib),
+            "--revision",
+            str(revision),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    return dict(json.loads(completed.stdout))
 
 
 def _git_sha(repo_root: Path) -> str:
@@ -149,7 +267,7 @@ def _git_sha(repo_root: Path) -> str:
     if executable is None:
         return "unknown"
     try:
-        return subprocess.run(
+        return subprocess.run(  # noqa: S603 - resolved git executable only
             [executable, "rev-parse", "HEAD"],
             cwd=repo_root,
             check=True,
@@ -166,6 +284,7 @@ def benchmark(
     warm_samples: int,
     repo_root: Path,
     label: str,
+    consume_samples: int = 3,
 ) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     with tempfile.TemporaryDirectory(prefix="iphoto-surface-cache-") as temporary:
@@ -177,15 +296,6 @@ def benchmark(
             surface = _surface(request)
             store = _store(library)
 
-            checksum_calls = 0
-            original_checksum = cache_module._checksum
-
-            def counted_checksum(payload, checksum=original_checksum) -> int:
-                nonlocal checksum_calls
-                checksum_calls += 1
-                return checksum(payload)
-
-            cache_module._checksum = counted_checksum
             rss_before = _rss_bytes()
             tracemalloc.start()
             write_started = time.perf_counter()
@@ -197,55 +307,158 @@ def benchmark(
             if not wrote:
                 raise RuntimeError(f"surface cache write failed for {size_mib} MiB")
 
-            close = getattr(store, "close", None)
-            if callable(close):
-                close()
-            store = _store(library)
-            first_started = time.perf_counter()
-            loaded = store.load(request)
-            first_hit_ms = (time.perf_counter() - first_started) * 1000.0
-            if loaded is None:
-                raise RuntimeError(f"surface cache first hit failed for {size_mib} MiB")
-            del loaded
-            gc.collect()
-
-            warm_values: list[float] = []
-            for _sample in range(max(1, warm_samples)):
-                started = time.perf_counter()
-                loaded = store.load(request)
-                warm_values.append((time.perf_counter() - started) * 1000.0)
-                if loaded is None:
-                    raise RuntimeError(f"surface cache warm hit failed for {size_mib} MiB")
-                del loaded
-            gc.collect()
-            cache_module._checksum = original_checksum
-            close = getattr(store, "close", None)
-            if callable(close):
-                close()
-
+            payload_bytes = int(surface.image.sizeInBytes())
             namespace = "unknown"
             root = getattr(store, "root", None)
             if isinstance(root, Path):
                 namespace = root.name
+            close = getattr(store, "close", None)
+            if callable(close):
+                close()
+            del surface
+            gc.collect()
+
+            fresh_probes = [
+                _fresh_process_probe(
+                    library,
+                    size_mib=size_mib,
+                    revision=revision,
+                )
+                for _sample in range(max(1, consume_samples))
+            ]
+
+            checksum_calls = 0
+            original_checksum = cache_module._checksum
+
+            def counted_checksum(payload, checksum=original_checksum) -> int:
+                nonlocal checksum_calls
+                checksum_calls += 1
+                return checksum(payload)
+
+            store = _store(library)
+            cache_module._checksum = counted_checksum
+            try:
+                first_probe = _measure_store_hit(store, request, size_mib=size_mib)
+                warm_probes: list[dict[str, Any]] = []
+                for _sample in range(max(1, warm_samples)):
+                    warm_probes.append(
+                        _measure_store_hit(store, request, size_mib=size_mib)
+                    )
+            finally:
+                cache_module._checksum = original_checksum
+                close = getattr(store, "close", None)
+                if callable(close):
+                    close()
+
+            digests = {
+                str(probe["consumption_digest"])
+                for probe in [*fresh_probes, first_probe, *warm_probes]
+            }
+            if len(digests) != 1:
+                raise RuntimeError(
+                    f"surface consumption digest changed for {size_mib} MiB"
+                )
+            fresh_load = [float(probe["load_ms"]) for probe in fresh_probes]
+            fresh_consume = [float(probe["consume_ms"]) for probe in fresh_probes]
+            fresh_total = [
+                float(probe["load_to_consumed_ms"]) for probe in fresh_probes
+            ]
+            warm_load = [float(probe["load_ms"]) for probe in warm_probes]
+            warm_consume = [float(probe["consume_ms"]) for probe in warm_probes]
+            warm_total = [
+                float(probe["load_to_consumed_ms"]) for probe in warm_probes
+            ]
             results.append(
                 {
                     "size_mib": size_mib,
-                    "payload_bytes": surface.image.sizeInBytes(),
+                    "payload_bytes": payload_bytes,
                     "namespace": namespace,
                     "write_ms": round(write_ms, 3),
-                    "first_hit_ms": round(first_hit_ms, 3),
-                    "warm_hit_p50_ms": round(statistics.median(warm_values), 3),
-                    "warm_hit_p95_ms": round(_percentile(warm_values, 0.95), 3),
+                    "first_hit_ms": round(float(first_probe["load_ms"]), 3),
+                    "first_consume_ms": round(float(first_probe["consume_ms"]), 3),
+                    "first_load_to_consumed_ms": round(
+                        float(first_probe["load_to_consumed_ms"]),
+                        3,
+                    ),
+                    "warm_hit_p50_ms": round(statistics.median(warm_load), 3),
+                    "warm_hit_p95_ms": round(_percentile(warm_load, 0.95), 3),
+                    "warm_consume_p50_ms": round(statistics.median(warm_consume), 3),
+                    "warm_consume_p95_ms": round(
+                        _percentile(warm_consume, 0.95),
+                        3,
+                    ),
+                    "warm_load_to_consumed_p50_ms": round(
+                        statistics.median(warm_total),
+                        3,
+                    ),
+                    "warm_load_to_consumed_p95_ms": round(
+                        _percentile(warm_total, 0.95),
+                        3,
+                    ),
+                    "fresh_process_load_p50_ms": round(
+                        statistics.median(fresh_load),
+                        3,
+                    ),
+                    "fresh_process_load_p95_ms": round(
+                        _percentile(fresh_load, 0.95),
+                        3,
+                    ),
+                    "fresh_process_consume_p50_ms": round(
+                        statistics.median(fresh_consume),
+                        3,
+                    ),
+                    "fresh_process_consume_p95_ms": round(
+                        _percentile(fresh_consume, 0.95),
+                        3,
+                    ),
+                    "fresh_process_load_to_consumed_p50_ms": round(
+                        statistics.median(fresh_total),
+                        3,
+                    ),
+                    "fresh_process_load_to_consumed_p95_ms": round(
+                        _percentile(fresh_total, 0.95),
+                        3,
+                    ),
+                    "fresh_process_page_faults_p95": int(
+                        _percentile(
+                            [float(probe["page_faults"]) for probe in fresh_probes],
+                            0.95,
+                        )
+                    ),
+                    "fresh_process_rss_delta_bytes_p95": int(
+                        _percentile(
+                            [
+                                float(probe["rss_delta_bytes"])
+                                for probe in fresh_probes
+                            ],
+                            0.95,
+                        )
+                    ),
+                    "warm_page_faults_p95": int(
+                        _percentile(
+                            [float(probe["page_faults"]) for probe in warm_probes],
+                            0.95,
+                        )
+                    ),
+                    "warm_rss_delta_bytes_p95": int(
+                        _percentile(
+                            [float(probe["rss_delta_bytes"]) for probe in warm_probes],
+                            0.95,
+                        )
+                    ),
+                    "consumption_digest": digests.pop(),
                     "checksum_calls": checksum_calls,
+                    "fresh_process_checksum_calls": sum(
+                        int(probe["checksum_calls"]) for probe in fresh_probes
+                    ),
                     "python_peak_bytes": int(python_peak),
                     "rss_write_delta_bytes": max(0, rss_after_write - rss_before),
                 }
             )
-            del surface
             gc.collect()
 
     return {
-        "schema": 1,
+        "schema": 2,
         "label": label,
         "commit_sha": _git_sha(repo_root),
         "platform": platform.platform(),
@@ -256,6 +469,7 @@ def benchmark(
         "pyside": pyside_version,
         "qt": qVersion(),
         "warm_samples": max(1, warm_samples),
+        "consume_samples": max(1, consume_samples),
         "results": results,
     }
 
@@ -268,14 +482,20 @@ def compare(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, An
         old = baseline_by_size[size]
         tolerance = max(float(old["warm_hit_p95_ms"]) * 0.05, 10.0)
         warm_limit = float(old["warm_hit_p95_ms"]) + tolerance
+        cold_consumed = float(old["fresh_process_load_to_consumed_p95_ms"])
+        cold_consumed_limit = cold_consumed + max(cold_consumed * 0.05, 10.0)
+        warm_consumed = float(old["warm_load_to_consumed_p95_ms"])
+        warm_consumed_limit = warm_consumed + max(warm_consumed * 0.05, 10.0)
         payload = int(row["payload_bytes"])
         checks.extend(
             [
                 {
                     "name": f"{size}MiB.trusted_hit_checksum_calls",
-                    "actual": int(row["checksum_calls"]),
+                    "actual": int(row["checksum_calls"])
+                    + int(row["fresh_process_checksum_calls"]),
                     "limit": 0,
-                    "passed": int(row["checksum_calls"]) == 0,
+                    "passed": int(row["checksum_calls"]) == 0
+                    and int(row["fresh_process_checksum_calls"]) == 0,
                 },
                 {
                     "name": f"{size}MiB.python_peak_bytes",
@@ -296,10 +516,24 @@ def compare(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, An
                     "limit": round(warm_limit, 3),
                     "passed": float(row["warm_hit_p95_ms"]) <= warm_limit,
                 },
+                {
+                    "name": f"{size}MiB.fresh_process_load_to_consumed_p95_ms",
+                    "actual": float(row["fresh_process_load_to_consumed_p95_ms"]),
+                    "limit": round(cold_consumed_limit, 3),
+                    "passed": float(row["fresh_process_load_to_consumed_p95_ms"])
+                    <= cold_consumed_limit,
+                },
+                {
+                    "name": f"{size}MiB.warm_load_to_consumed_p95_ms",
+                    "actual": float(row["warm_load_to_consumed_p95_ms"]),
+                    "limit": round(warm_consumed_limit, 3),
+                    "passed": float(row["warm_load_to_consumed_p95_ms"])
+                    <= warm_consumed_limit,
+                },
             ]
         )
     return {
-        "schema": 1,
+        "schema": 2,
         "baseline_sha": baseline.get("commit_sha"),
         "candidate_sha": candidate.get("commit_sha"),
         "passed": all(check["passed"] for check in checks),
@@ -321,6 +555,11 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--label", default="candidate")
     run_parser.add_argument("--sizes-mib", default="16,64,180")
     run_parser.add_argument("--warm-samples", type=int, default=3)
+    run_parser.add_argument("--consume-samples", type=int, default=3)
+    probe_parser = subparsers.add_parser("probe")
+    probe_parser.add_argument("--library", required=True, type=Path)
+    probe_parser.add_argument("--size-mib", required=True, type=int)
+    probe_parser.add_argument("--revision", required=True, type=int)
     compare_parser = subparsers.add_parser("compare")
     compare_parser.add_argument("--baseline", required=True, type=Path)
     compare_parser.add_argument("--candidate", required=True, type=Path)
@@ -338,8 +577,18 @@ def main(argv: list[str] | None = None) -> int:
             warm_samples=max(1, int(args.warm_samples)),
             repo_root=args.repo_root,
             label=str(args.label),
+            consume_samples=max(1, int(args.consume_samples)),
         )
         _write_json(args.output, payload)
+        return 0
+
+    if args.command == "probe":
+        payload = _load_and_consume(
+            args.library,
+            size_mib=max(1, int(args.size_mib)),
+            revision=max(1, int(args.revision)),
+        )
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False))
         return 0
 
     baseline = json.loads(args.baseline.read_text(encoding="utf-8"))

--- a/tools/detail_surface_cache_benchmark.py
+++ b/tools/detail_surface_cache_benchmark.py
@@ -223,6 +223,12 @@ def _load_and_consume(
     checksum_calls = 0
     original_checksum = cache_module._checksum
 
+    initialization_started = time.perf_counter()
+    maintenance = getattr(store, "maintenance", None)
+    if callable(maintenance):
+        maintenance()
+    store_initialization_ms = (time.perf_counter() - initialization_started) * 1000.0
+
     def counted_checksum(payload, checksum=original_checksum) -> int:
         nonlocal checksum_calls
         checksum_calls += 1
@@ -232,6 +238,7 @@ def _load_and_consume(
     try:
         result = _measure_store_hit(store, request, size_mib=size_mib)
         result["checksum_calls"] = checksum_calls
+        result["store_initialization_ms"] = store_initialization_ms
         return result
     finally:
         cache_module._checksum = original_checksum
@@ -369,6 +376,9 @@ def benchmark(
             fresh_total = [
                 float(probe["load_to_consumed_ms"]) for probe in fresh_probes
             ]
+            fresh_initialization = [
+                float(probe["store_initialization_ms"]) for probe in fresh_probes
+            ]
             warm_load = [float(probe["load_ms"]) for probe in warm_probes]
             warm_consume = [float(probe["consume_ms"]) for probe in warm_probes]
             warm_total = [
@@ -423,6 +433,14 @@ def benchmark(
                     ),
                     "fresh_process_load_to_consumed_p95_ms": round(
                         _percentile(fresh_total, 0.95),
+                        3,
+                    ),
+                    "fresh_process_store_initialization_p50_ms": round(
+                        statistics.median(fresh_initialization),
+                        3,
+                    ),
+                    "fresh_process_store_initialization_p95_ms": round(
+                        _percentile(fresh_initialization, 0.95),
                         3,
                     ),
                     "fresh_process_page_faults_p95": int(

--- a/tools/detail_surface_cache_benchmark.py
+++ b/tools/detail_surface_cache_benchmark.py
@@ -252,6 +252,7 @@ def _fresh_process_probe(
     *,
     size_mib: int,
     revision: int,
+    env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     completed = subprocess.run(  # noqa: S603 - fixed interpreter and local tool
         [
@@ -268,9 +269,192 @@ def _fresh_process_probe(
         check=True,
         capture_output=True,
         text=True,
-        env=os.environ.copy(),
+        env=os.environ.copy() if env is None else env,
     )
     return dict(json.loads(completed.stdout))
+
+
+def _fresh_probe_orders(samples: int) -> list[tuple[str, str]]:
+    return [
+        ("baseline", "candidate")
+        if sample % 2 == 0
+        else ("candidate", "baseline")
+        for sample in range(samples)
+    ]
+
+
+def _fresh_probe_metrics(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    if not probes:
+        raise ValueError("fresh-process probes must not be empty")
+    fresh_load = [float(probe["load_ms"]) for probe in probes]
+    fresh_consume = [float(probe["consume_ms"]) for probe in probes]
+    fresh_total = [float(probe["load_to_consumed_ms"]) for probe in probes]
+    fresh_initialization = [
+        float(probe["store_initialization_ms"]) for probe in probes
+    ]
+    return {
+        "fresh_process_load_p50_ms": round(statistics.median(fresh_load), 3),
+        "fresh_process_load_p95_ms": round(_percentile(fresh_load, 0.95), 3),
+        "fresh_process_consume_p50_ms": round(
+            statistics.median(fresh_consume),
+            3,
+        ),
+        "fresh_process_consume_p95_ms": round(
+            _percentile(fresh_consume, 0.95),
+            3,
+        ),
+        "fresh_process_load_to_consumed_p50_ms": round(
+            statistics.median(fresh_total),
+            3,
+        ),
+        "fresh_process_load_to_consumed_p95_ms": round(
+            _percentile(fresh_total, 0.95),
+            3,
+        ),
+        "fresh_process_store_initialization_p50_ms": round(
+            statistics.median(fresh_initialization),
+            3,
+        ),
+        "fresh_process_store_initialization_p95_ms": round(
+            _percentile(fresh_initialization, 0.95),
+            3,
+        ),
+        "fresh_process_page_faults_p95": int(
+            _percentile([float(probe["page_faults"]) for probe in probes], 0.95)
+        ),
+        "fresh_process_rss_delta_bytes_p95": int(
+            _percentile(
+                [float(probe["rss_delta_bytes"]) for probe in probes],
+                0.95,
+            )
+        ),
+        "fresh_process_samples": probes,
+        "fresh_process_checksum_calls": sum(
+            int(probe["checksum_calls"]) for probe in probes
+        ),
+    }
+
+
+def _replace_fresh_process_samples(
+    payload: dict[str, Any],
+    *,
+    size_mib: int,
+    probes: list[dict[str, Any]],
+) -> None:
+    row = next(
+        (row for row in payload["results"] if int(row["size_mib"]) == size_mib),
+        None,
+    )
+    if row is None:
+        raise ValueError(f"missing {size_mib} MiB benchmark result")
+    digests = {str(probe["consumption_digest"]) for probe in probes}
+    if digests != {str(row["consumption_digest"])}:
+        raise RuntimeError(f"surface consumption digest changed for {size_mib} MiB")
+    row.update(_fresh_probe_metrics(probes))
+    payload["consume_samples"] = len(probes)
+
+
+def _prepare_surface_cache(
+    library: Path,
+    *,
+    size_mib: int,
+    revision: int,
+) -> None:
+    library.mkdir(parents=True, exist_ok=True)
+    request = _request(library, size_mib=size_mib, revision=revision)
+    store = _store(library)
+    try:
+        if not store.write(request, _surface(request)):
+            raise RuntimeError(f"surface cache write failed for {size_mib} MiB")
+    finally:
+        close = getattr(store, "close", None)
+        if callable(close):
+            close()
+
+
+def _repo_environment(repo_root: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root.resolve() / "src")
+    return env
+
+
+def _prepare_surface_cache_subprocess(
+    library: Path,
+    *,
+    size_mib: int,
+    revision: int,
+    env: dict[str, str],
+) -> None:
+    subprocess.run(  # noqa: S603 - fixed interpreter and local tool
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "prepare",
+            "--library",
+            str(library),
+            "--size-mib",
+            str(size_mib),
+            "--revision",
+            str(revision),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def pair_fresh_process_samples(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    baseline_repo: Path,
+    candidate_repo: Path,
+    size_mib: int,
+    samples: int,
+) -> None:
+    sample_count = max(_P95_MIN_SAMPLES, int(samples))
+    environments = {
+        "baseline": _repo_environment(baseline_repo),
+        "candidate": _repo_environment(candidate_repo),
+    }
+    probes: dict[str, list[dict[str, Any]]] = {
+        "baseline": [],
+        "candidate": [],
+    }
+    with tempfile.TemporaryDirectory(prefix="iphoto-surface-cache-paired-") as temp:
+        base = Path(temp)
+        libraries = {
+            "baseline": base / "baseline-library",
+            "candidate": base / "candidate-library",
+        }
+        for label in ("baseline", "candidate"):
+            _prepare_surface_cache_subprocess(
+                libraries[label],
+                size_mib=size_mib,
+                revision=1,
+                env=environments[label],
+            )
+        for order in _fresh_probe_orders(sample_count):
+            for label in order:
+                probes[label].append(
+                    _fresh_process_probe(
+                        libraries[label],
+                        size_mib=size_mib,
+                        revision=1,
+                        env=environments[label],
+                    )
+                )
+    _replace_fresh_process_samples(
+        baseline,
+        size_mib=size_mib,
+        probes=probes["baseline"],
+    )
+    _replace_fresh_process_samples(
+        candidate,
+        size_mib=size_mib,
+        probes=probes["candidate"],
+    )
 
 
 def _git_sha(repo_root: Path) -> str:
@@ -296,6 +480,7 @@ def benchmark(
     repo_root: Path,
     label: str,
     consume_samples: int = 3,
+    defer_fresh_probes: bool = False,
 ) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
     warm_sample_count = max(_P95_MIN_SAMPLES, int(warm_samples))
@@ -331,13 +516,14 @@ def benchmark(
             del surface
             gc.collect()
 
+            fresh_probe_count = 1 if defer_fresh_probes else consume_sample_count
             fresh_probes = [
                 _fresh_process_probe(
                     library,
                     size_mib=size_mib,
                     revision=revision,
                 )
-                for _sample in range(consume_sample_count)
+                for _sample in range(fresh_probe_count)
             ]
 
             checksum_calls = 0
@@ -371,14 +557,6 @@ def benchmark(
                 raise RuntimeError(
                     f"surface consumption digest changed for {size_mib} MiB"
                 )
-            fresh_load = [float(probe["load_ms"]) for probe in fresh_probes]
-            fresh_consume = [float(probe["consume_ms"]) for probe in fresh_probes]
-            fresh_total = [
-                float(probe["load_to_consumed_ms"]) for probe in fresh_probes
-            ]
-            fresh_initialization = [
-                float(probe["store_initialization_ms"]) for probe in fresh_probes
-            ]
             warm_load = [float(probe["load_ms"]) for probe in warm_probes]
             warm_consume = [float(probe["consume_ms"]) for probe in warm_probes]
             warm_total = [
@@ -411,53 +589,7 @@ def benchmark(
                         _percentile(warm_total, 0.95),
                         3,
                     ),
-                    "fresh_process_load_p50_ms": round(
-                        statistics.median(fresh_load),
-                        3,
-                    ),
-                    "fresh_process_load_p95_ms": round(
-                        _percentile(fresh_load, 0.95),
-                        3,
-                    ),
-                    "fresh_process_consume_p50_ms": round(
-                        statistics.median(fresh_consume),
-                        3,
-                    ),
-                    "fresh_process_consume_p95_ms": round(
-                        _percentile(fresh_consume, 0.95),
-                        3,
-                    ),
-                    "fresh_process_load_to_consumed_p50_ms": round(
-                        statistics.median(fresh_total),
-                        3,
-                    ),
-                    "fresh_process_load_to_consumed_p95_ms": round(
-                        _percentile(fresh_total, 0.95),
-                        3,
-                    ),
-                    "fresh_process_store_initialization_p50_ms": round(
-                        statistics.median(fresh_initialization),
-                        3,
-                    ),
-                    "fresh_process_store_initialization_p95_ms": round(
-                        _percentile(fresh_initialization, 0.95),
-                        3,
-                    ),
-                    "fresh_process_page_faults_p95": int(
-                        _percentile(
-                            [float(probe["page_faults"]) for probe in fresh_probes],
-                            0.95,
-                        )
-                    ),
-                    "fresh_process_rss_delta_bytes_p95": int(
-                        _percentile(
-                            [
-                                float(probe["rss_delta_bytes"])
-                                for probe in fresh_probes
-                            ],
-                            0.95,
-                        )
-                    ),
+                    **_fresh_probe_metrics(fresh_probes),
                     "warm_page_faults_p95": int(
                         _percentile(
                             [float(probe["page_faults"]) for probe in warm_probes],
@@ -471,12 +603,8 @@ def benchmark(
                         )
                     ),
                     "consumption_digest": digests.pop(),
-                    "fresh_process_samples": fresh_probes,
                     "warm_process_samples": warm_probes,
                     "checksum_calls": checksum_calls,
-                    "fresh_process_checksum_calls": sum(
-                        int(probe["checksum_calls"]) for probe in fresh_probes
-                    ),
                     "python_peak_bytes": int(python_peak),
                     "rss_write_delta_bytes": max(0, rss_after_write - rss_before),
                 }
@@ -495,7 +623,7 @@ def benchmark(
         "pyside": pyside_version,
         "qt": qVersion(),
         "warm_samples": warm_sample_count,
-        "consume_samples": consume_sample_count,
+        "consume_samples": 1 if defer_fresh_probes else consume_sample_count,
         "results": results,
     }
 
@@ -582,6 +710,11 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--sizes-mib", default="16,64,180")
     run_parser.add_argument("--warm-samples", type=int, default=_P95_MIN_SAMPLES)
     run_parser.add_argument("--consume-samples", type=int, default=_P95_MIN_SAMPLES)
+    run_parser.add_argument("--defer-fresh-probes", action="store_true")
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--library", required=True, type=Path)
+    prepare_parser.add_argument("--size-mib", required=True, type=int)
+    prepare_parser.add_argument("--revision", required=True, type=int)
     probe_parser = subparsers.add_parser("probe")
     probe_parser.add_argument("--library", required=True, type=Path)
     probe_parser.add_argument("--size-mib", required=True, type=int)
@@ -590,6 +723,13 @@ def main(argv: list[str] | None = None) -> int:
     compare_parser.add_argument("--baseline", required=True, type=Path)
     compare_parser.add_argument("--candidate", required=True, type=Path)
     compare_parser.add_argument("--output", required=True, type=Path)
+    pair_parser = subparsers.add_parser("pair-fresh")
+    pair_parser.add_argument("--baseline", required=True, type=Path)
+    pair_parser.add_argument("--candidate", required=True, type=Path)
+    pair_parser.add_argument("--baseline-repo", required=True, type=Path)
+    pair_parser.add_argument("--candidate-repo", required=True, type=Path)
+    pair_parser.add_argument("--size-mib", required=True, type=int)
+    pair_parser.add_argument("--samples", type=int, default=_P95_MIN_SAMPLES)
     args = parser.parse_args(argv)
 
     if args.command == "run":
@@ -604,8 +744,17 @@ def main(argv: list[str] | None = None) -> int:
             repo_root=args.repo_root,
             label=str(args.label),
             consume_samples=max(1, int(args.consume_samples)),
+            defer_fresh_probes=bool(args.defer_fresh_probes),
         )
         _write_json(args.output, payload)
+        return 0
+
+    if args.command == "prepare":
+        _prepare_surface_cache(
+            args.library,
+            size_mib=max(1, int(args.size_mib)),
+            revision=max(1, int(args.revision)),
+        )
         return 0
 
     if args.command == "probe":
@@ -615,6 +764,21 @@ def main(argv: list[str] | None = None) -> int:
             revision=max(1, int(args.revision)),
         )
         sys.stdout.write(json.dumps(payload, ensure_ascii=False))
+        return 0
+
+    if args.command == "pair-fresh":
+        baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+        candidate = json.loads(args.candidate.read_text(encoding="utf-8"))
+        pair_fresh_process_samples(
+            baseline,
+            candidate,
+            baseline_repo=args.baseline_repo,
+            candidate_repo=args.candidate_repo,
+            size_mib=max(1, int(args.size_mib)),
+            samples=max(1, int(args.samples)),
+        )
+        _write_json(args.baseline, baseline)
+        _write_json(args.candidate, candidate)
         return 0
 
     baseline = json.loads(args.baseline.read_text(encoding="utf-8"))

--- a/tools/detail_surface_cache_benchmark.py
+++ b/tools/detail_surface_cache_benchmark.py
@@ -39,6 +39,7 @@ from iPhoto.infrastructure.services.thumbnail_runtime_policy import (
 )
 
 _MIB = 1024 * 1024
+_P95_MIN_SAMPLES = 20
 
 try:
     import xxhash as benchmark_xxhash
@@ -287,6 +288,8 @@ def benchmark(
     consume_samples: int = 3,
 ) -> dict[str, Any]:
     results: list[dict[str, Any]] = []
+    warm_sample_count = max(_P95_MIN_SAMPLES, int(warm_samples))
+    consume_sample_count = max(_P95_MIN_SAMPLES, int(consume_samples))
     with tempfile.TemporaryDirectory(prefix="iphoto-surface-cache-") as temporary:
         base = Path(temporary)
         for revision, size_mib in enumerate(sizes_mib, start=1):
@@ -324,7 +327,7 @@ def benchmark(
                     size_mib=size_mib,
                     revision=revision,
                 )
-                for _sample in range(max(1, consume_samples))
+                for _sample in range(consume_sample_count)
             ]
 
             checksum_calls = 0
@@ -340,7 +343,7 @@ def benchmark(
             try:
                 first_probe = _measure_store_hit(store, request, size_mib=size_mib)
                 warm_probes: list[dict[str, Any]] = []
-                for _sample in range(max(1, warm_samples)):
+                for _sample in range(warm_sample_count):
                     warm_probes.append(
                         _measure_store_hit(store, request, size_mib=size_mib)
                     )
@@ -447,6 +450,8 @@ def benchmark(
                         )
                     ),
                     "consumption_digest": digests.pop(),
+                    "fresh_process_samples": fresh_probes,
+                    "warm_process_samples": warm_probes,
                     "checksum_calls": checksum_calls,
                     "fresh_process_checksum_calls": sum(
                         int(probe["checksum_calls"]) for probe in fresh_probes
@@ -468,8 +473,8 @@ def benchmark(
         "python": platform.python_version(),
         "pyside": pyside_version,
         "qt": qVersion(),
-        "warm_samples": max(1, warm_samples),
-        "consume_samples": max(1, consume_samples),
+        "warm_samples": warm_sample_count,
+        "consume_samples": consume_sample_count,
         "results": results,
     }
 
@@ -554,8 +559,8 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     run_parser.add_argument("--label", default="candidate")
     run_parser.add_argument("--sizes-mib", default="16,64,180")
-    run_parser.add_argument("--warm-samples", type=int, default=3)
-    run_parser.add_argument("--consume-samples", type=int, default=3)
+    run_parser.add_argument("--warm-samples", type=int, default=_P95_MIN_SAMPLES)
+    run_parser.add_argument("--consume-samples", type=int, default=_P95_MIN_SAMPLES)
     probe_parser = subparsers.add_parser("probe")
     probe_parser.add_argument("--library", required=True, type=Path)
     probe_parser.add_argument("--size-mib", required=True, type=int)

--- a/tools/detail_surface_cache_benchmark.py
+++ b/tools/detail_surface_cache_benchmark.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Benchmark neutral-surface cache I/O without requiring the full GUI runtime."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import math
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+from PySide6 import __version__ as pyside_version
+from PySide6.QtCore import qVersion
+from PySide6.QtGui import QImage
+
+import iPhoto.gui.detail_surface_cache as cache_module
+from iPhoto.core.color_resolver import ColorStats
+from iPhoto.gui.detail_decode_backend import DecodedSurface
+from iPhoto.gui.detail_pipeline import (
+    AssetSourceIdentity,
+    DetailDecodeKey,
+    DetailGeometryState,
+    DetailRenderRequest,
+)
+from iPhoto.gui.detail_surface_cache import NeutralSurfaceStore
+from iPhoto.infrastructure.services.thumbnail_runtime_policy import (
+    resolve_physical_memory_bytes,
+)
+
+_MIB = 1024 * 1024
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(len(ordered) * percentile) - 1)
+    return float(ordered[index])
+
+
+def _request(root: Path, *, size_mib: int, revision: int) -> DetailRenderRequest:
+    source = root / f"surface-{size_mib}.rgba"
+    return DetailRenderRequest(
+        generation=revision,
+        asset_id=f"surface-{size_mib}",
+        source_identity=AssetSourceIdentity.create(
+            source,
+            size_bytes=size_mib * _MIB,
+            source_mtime_ns=revision,
+            width=4096,
+            height=max(1, size_mib * _MIB // (4096 * 4)),
+            orientation=1,
+        ),
+        viewport_physical_size=(1920, 1080),
+        device_pixel_ratio=1.0,
+        geometry=DetailGeometryState(),
+        reason="cache-benchmark",
+        decode_level="full",
+    )
+
+
+def _surface(request: DetailRenderRequest) -> DecodedSurface:
+    width = int(request.source_identity.width)
+    height = int(request.source_identity.height)
+    image = QImage(width, height, QImage.Format.Format_RGBA8888)
+    if image.isNull():
+        raise MemoryError(f"unable to allocate benchmark QImage {width}x{height}")
+    image.fill(0xFF123456)
+    return DecodedSurface(
+        image=image,
+        decode_key=DetailDecodeKey.from_request(request),
+        source_size=(width, height),
+        decoded_size=(width, height),
+        decode_level="full",
+        backend="benchmark",
+        color_stats=ColorStats(),
+    )
+
+
+def _store(root: Path) -> NeutralSurfaceStore:
+    try:
+        return NeutralSurfaceStore(root, budget_bytes=4 * 1024 * _MIB)
+    except TypeError:
+        # Fixed v2 baseline did not expose a budget override.
+        return NeutralSurfaceStore(root)
+
+
+def _rss_bytes() -> int:
+    if sys.platform == "win32":
+        import ctypes
+        from ctypes import wintypes
+
+        class _Counters(ctypes.Structure):
+            _fields_ = [
+                ("cb", wintypes.DWORD),
+                ("PageFaultCount", wintypes.DWORD),
+                ("PeakWorkingSetSize", ctypes.c_size_t),
+                ("WorkingSetSize", ctypes.c_size_t),
+                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+                ("PagefileUsage", ctypes.c_size_t),
+                ("PeakPagefileUsage", ctypes.c_size_t),
+            ]
+
+        counters = _Counters()
+        counters.cb = ctypes.sizeof(counters)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        psapi = ctypes.WinDLL("psapi", use_last_error=True)
+        kernel32.GetCurrentProcess.argtypes = []
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        psapi.GetProcessMemoryInfo.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(_Counters),
+            wintypes.DWORD,
+        ]
+        psapi.GetProcessMemoryInfo.restype = wintypes.BOOL
+        process = kernel32.GetCurrentProcess()
+        if psapi.GetProcessMemoryInfo(process, ctypes.byref(counters), counters.cb):
+            return int(counters.WorkingSetSize)
+        return 0
+    if sys.platform.startswith("linux"):
+        try:
+            for line in Path("/proc/self/status").read_text(encoding="utf-8").splitlines():
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) * 1024
+        except (OSError, ValueError):
+            return 0
+    try:
+        import resource
+
+        value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+        return value if sys.platform == "darwin" else value * 1024
+    except (ImportError, OSError, ValueError):
+        return 0
+
+
+def _git_sha(repo_root: Path) -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        return "unknown"
+    try:
+        return subprocess.run(
+            [executable, "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def benchmark(
+    *,
+    sizes_mib: tuple[int, ...],
+    warm_samples: int,
+    repo_root: Path,
+    label: str,
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="iphoto-surface-cache-") as temporary:
+        base = Path(temporary)
+        for revision, size_mib in enumerate(sizes_mib, start=1):
+            library = base / f"library-{size_mib}"
+            library.mkdir(parents=True)
+            request = _request(library, size_mib=size_mib, revision=revision)
+            surface = _surface(request)
+            store = _store(library)
+
+            checksum_calls = 0
+            original_checksum = cache_module._checksum
+
+            def counted_checksum(payload, checksum=original_checksum) -> int:
+                nonlocal checksum_calls
+                checksum_calls += 1
+                return checksum(payload)
+
+            cache_module._checksum = counted_checksum
+            rss_before = _rss_bytes()
+            tracemalloc.start()
+            write_started = time.perf_counter()
+            wrote = store.write(request, surface)
+            write_ms = (time.perf_counter() - write_started) * 1000.0
+            _current, python_peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            rss_after_write = _rss_bytes()
+            if not wrote:
+                raise RuntimeError(f"surface cache write failed for {size_mib} MiB")
+
+            close = getattr(store, "close", None)
+            if callable(close):
+                close()
+            store = _store(library)
+            first_started = time.perf_counter()
+            loaded = store.load(request)
+            first_hit_ms = (time.perf_counter() - first_started) * 1000.0
+            if loaded is None:
+                raise RuntimeError(f"surface cache first hit failed for {size_mib} MiB")
+            del loaded
+            gc.collect()
+
+            warm_values: list[float] = []
+            for _sample in range(max(1, warm_samples)):
+                started = time.perf_counter()
+                loaded = store.load(request)
+                warm_values.append((time.perf_counter() - started) * 1000.0)
+                if loaded is None:
+                    raise RuntimeError(f"surface cache warm hit failed for {size_mib} MiB")
+                del loaded
+            gc.collect()
+            cache_module._checksum = original_checksum
+            close = getattr(store, "close", None)
+            if callable(close):
+                close()
+
+            namespace = "unknown"
+            root = getattr(store, "root", None)
+            if isinstance(root, Path):
+                namespace = root.name
+            results.append(
+                {
+                    "size_mib": size_mib,
+                    "payload_bytes": surface.image.sizeInBytes(),
+                    "namespace": namespace,
+                    "write_ms": round(write_ms, 3),
+                    "first_hit_ms": round(first_hit_ms, 3),
+                    "warm_hit_p50_ms": round(statistics.median(warm_values), 3),
+                    "warm_hit_p95_ms": round(_percentile(warm_values, 0.95), 3),
+                    "checksum_calls": checksum_calls,
+                    "python_peak_bytes": int(python_peak),
+                    "rss_write_delta_bytes": max(0, rss_after_write - rss_before),
+                }
+            )
+            del surface
+            gc.collect()
+
+    return {
+        "schema": 1,
+        "label": label,
+        "commit_sha": _git_sha(repo_root),
+        "platform": platform.platform(),
+        "runner_os": os.environ.get("RUNNER_OS", platform.system()),
+        "runner_image": os.environ.get("ImageOS", "local"),
+        "physical_memory_bytes": int(resolve_physical_memory_bytes()),
+        "python": platform.python_version(),
+        "pyside": pyside_version,
+        "qt": qVersion(),
+        "warm_samples": max(1, warm_samples),
+        "results": results,
+    }
+
+
+def compare(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    baseline_by_size = {int(row["size_mib"]): row for row in baseline["results"]}
+    checks: list[dict[str, Any]] = []
+    for row in candidate["results"]:
+        size = int(row["size_mib"])
+        old = baseline_by_size[size]
+        tolerance = max(float(old["warm_hit_p95_ms"]) * 0.05, 10.0)
+        warm_limit = float(old["warm_hit_p95_ms"]) + tolerance
+        payload = int(row["payload_bytes"])
+        checks.extend(
+            [
+                {
+                    "name": f"{size}MiB.trusted_hit_checksum_calls",
+                    "actual": int(row["checksum_calls"]),
+                    "limit": 0,
+                    "passed": int(row["checksum_calls"]) == 0,
+                },
+                {
+                    "name": f"{size}MiB.python_peak_bytes",
+                    "actual": int(row["python_peak_bytes"]),
+                    "limit": 8 * _MIB + 4096,
+                    "passed": int(row["python_peak_bytes"]) <= 8 * _MIB + 4096,
+                },
+                {
+                    "name": f"{size}MiB.rss_write_delta_bytes",
+                    "actual": int(row["rss_write_delta_bytes"]),
+                    "limit": max(16 * _MIB, int(payload * 0.25)),
+                    "passed": int(row["rss_write_delta_bytes"])
+                    <= max(16 * _MIB, int(payload * 0.25)),
+                },
+                {
+                    "name": f"{size}MiB.warm_hit_p95_ms",
+                    "actual": float(row["warm_hit_p95_ms"]),
+                    "limit": round(warm_limit, 3),
+                    "passed": float(row["warm_hit_p95_ms"]) <= warm_limit,
+                },
+            ]
+        )
+    return {
+        "schema": 1,
+        "baseline_sha": baseline.get("commit_sha"),
+        "candidate_sha": candidate.get("commit_sha"),
+        "passed": all(check["passed"] for check in checks),
+        "checks": checks,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("--output", required=True, type=Path)
+    run_parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    run_parser.add_argument("--label", default="candidate")
+    run_parser.add_argument("--sizes-mib", default="16,64,180")
+    run_parser.add_argument("--warm-samples", type=int, default=3)
+    compare_parser = subparsers.add_parser("compare")
+    compare_parser.add_argument("--baseline", required=True, type=Path)
+    compare_parser.add_argument("--candidate", required=True, type=Path)
+    compare_parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        sizes = tuple(
+            int(value.strip())
+            for value in str(args.sizes_mib).split(",")
+            if value.strip()
+        )
+        payload = benchmark(
+            sizes_mib=sizes,
+            warm_samples=max(1, int(args.warm_samples)),
+            repo_root=args.repo_root,
+            label=str(args.label),
+        )
+        _write_json(args.output, payload)
+        return 0
+
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+    candidate = json.loads(args.candidate.read_text(encoding="utf-8"))
+    result = compare(baseline, candidate)
+    _write_json(args.output, result)
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/detail_surface_cache_benchmark.py
+++ b/tools/detail_surface_cache_benchmark.py
@@ -39,7 +39,7 @@ from iPhoto.infrastructure.services.thumbnail_runtime_policy import (
 )
 
 _MIB = 1024 * 1024
-_P95_MIN_SAMPLES = 20
+_P95_MIN_SAMPLES = 40
 
 try:
     import xxhash as benchmark_xxhash
@@ -187,6 +187,7 @@ def _measure_store_hit(
 ) -> dict[str, Any]:
     rss_before, faults_before = _process_metrics()
     total_started = time.perf_counter()
+    cpu_started = time.process_time()
     load_started = total_started
     loaded = store.load(request)
     load_ms = (time.perf_counter() - load_started) * 1000.0
@@ -196,6 +197,7 @@ def _measure_store_hit(
     digest = _consume_image(loaded.image)
     consume_ms = (time.perf_counter() - consume_started) * 1000.0
     total_ms = (time.perf_counter() - total_started) * 1000.0
+    cpu_ms = (time.process_time() - cpu_started) * 1000.0
     rss_after, faults_after = _process_metrics()
     del loaded
     gc.collect()
@@ -203,6 +205,7 @@ def _measure_store_hit(
         "load_ms": load_ms,
         "consume_ms": consume_ms,
         "load_to_consumed_ms": total_ms,
+        "process_cpu_ms": cpu_ms,
         "rss_delta_bytes": max(0, rss_after - rss_before),
         "page_faults": max(0, faults_after - faults_before),
         "consumption_digest": digest,


### PR DESCRIPTION
## Summary

- finish TD-890-01 without expanding into TD-890-02 budget enforcement
- replace hot-path payload hashing, full Python payload copies, and per-write directory scans with a v3 SQLite index, chunked writes, trusted mmap hits, and indexed LRU maintenance
- isolate library generations and make recovery, shutdown, SQLite failures, disk-capacity failures, and rebind races fail open
- serialize each canonical v3 cache namespace across processes; a secondary iPhotron process keeps browsing and decoding but temporarily disables only the surface disk tier
- retain full mmap payload CPU-consumption evidence while leaving real renderer coverage to the existing three-platform GPU-first contracts

Depends on #902 (merged). The PR targets `codex/startup-chain-optimization`, remains Draft, and does not change required-check or promotion policy.

## Cross-process namespace ownership

The prior process-session and SQLite lease markers were correct for overlapping generations in one process, but an in-memory lease registry could not distinguish a live owner in another process from a crashed session. A second iPhotron instance could therefore trigger a false O(N) recovery and later write `clean_shutdown=1` while the first process was still active.

The current head fixes that boundary before any SQLite access:

- `<library>/.iPhoto/cache/detail-surfaces/v3/index.sqlite3.lock` is held with long-lived `QLockFile` semantics: stale time 0 and non-blocking acquisition
- cache roots, lock keys, and backend generation identities use canonical resolved paths, including symlink/junction aliases
- same-process A1/A2 generations share the OS lock by refcount; the final index close releases it only after the SQLite lease is released
- a secondary process that cannot acquire the lock does not open, rebuild, rename, or clean-close SQLite and does not glob, write, audit, or prune payloads
- disk lookup becomes a miss, so original decode and the bounded memory cache continue normally
- acquisition is retried at most once per 30-second monotonic interval; a clean handoff opens without a payload scan, while a crashed owner follows the existing dirty recovery scan
- lock contention, permission failure, and other lock I/O failures are exposed as one diagnostic event per store generation and never reach the UI

No persistent heartbeat or multi-process writer lease was added. The invariant is one process writer per rebuildable v3 cache namespace, not one process per library.

## Recovery and lifecycle model

- clean/fresh bind calls ordinary maintenance; only persistent recovery state enters the payload scan
- every library root receives an immutable store generation with ordered asynchronous close barriers
- stale generation results cannot repopulate the active memory cache
- shutdown timeout never clean-closes ahead of accepted I/O
- runtime SQLite `DatabaseError` closes the connection and fails open to original decode while retaining namespace ownership until permanent store close
- replace/upsert and prune failures preserve payload/index consistency or persist recovery-required
- unavailable disk capacity never means zero budget; explicit `budget_bytes=0` keeps its intentional clear-all contract
- closed stores and indexes cannot reopen

## v3 performance and corruption contracts

- trusted hits validate index/header/digest/schema/geometry/file length/mtime and mmap without a full payload checksum
- writes stream `QImage.constBits()` in 4 MiB chunks, hash incrementally, fsync, atomically replace, then commit metadata
- access timestamps are batched and prune uses indexed bytes plus bounded LRU batches
- checksum remains on initial write, untrusted recovery, deterministic sampling, and 30-day audit
- benchmark schema 2 records load-only and full CPU payload-consumption latency, page faults, RSS, Python allocation peak, digest, and raw samples for 16/64/180 MiB fixtures
- the fixed `fe623e68` comparison retains the `baseline + max(5%, 10 ms)` gate and zero internal checksum calls on trusted hits

This evidence is full CPU payload consumption, not a claim that mmap load time equals GPU upload time.

## v6.6.8 compatibility

Tag `v6.6.8` has no neutral-surface persistence format. A supported upgrade therefore initializes v3 from an empty namespace; this PR does not read or migrate the development-only v2 cache.

## Current implementation and local validation

Implementation commits:

- `b839950a` serialize canonical cache ownership across processes
- `f1aac226` add real secondary-process, crash, retry, alias, and lock-failure contracts
- `50b46215` preserve source membership through canonical path aliases
- `6bb3bdbc` record the implementation-head validation state
- `5d87c1ed` record the verified process-lock CI evidence and restore TD-890-01 to `automated_pass`

Local results for head `6bb3bdbc`:

- cache plus benchmark: 59 passed
- Detail/GPU-first group: 137 passed, 1 Windows-only WIC skip
- startup contracts: 108 passed
- complete pytest: 2928 passed, 16 skipped
- architecture checks, compileall, focused Ruff F/E9, and `git diff --check`: passed

## CI status

Implementation/validation head `6bb3bdbc` completed [Run 31379327676](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31379327676) with all 14 non-Windows-long-tail jobs successful. This includes the complete test job plus three-platform surface-cache, GPU-first, and startup jobs. Ubuntu, macOS, and Windows raw cache artifacts were verified.

Final evidence-only head `5d87c1ed` repeated the same closure gates in [Run 31379761360](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31379761360): complete test, all three surface-cache jobs, all three GPU-first jobs, and all three startup jobs completed successfully. All three final-head cache artifacts are present.

Windows Pets production-shape remains enabled, unweakened, and in progress. It is tracked under TD-890-03 and is not a blocker for this closure; the PR does not claim that the entire workflow has completed while that job is running.

## Rollback

The v3 payload and index are rebuildable cache data only. Reverting the process-lock commits restores the previous PR behavior; deleting `detail-surfaces/v3` does not remove user library data.

## Out of scope

- TD-890-02 CPU/session leases, RAW admission/fallback, and unified GPU budgets
- TD-890-03 Windows Pets optimization
- TD-890-04 required-check/promotion policy
- rewriting PR #890 history

The PR remains Draft and will not be merged or marked Ready as part of this closure.