### PR TITLE
Fix PR #890 cache retirement and scheduling blockers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, codex/startup-chain-optimization]
+    branches: [main, edit-base]
   pull_request:
-    branches: [main, codex/startup-chain-optimization, codex/pets-review-remediation]
+    branches: [main, edit-base, codex/startup-chain-optimization]
 
 permissions:
   contents: read

--- a/src/iPhoto/gui/detail_request_scheduler.py
+++ b/src/iPhoto/gui/detail_request_scheduler.py
@@ -29,8 +29,9 @@ class DetailStillRequestScheduler(QObject):
 
     Native image decoders cannot reliably be interrupted once running.  The
     scheduler therefore promotes or subscribes to an existing same-key task
-    instead of launching a second decoder, while unrelated running stale tasks
-    are allowed to finish without publishing into the active generation.
+    instead of launching a second decoder.  Unrelated running stale tasks are
+    cooperatively cancelled and retained until their terminal signal, while the
+    queue keeps only the latest foreground request.
     """
 
     ready = Signal(int, object)
@@ -198,10 +199,18 @@ class DetailStillRequestScheduler(QObject):
         self._current_generation += 1
         self._prefetch_queue.clear()
         self._active_window_generation += 1
-        for entry in tuple(self._inflight_by_key.values()):
+        for entry in tuple(self._entry_by_worker_id.values()):
             entry.foreground_generation = None
+            cancel = getattr(entry.worker, "cancel", None)
+            if callable(cancel):
+                cancel()
             if entry.state == "queued" and self._pool.tryTake(entry.worker):
-                self._retire_entry(entry, cancel=True)
+                self._retire_entry(entry, cancel=False)
+            elif self._inflight_by_key.get(entry.key) is entry:
+                # A cancelled running worker remains owned through
+                # ``_entry_by_worker_id`` until its terminal signal, but it can
+                # no longer satisfy a later same-key request.
+                self._inflight_by_key.pop(entry.key, None)
 
     def shutdown(self, *, timeout_ms: int = 1500) -> None:
         """Cancel queued/running work and wait for the dedicated pool."""
@@ -211,7 +220,7 @@ class DetailStillRequestScheduler(QObject):
         self._shutting_down = True
         self._current_generation += 1
         self._prefetch_queue.clear()
-        for entry in tuple(self._inflight_by_key.values()):
+        for entry in tuple(self._entry_by_worker_id.values()):
             entry.foreground_generation = None
             cancel = getattr(entry.worker, "cancel", None)
             if callable(cancel):
@@ -221,7 +230,7 @@ class DetailStillRequestScheduler(QObject):
         self._pool.clear()
         completed = self._pool.waitForDone(max(0, int(timeout_ms)))
         if completed:
-            for entry in tuple(self._inflight_by_key.values()):
+            for entry in tuple(self._entry_by_worker_id.values()):
                 self._retire_entry(entry, cancel=False)
 
     def _create_entry(
@@ -275,9 +284,16 @@ class DetailStillRequestScheduler(QObject):
                 self._retire_entry(entry, cancel=True)
 
     def _detach_running_other_keys(self, active_key: DetailDecodeKey) -> None:
-        for entry in self._inflight_by_key.values():
+        for entry in tuple(self._inflight_by_key.values()):
             if entry.key != active_key:
                 entry.foreground_generation = None
+                cancel_worker = getattr(entry.worker, "cancel", None)
+                if callable(cancel_worker):
+                    cancel_worker()
+                if self._inflight_by_key.get(entry.key) is entry:
+                    # Retain lifecycle ownership by worker id, but do not reuse
+                    # a cancellation token that can never become active again.
+                    self._inflight_by_key.pop(entry.key, None)
 
     def _on_worker_started(self, worker: object) -> None:
         entry = self._entry_by_worker_id.get(id(worker))

--- a/src/iPhoto/gui/detail_surface_cache.py
+++ b/src/iPhoto/gui/detail_surface_cache.py
@@ -12,8 +12,8 @@ import tempfile
 import time
 from collections import OrderedDict
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor, wait
-from dataclasses import dataclass, field, replace
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, replace
 from pathlib import Path
 from threading import Event, RLock
 from typing import Final
@@ -938,12 +938,13 @@ class _SurfaceStoreGeneration:
     library_root: Path | None
     store: NeutralSurfaceStore
     retired: bool = False
+    retirement_started: bool = False
+    io_drained: bool = False
     close_submitted: bool = False
+    closed: bool = False
     active_calls: int = 0
-    drained: Event = field(default_factory=Event)
-
-    def __post_init__(self) -> None:
-        self.drained.set()
+    retire_barrier: Future | None = None
+    close_future: Future | None = None
 
 
 def _normalise_library_root(library_root: Path | None) -> Path | None:
@@ -980,11 +981,14 @@ class CachedStillDecodeBackend:
             library_root=initial_root,
             store=initial_store,
         )
+        self._store_generations: dict[int, _SurfaceStoreGeneration] = {
+            self._store_epoch: self._active_store_generation
+        }
         self._io = ThreadPoolExecutor(max_workers=1, thread_name_prefix="iPhoto-surface-cache")
         self._futures: set[Future] = set()
         self._lock = RLock()
         self._shutting_down = False
-        self._shutdown_barrier: Future | None = None
+        self._shutdown_complete = Event()
         self._executor_shutdown = False
         self._color_stats_by_source: OrderedDict[tuple, ColorStats] = OrderedDict()
 
@@ -1011,11 +1015,12 @@ class CachedStillDecodeBackend:
                 library_root=normalised_root,
                 store=replacement,
             )
+            self._store_generations[generation.epoch] = generation
             current.retired = True
             self._active_store_generation = generation
             self._color_stats_by_source.clear()
             self.memory_cache.clear()
-            self._queue_store_close_locked(current)
+            self._begin_generation_retirement_locked(current)
             self._submit_generation_locked(generation, replacement.maintenance)
 
     @staticmethod
@@ -1160,7 +1165,6 @@ class CachedStillDecodeBackend:
             generation = self._active_store_generation
             self._raise_if_generation_stale_locked(generation, cancellation)
             generation.active_calls += 1
-            generation.drained.clear()
             return generation
 
     def _release_store_generation(
@@ -1170,7 +1174,7 @@ class CachedStillDecodeBackend:
         with self._lock:
             generation.active_calls = max(0, generation.active_calls - 1)
             if generation.active_calls == 0:
-                generation.drained.set()
+                self._maybe_submit_generation_close_locked(generation)
 
     def _write_surface(
         self,
@@ -1254,19 +1258,102 @@ class CachedStillDecodeBackend:
         _ = generation
         return fn(*args, **kwargs)
 
-    def _queue_store_close_locked(
+    def _begin_generation_retirement_locked(
         self,
         generation: _SurfaceStoreGeneration,
     ) -> Future | None:
-        if generation.close_submitted:
+        if generation.retirement_started:
+            self._maybe_submit_generation_close_locked(generation)
+            return generation.retire_barrier
+        generation.retirement_started = True
+        barrier = self._submit_raw_locked(lambda: None)
+        generation.retire_barrier = barrier
+        if barrier is None:
+            generation.io_drained = True
+            self._maybe_submit_generation_close_locked(generation)
             return None
+        barrier.add_done_callback(
+            lambda completed, active=generation: self._on_generation_io_drained(
+                active,
+                completed,
+            )
+        )
+        return barrier
+
+    def _on_generation_io_drained(
+        self,
+        generation: _SurfaceStoreGeneration,
+        barrier: Future,
+    ) -> None:
+        with self._lock:
+            if generation.retire_barrier is not barrier:
+                return
+            generation.io_drained = True
+            self._maybe_submit_generation_close_locked(generation)
+
+    def _maybe_submit_generation_close_locked(
+        self,
+        generation: _SurfaceStoreGeneration,
+    ) -> Future | None:
+        if (
+            not generation.retired
+            or not generation.retirement_started
+            or not generation.io_drained
+            or generation.active_calls > 0
+            or generation.close_submitted
+            or generation.closed
+        ):
+            return generation.close_future
         generation.close_submitted = True
-        return self._submit_raw_locked(self._close_generation_store, generation)
+        future = self._submit_raw_locked(self._close_generation_store, generation)
+        if future is None:
+            generation.close_submitted = False
+            return None
+        generation.close_future = future
+        future.add_done_callback(
+            lambda completed, active=generation: self._on_generation_closed(
+                active,
+                completed,
+            )
+        )
+        return future
 
     @staticmethod
     def _close_generation_store(generation: _SurfaceStoreGeneration) -> None:
-        generation.drained.wait()
         generation.store.close()
+
+    def _on_generation_closed(
+        self,
+        generation: _SurfaceStoreGeneration,
+        future: Future,
+    ) -> None:
+        error: Exception | None = None
+        try:
+            future.result()
+        except Exception as exc:  # noqa: BLE001 - cache close is best-effort at shutdown
+            error = exc
+        with self._lock:
+            generation.closed = True
+            self._store_generations.pop(generation.epoch, None)
+            finish_shutdown = self._shutting_down and not self._store_generations
+        if error is not None:
+            emit_detail_event(
+                "surface_cache_close_failed",
+                generation=0,
+                store_epoch=generation.epoch,
+                error=str(error),
+            )
+        if finish_shutdown:
+            self._finish_executor_shutdown()
+
+    def _finish_executor_shutdown(self) -> None:
+        with self._lock:
+            if self._executor_shutdown:
+                self._shutdown_complete.set()
+                return
+            self._executor_shutdown = True
+        self._io.shutdown(wait=False, cancel_futures=False)
+        self._shutdown_complete.set()
 
     def _submit_raw_locked(self, fn, *args, **kwargs) -> Future | None:
         try:
@@ -1282,21 +1369,19 @@ class CachedStillDecodeBackend:
             self._futures.discard(future)
 
     def shutdown(self, *, timeout_ms: int = 1000) -> None:
+        finish_shutdown = False
         with self._lock:
             if not self._shutting_down:
                 self._shutting_down = True
                 generation = self._active_store_generation
                 generation.retired = True
-                self._queue_store_close_locked(generation)
-                self._shutdown_barrier = self._submit_raw_locked(lambda: None)
-            barrier = self._shutdown_barrier
-        completed = not bool(barrier)
-        if barrier is not None:
-            done, _pending = wait(
-                (barrier,),
-                timeout=max(0, int(timeout_ms)) / 1000.0,
-            )
-            completed = barrier in done
+                self._begin_generation_retirement_locked(generation)
+            finish_shutdown = not self._store_generations
+        if finish_shutdown:
+            self._finish_executor_shutdown()
+        completed = self._shutdown_complete.wait(
+            timeout=max(0, int(timeout_ms)) / 1000.0,
+        )
         if not completed:
             with self._lock:
                 pending_count = len(self._futures)
@@ -1306,11 +1391,6 @@ class CachedStillDecodeBackend:
                 pending=pending_count,
             )
         self.memory_cache.clear()
-        with self._lock:
-            if self._executor_shutdown:
-                return
-            self._executor_shutdown = True
-        self._io.shutdown(wait=False, cancel_futures=False)
 
 
 __all__ = [

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -317,13 +317,14 @@ class _PreparationEntry:
 
 
 class StillImageDecodeScheduler(QThreadPool):
-    """Two-lane latest-wins scheduler for non-cancellable native decoders."""
+    """Two-lane latest-only queue with one-stuck-worker bypass."""
 
     def __init__(self, parent: QObject | None = None) -> None:
         super().__init__(parent)
         # One native decoder may be stuck in an uninterruptible codec call. A
         # second lane lets the newest request bypass it; queued middle requests
-        # are removed by ``tryTake`` and running stale results are discarded.
+        # are removed by ``tryTake`` and running stale workers are cooperatively
+        # cancelled so they stop at the first checkpoint after native work.
         self.setMaxThreadCount(2)
         self.setThreadPriority(QThread.Priority.HighPriority)
 

--- a/tests/gui/test_detail_request_scheduler.py
+++ b/tests/gui/test_detail_request_scheduler.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
+from threading import Event
 
-from PySide6.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
 from PySide6.QtGui import QImage
 
 from iPhoto.gui.detail_decode_backend import DecodedSurface
@@ -86,6 +88,57 @@ class _FakePool:
     def waitForDone(self, timeout_ms: int) -> bool:
         self.wait_timeout = timeout_ms
         return self.wait_result
+
+
+class _BlockingWorker(QRunnable):
+    def __init__(self, request: DetailRenderRequest, release: Event) -> None:
+        super().__init__()
+        self.setAutoDelete(False)
+        self.request = request.with_decode_level()
+        self.source = request.source_identity.path
+        self.signals = _WorkerSignals()
+        self.release = release
+        self.started = Event()
+        self.cancelled = Event()
+        self.cache_hit = False
+
+    def cancel(self) -> None:
+        self.cancelled.set()
+
+    def update_request(self, request: DetailRenderRequest) -> None:
+        self.request = request.with_decode_level()
+
+    def run(self) -> None:
+        self.signals.started.emit(self)
+        self.started.set()
+        try:
+            if not self.release.wait(5) or self.cancelled.is_set():
+                return
+            image = QImage(8, 8, QImage.Format.Format_RGBA8888)
+            image.fill(0xFF112233)
+            self.signals.completed.emit(
+                DecodedSurface(
+                    image=image,
+                    decode_key=DetailDecodeKey.from_request(self.request),
+                    source_size=(8, 8),
+                    decoded_size=(8, 8),
+                    decode_level=self.request.decode_level or "full",
+                    backend="blocking-fake",
+                )
+            )
+        finally:
+            self.signals.finished.emit(self)
+
+
+def _spin_until(qapp, predicate, *, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.005)
+    qapp.processEvents()
+    return bool(predicate())
 
 
 def _harness() -> tuple[
@@ -218,10 +271,85 @@ def test_new_asset_bypasses_running_stale_decoder_and_stale_never_presents(
 
     # B has started on the second lane before uninterruptible A completes.
     assert len(pool.starts) == 2
+    assert worker_a.cancelled
     pool.complete(worker_a)
     pool.complete(worker_b)
 
     assert presented == [(2, source_b)]
+
+
+def test_real_two_lane_pool_cancels_stale_workers_and_starts_latest_next(
+    qapp,
+    tmp_path: Path,
+) -> None:
+    pool = QThreadPool()
+    pool.setMaxThreadCount(2)
+    workers: dict[str, _BlockingWorker] = {}
+    releases: dict[str, Event] = {}
+
+    def factory(request: DetailRenderRequest) -> _BlockingWorker:
+        release = Event()
+        worker = _BlockingWorker(request, release)
+        workers[request.asset_id] = worker
+        releases[request.asset_id] = release
+        return worker
+
+    scheduler = DetailStillRequestScheduler(pool=pool, worker_factory=factory)
+    presented: list[tuple[int, Path]] = []
+    scheduler.ready.connect(
+        lambda generation, surface: presented.append(
+            (generation, surface.decode_key.source)
+        )
+    )
+    source_a = tmp_path / "a.raw"
+    source_b = tmp_path / "b.raw"
+    source_c = tmp_path / "c.jpg"
+
+    try:
+        assert scheduler.request(_request(source_a, asset_id="A", generation=1))
+        assert workers["A"].started.wait(5)
+        assert _spin_until(
+            qapp,
+            lambda: scheduler._inflight_by_key[
+                DetailDecodeKey.from_request(
+                    _request(source_a, asset_id="A", generation=1)
+                )
+            ].state
+            == "running",
+        )
+
+        assert scheduler.request(_request(source_b, asset_id="B", generation=2))
+        assert workers["B"].started.wait(5)
+        assert _spin_until(
+            qapp,
+            lambda: scheduler._inflight_by_key[
+                DetailDecodeKey.from_request(
+                    _request(source_b, asset_id="B", generation=2)
+                )
+            ].state
+            == "running",
+        )
+
+        assert scheduler.request(_request(source_c, asset_id="C", generation=3))
+
+        assert workers["A"].cancelled.is_set()
+        assert workers["B"].cancelled.is_set()
+        assert not workers["C"].started.is_set()
+
+        releases["B"].set()
+        assert workers["C"].started.wait(5)
+        assert not releases["A"].is_set()
+
+        releases["C"].set()
+        assert _spin_until(qapp, lambda: presented == [(3, source_c)])
+    finally:
+        for release in releases.values():
+            release.set()
+        assert pool.waitForDone(5000)
+        qapp.processEvents()
+        scheduler.shutdown(timeout_ms=1000)
+
+    assert presented == [(3, source_c)]
 
 
 def test_repeated_click_updates_generation_without_parallel_same_key_decoder(
@@ -241,6 +369,30 @@ def test_repeated_click_updates_generation_without_parallel_same_key_decoder(
 
     assert len(workers) == 1
     assert presented == [2]
+
+
+def test_cancelled_running_key_is_not_reused_after_a_b_a_navigation(
+    tmp_path: Path,
+) -> None:
+    scheduler, pool, workers = _harness()
+    source_a = tmp_path / "a.raw"
+    source_b = tmp_path / "b.raw"
+
+    assert scheduler.request(_request(source_a, asset_id="A", generation=1))
+    first_a = workers[0]
+    pool.mark_running(first_a)
+
+    assert scheduler.request(_request(source_b, asset_id="B", generation=2))
+    worker_b = workers[1]
+    pool.mark_running(worker_b)
+    assert first_a.cancelled
+
+    assert scheduler.request(_request(source_a, asset_id="A", generation=3))
+
+    assert worker_b.cancelled
+    assert len(workers) == 3
+    assert workers[2] is not first_a
+    assert workers[2].request.generation == 3
 
 
 def test_different_decode_levels_do_not_reuse_the_same_worker(tmp_path: Path) -> None:

--- a/tests/gui/test_detail_surface_cache.py
+++ b/tests/gui/test_detail_surface_cache.py
@@ -1157,6 +1157,68 @@ def test_rebind_returns_before_old_store_io_drains(tmp_path: Path) -> None:
     assert old_closed.is_set()
 
 
+def test_rebind_new_generation_io_progresses_while_old_decode_is_active(
+    tmp_path: Path,
+) -> None:
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    request = _request(old_root / "photo.jpg")
+    decode_started = Event()
+    release_decode = Event()
+    new_maintenance = Event()
+    new_io_progress = Event()
+    old_closed = Event()
+    old_store = Mock()
+    old_store.library_root = old_root.absolute()
+
+    def slow_load(_request: DetailRenderRequest) -> None:
+        decode_started.set()
+        assert release_decode.wait(5)
+        return None
+
+    old_store.load.side_effect = slow_load
+    old_store.close.side_effect = old_closed.set
+    new_store = Mock()
+    new_store.library_root = new_root.absolute()
+    new_store.maintenance.side_effect = new_maintenance.set
+    backend = CachedStillDecodeBackend(
+        Mock(),
+        store=old_store,
+        store_factory=Mock(return_value=new_store),
+    )
+    failures: list[BaseException] = []
+
+    def decode() -> None:
+        try:
+            backend.decode(request, _Token())
+        except DecodeCancelledError as exc:
+            failures.append(exc)
+
+    worker = Thread(target=decode)
+    worker.start()
+    assert decode_started.wait(5)
+
+    try:
+        backend.bind_library(new_root)
+        new_generation = backend._active_store_generation
+        backend._submit_for_generation(new_generation, new_io_progress.set)
+
+        assert new_maintenance.wait(5)
+        assert new_io_progress.wait(5)
+        assert not old_closed.is_set()
+    finally:
+        release_decode.set()
+        worker.join(timeout=5)
+        backend.shutdown(timeout_ms=5000)
+
+    assert not worker.is_alive()
+    assert old_closed.is_set()
+    assert len(failures) == 1
+    assert isinstance(failures[0], DecodeCancelledError)
+    old_store.close.assert_called_once_with()
+    new_store.close.assert_called_once_with()
+
+
 def test_a_b_a_rebind_keeps_latest_library_lease_dirty(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1275,6 +1337,8 @@ def test_shutdown_timeout_closes_store_after_active_decode_finishes(
     worker.join(timeout=5)
     assert not worker.is_alive()
     assert closed.wait(5)
+    assert backend._shutdown_complete.wait(5)
+    assert backend._executor_shutdown
     assert len(failures) == 1
     assert isinstance(failures[0], DecodeCancelledError)
 


### PR DESCRIPTION
## Summary

- replace blocking surface-cache generation retirement with a non-blocking I/O barrier and eventual-close lifecycle
- cooperatively cancel running stale decoders, detach cancelled workers from same-key reuse, and preserve lifecycle ownership until completion
- document and test the two-lane scheduler as a latest-only queue with one-stuck-worker bypass
- route CI for PRs targeting `main`, `edit-base`, and the PR #890 head branch, while validating pushes to `main` and `edit-base`

## Root cause

A retired store previously executed `generation.drained.wait()` inside the only surface-cache I/O worker. An uninterruptible old-library decode could therefore block all maintenance, writes, audits, and access flushes for the newly bound library.

Running stale decoder entries were also only detached from foreground delivery. They were not cancelled, and a cancelled worker could be reused during A → B → A navigation unless reusable-key indexing was separated from worker lifecycle ownership.

## Validation

- `149 passed, 1 skipped` for the local detail GPU-first test set; the skip is the Windows-only WIC contract
- `76 passed` for focused surface-cache, scheduler, render-session, and benchmark tests
- architecture boundary check passed
- `compileall`, Ruff F/E9 checks, and `git diff --check` passed
- macOS surface-cache rerun for PR #890 head `7d33f963…` passed on attempt 2: https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31384392746/job/93453382492

## Compatibility

The changes are forward-only and do not add database migrations or compatibility reads. Surface-cache data remains rebuildable.