### PR TITLE
Fix PR #890 preparation and CI merge blockers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, edit-base]
-  pull_request:
     branches: [main, edit-base, codex/startup-chain-optimization]
+  pull_request:
+    branches: [main, edit-base]
 
 permissions:
   contents: read
@@ -43,7 +43,6 @@ jobs:
         run: python -m pytest -q tests/contracts/test_pets_scale_contract.py
 
   pets-production-shape-contract:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/docs/requirements/gallery-detail-gpu-first/PHASE2_VIEWPORT_DECODER_HANDOFF.md
+++ b/docs/requirements/gallery-detail-gpu-first/PHASE2_VIEWPORT_DECODER_HANDOFF.md
@@ -53,9 +53,9 @@ GUI thread
   -> 由内存索引构造 AssetSourceIdentity（点击/hover 不 stat）
   -> 读取 viewer layout + DPR，选择 LOD，提交完整 request
 
-sidecar preparation pool (1 lane)
-  -> read_adjustments，仅保留进行中的同源结果
-  -> hover/click 可 promotion/reuse
+sidecar preparation pool (2 lanes)
+  -> read_adjustments；latest-only queue 可绕过一个卡住的 native RAW probe
+  -> hover/click 可 promotion/reuse；running stale cooperative cancel 后不再按 key 复用
   -> 完成后释放，不形成 edit-state cache
 
 still decode pool (2 lanes)

--- a/docs/requirements/gallery-detail-gpu-first/PHASE2_VIEWPORT_DECODER_HANDOFF.md
+++ b/docs/requirements/gallery-detail-gpu-first/PHASE2_VIEWPORT_DECODER_HANDOFF.md
@@ -54,7 +54,8 @@ GUI thread
   -> 读取 viewer layout + DPR，选择 LOD，提交完整 request
 
 sidecar preparation pool (2 lanes)
-  -> read_adjustments；latest-only queue 可绕过一个卡住的 native RAW probe
+  -> 最多 1 个 speculative preparation；previous/next 使用 bounded window queue
+  -> 第二 lane 保留给 latest foreground，允许绕过一个卡住的 native RAW probe
   -> hover/click 可 promotion/reuse；running stale cooperative cancel 后不再按 key 复用
   -> 完成后释放，不形成 edit-state cache
 

--- a/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
+++ b/docs/requirements/startup-chain-optimization/PR_890_DEFERRED_TECHNICAL_DEBT.md
@@ -1,13 +1,13 @@
 # PR #890 延期技术债务台账
 
-更新日期：2026-08-10
+更新日期：2026-08-11
 
 ## 状态与范围
 
 - 原审查基线：`59c961875a5e337299cf7f2fb1bff59c63b74f93`
 - Bug-only 修复提交：`588682c29f526e9903dd90c32796bb7e3e744fe5`
 - 修复 PR：[#902](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/pull/902)
-- 当前状态：`deferred / not_started`
+- 当前状态：`remediation_in_progress / remote_pending`
 
 PR #902 只修复 PR #890 审查项 1–6、9，并补充第 10 项的正常解释器退出
 smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR 的组织方式，以及
@@ -23,8 +23,8 @@ smoke test。磁盘缓存性能、统一 surface/RAW 内存预算、历史 PR �
 | --- | --- | --- | --- | --- |
 | TD-890-01 | P1 | 磁盘 neutral-surface cache 的命中、写入和 prune 为高线性成本 | PR #903 已完成跨进程 cache namespace ownership，并通过全部非 Windows 长尾门禁 | `automated_pass` |
 | TD-890-02 | P1 | CPU/mmap/RenderSession/GPU/RAW 缺少统一字节所有权 | 只观测 tracker 已接入；预算执行与 lease 迁移仍未开始 | `in_progress` |
-| TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | PR #902 CI 中唯一非成功项，无法提供稳定的三平台 50k×384 证据 | `not_started` |
-| TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | 当前只保证本阶段 base/head 触发，向前合并后的同 SHA 证据仍需人工组织 | `not_started` |
+| TD-890-03 | P2 | Windows Pets production-shape 合同超过 30 分钟 job 上限 | SQLite connection/I/O 放大已在本地收口并加入阶段 metrics；仍需 Windows 连续两次 30 分钟内成功 | `local_pass_remote_pending` |
+| TD-890-04 | P2 | stacked branch 到 `edit-base`/`main` 的 CI promotion 策略未闭环 | strict head、merge-ref、merge-SHA 触发已写入 workflow；实际远端 run 证据待补 | `remote_pending` |
 | TD-890-05 | P3 | 大型跨子系统 PR 的回滚和归因边界不足 | 历史 PR 无法安全追溯拆分；未来同类变更仍可能形成不可独立回滚的组合 | `process_debt` |
 
 ## TD-890-01：磁盘 surface cache 的线性成本
@@ -199,10 +199,25 @@ PR #902 的 [GitHub Actions run 31333850127](https://github.com/OliverZhaohaibin
 成功。PR #902 没有修改 Pets repository 或该合同实现，因此未在 bug-only PR 中通过
 放宽 timeout、缩小数据规模或跳过 Windows 来制造绿灯。
 
+当前修复基线 `54eef7b3` 的
+[GitHub Actions run 31391123235](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31391123235)
+中，Windows production-shape 在测试运行约 27 分 50 秒后同样触发 30 分钟 job
+timeout 并被取消。针对该热点，本轮实现将 rejected keys、pet-key mapping、redirects
+和 durable profiles 合并为一次 state DB 只读快照；正常增量提交直接复用已构造的
+payload、pets、detections 和 runtime connection 完成 state sync、`state_synced` 标记与
+有界 prune。`sync_scan_results()` 的名称查询也复用同一 state connection，并新增正常
+warm batch 两个数据库合计不超过 4 次 connection open/close 的合同。
+
+本地 50k×384、batch=16、USearch production-shape 已在 30 分钟门槛内通过：growth
+65.26 秒、cold restart 3.86 秒、mutation 12.96 秒；growth 内 assignment 6.65 秒、
+state sync 24.72 秒、index update 0.08 秒、runtime mutation 33.45 秒。该结果证明实现
+与 metrics 合同可运行，但不能替代 Windows runner 证据，因此本项保持
+`local_pass_remote_pending`。
+
 ### 后续计划与验收
 
-1. 在 `_benchmark_growth()` 增加分阶段耗时和进度采样，区分 SQLite mutation、
-   USearch add/rebuild、restart、merge/delete 和 RSS probe。
+1. `_benchmark_growth()` 已增加每 5k 项进度和 assignment、runtime mutation、state
+   sync、index update、restart、mutation 分阶段耗时。
 2. 使用 Windows profiler/ETW 或等价工具确认 50k batch-16 增长的主热点，并与同一
    runner image 上的 Ubuntu/macOS 结构对比。
 3. 优先修复算法或 I/O 放大；只有在有稳定 P95 数据证明工作量合理且不可再优化时，
@@ -214,9 +229,14 @@ PR #902 的 [GitHub Actions run 31333850127](https://github.com/OliverZhaohaibin
 
 ## TD-890-04：CI promotion 与分支触发策略
 
-PR #902 当前只保证 `codex/startup-chain-optimization` 阶段的 pull request 和 push
-触发。`edit-base`/`main` 的向前合并、同一或组合 SHA 的重新验证，以及 stacked PR
-解除后的最终 required-check 策略未在本轮修改。
+当前 workflow 已按 strict policy 配置：push 覆盖 `main`、`edit-base` 和
+`codex/startup-chain-optimization`，pull request 只以 `main`、`edit-base` 作为 base
+filter；`pets-production-shape-contract` 不再按 event 跳过 push，三平台矩阵继续保持
+50k×384、batch=16 和 30 分钟门槛。静态 workflow 合同已锁定这些条件。
+
+远端仍需取得 exact head push、PR synthetic merge-ref，以及合并到 `edit-base` 后实际
+merge SHA 的正常事件成功 run；其中 Windows production-shape 还必须连续两次在 30
+分钟内完成。因此本项只能标记为 `remote_pending`，不能仅凭 workflow 修改关闭。
 
 后续应为每个实际 promotion base 明确：
 

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
+from typing import Literal
 
 from PySide6.QtCore import (
     QObject,
@@ -198,6 +199,7 @@ class _ScheduledStillSurfaceDecodeWorker(_StillSurfaceDecodeWorker):
 
 
 class _AdjustmentPreparationSignals(QObject):
+    started = Signal(object)
     ready = Signal(object, object)
     failed = Signal(object, str)
     finished = Signal(object)
@@ -230,6 +232,7 @@ class _AdjustmentPreparationWorker(QRunnable):
         self._cancelled = True
 
     def run(self) -> None:  # pragma: no cover - worker-thread filesystem boundary
+        self.signals.started.emit(self)
         try:
             if self._cancelled:
                 return
@@ -271,12 +274,12 @@ class _AdjustmentPreparationWorker(QRunnable):
             )
             if not self._cancelled:
                 self.signals.ready.emit(
-                    self.key,
+                    self,
                     PreparedStillState.create(adjustments, identity),
                 )
         except Exception as exc:  # noqa: BLE001 - edit providers have varied I/O failures
             if not self._cancelled:
-                self.signals.failed.emit(self.key, str(exc))
+                self.signals.failed.emit(self, str(exc))
         finally:
             self.signals.finished.emit(self)
 
@@ -313,6 +316,7 @@ class _PreparationEntry:
     worker: _AdjustmentPreparationWorker
     intents: list[_PreparedRequestIntent]
     priority: int
+    state: Literal["queued", "running"] = "queued"
     result: PreparedStillState | None = None
 
 
@@ -398,7 +402,10 @@ class PlayerViewController(QObject):
         self._still_scheduler.warmed.connect(self._on_scheduled_surface_warmed)
         self._still_scheduler.failed.connect(self._on_scheduled_image_failed)
         self._preparation_pool = QThreadPool(self)
-        self._preparation_pool.setMaxThreadCount(1)
+        # RAW geometry probing enters LibRaw and cannot always be physically
+        # interrupted.  Keep a second lane available so the newest foreground
+        # preparation can bypass one stale native worker.
+        self._preparation_pool.setMaxThreadCount(2)
         self._preparation_entries: dict[object, _PreparationEntry] = {}
         self._preparation_entry_by_worker: dict[int, _PreparationEntry] = {}
         self._raw_source_probe_cache: OrderedDict[
@@ -757,7 +764,7 @@ class PlayerViewController(QObject):
                     entry.worker.cancel()
                     self._retire_preparation_entry(entry)
                 else:
-                    entry.intents.clear()
+                    self._detach_running_preparation_entry(entry)
 
         signals = _AdjustmentPreparationSignals()
         edit_service = self._edit_service_getter() if self._edit_service_getter else None
@@ -771,6 +778,7 @@ class PlayerViewController(QObject):
         entry = _PreparationEntry(worker=worker, intents=[intent], priority=priority)
         self._preparation_entries[key] = entry
         self._preparation_entry_by_worker[id(worker)] = entry
+        signals.started.connect(self._on_adjustment_preparation_started)
         signals.ready.connect(self._on_adjustment_prepared)
         signals.failed.connect(self._on_adjustment_preparation_failed)
         signals.finished.connect(self._on_adjustment_preparation_finished)
@@ -781,9 +789,18 @@ class PlayerViewController(QObject):
             return False
         return True
 
-    def _on_adjustment_prepared(self, key: object, state: object) -> None:
-        entry = self._preparation_entries.get(key)
-        if entry is None or not isinstance(state, PreparedStillState):
+    def _on_adjustment_preparation_started(self, worker: object) -> None:
+        entry = self._preparation_entry_by_worker.get(id(worker))
+        if entry is not None:
+            entry.state = "running"
+
+    def _on_adjustment_prepared(self, worker: object, state: object) -> None:
+        entry = self._preparation_entry_by_worker.get(id(worker))
+        if (
+            entry is None
+            or self._preparation_entries.get(entry.worker.key) is not entry
+            or not isinstance(state, PreparedStillState)
+        ):
             return
         entry.result = state
         identity = state.source_identity
@@ -1026,9 +1043,12 @@ class PlayerViewController(QObject):
         getter = getattr(self._image_viewer, "maximum_texture_size", None)
         return max(1, int(getter())) if callable(getter) else 8192
 
-    def _on_adjustment_preparation_failed(self, key: object, message: str) -> None:
-        entry = self._preparation_entries.get(key)
-        if entry is None:
+    def _on_adjustment_preparation_failed(self, worker: object, message: str) -> None:
+        entry = self._preparation_entry_by_worker.get(id(worker))
+        if (
+            entry is None
+            or self._preparation_entries.get(entry.worker.key) is not entry
+        ):
             return
         for intent in tuple(entry.intents):
             if intent.reason != "prefetch" and intent.generation == self._request_generation:
@@ -1045,6 +1065,16 @@ class PlayerViewController(QObject):
             self._preparation_entries.pop(key, None)
         self._preparation_entry_by_worker.pop(id(entry.worker), None)
         entry.worker.signals.deleteLater()
+
+    def _detach_running_preparation_entry(self, entry: _PreparationEntry) -> None:
+        """Cancel stale delivery while retaining terminal worker ownership."""
+
+        entry.worker.cancel()
+        entry.intents.clear()
+        entry.result = None
+        key = entry.worker.key
+        if self._preparation_entries.get(key) is entry:
+            self._preparation_entries.pop(key, None)
 
     def _on_scheduled_image_ready(
         self,
@@ -1287,7 +1317,10 @@ class PlayerViewController(QObject):
 
         self.cancel_pending_image_requests()
         self._preparation_pool.clear()
-        self._preparation_pool.waitForDone(max(0, int(timeout_ms)))
+        preparation_done = self._preparation_pool.waitForDone(max(0, int(timeout_ms)))
+        if preparation_done:
+            for entry in tuple(self._preparation_entry_by_worker.values()):
+                self._retire_preparation_entry(entry)
         self._still_scheduler.shutdown(timeout_ms=timeout_ms)
         self._decode_backend.shutdown(timeout_ms=min(max(0, int(timeout_ms)), 1000))
         clear_residency = getattr(self._image_viewer, "clear_still_residency", None)
@@ -1684,6 +1717,8 @@ class PlayerViewController(QObject):
             entry.worker.cancel()
             if self._preparation_pool.tryTake(entry.worker):
                 self._retire_preparation_entry(entry)
+            else:
+                self._detach_running_preparation_entry(entry)
 
     def defer_still_updates(self, enabled: bool) -> None:
         """Control whether still frames should be applied immediately."""

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -408,6 +408,8 @@ class PlayerViewController(QObject):
         self._preparation_pool.setMaxThreadCount(2)
         self._preparation_entries: dict[object, _PreparationEntry] = {}
         self._preparation_entry_by_worker: dict[int, _PreparationEntry] = {}
+        self._preparation_prefetch_queue: list[_PreparedRequestIntent] = []
+        self._preparation_shutting_down = False
         self._raw_source_probe_cache: OrderedDict[
             tuple,
             AssetSourceIdentity,
@@ -705,8 +707,11 @@ class PlayerViewController(QObject):
     ) -> bool:
         """Warm the previous/next window without occupying both decode lanes."""
 
+        if self._preparation_shutting_down:
+            return False
         self._residency_window_generation += 1
         window_generation = self._residency_window_generation
+        self._replace_preparation_prefetch_window(window_generation)
         accepted = False
         for slot, candidate in zip(("previous", "next"), candidates[:2], strict=False):
             if isinstance(candidate, DetailPrefetchDescriptor):
@@ -728,6 +733,8 @@ class PlayerViewController(QObject):
         return accepted
 
     def _schedule_adjustment_preparation(self, intent: _PreparedRequestIntent) -> bool:
+        if self._preparation_shutting_down:
+            return False
         identity = intent.source_identity
         probe_key = (identity.path, identity.revision)
         cached_identity = self._raw_source_probe_cache.get(probe_key)
@@ -738,6 +745,8 @@ class PlayerViewController(QObject):
         key = (intent.asset_id, identity.path, identity.revision)
         existing = self._preparation_entries.get(key)
         priority = 1 if intent.reason != "prefetch" else -1
+        if priority > 0:
+            self._preparation_prefetch_queue.clear()
         if existing is not None:
             if existing.result is not None:
                 prepared_intent = replace(
@@ -751,10 +760,13 @@ class PlayerViewController(QObject):
             existing.intents.append(intent)
             if priority > existing.priority:
                 existing.worker.generation = int(intent.generation)
-            if priority > existing.priority and self._preparation_pool.tryTake(existing.worker):
                 existing.priority = priority
-                self._preparation_pool.start(existing.worker, priority)
+                if self._preparation_pool.tryTake(existing.worker):
+                    self._preparation_pool.start(existing.worker, priority)
             return True
+
+        if priority < 0 and self._preparation_entry_by_worker:
+            return self._queue_preparation_prefetch(intent)
 
         if priority > 0:
             for other_key, entry in tuple(self._preparation_entries.items()):
@@ -1058,6 +1070,7 @@ class PlayerViewController(QObject):
         entry = self._preparation_entry_by_worker.get(id(worker))
         if entry is not None:
             self._retire_preparation_entry(entry)
+            self._start_next_preparation_prefetch()
 
     def _retire_preparation_entry(self, entry: _PreparationEntry) -> None:
         key = entry.worker.key
@@ -1075,6 +1088,63 @@ class PlayerViewController(QObject):
         key = entry.worker.key
         if self._preparation_entries.get(key) is entry:
             self._preparation_entries.pop(key, None)
+
+    @staticmethod
+    def _preparation_intent_key(intent: _PreparedRequestIntent) -> tuple:
+        identity = intent.source_identity
+        return (intent.asset_id, identity.path, identity.revision)
+
+    def _queue_preparation_prefetch(self, intent: _PreparedRequestIntent) -> bool:
+        """Queue one current-window neighbor without consuming the bypass lane."""
+
+        if (
+            intent.residency_slot is None
+            or intent.window_generation != self._residency_window_generation
+        ):
+            return False
+        key = self._preparation_intent_key(intent)
+        self._preparation_prefetch_queue = [
+            queued
+            for queued in self._preparation_prefetch_queue
+            if queued.window_generation == intent.window_generation
+            and queued.residency_slot != intent.residency_slot
+            and self._preparation_intent_key(queued) != key
+        ]
+        self._preparation_prefetch_queue.append(intent)
+        self._preparation_prefetch_queue = self._preparation_prefetch_queue[-2:]
+        return True
+
+    def _replace_preparation_prefetch_window(self, window_generation: int) -> None:
+        """Invalidate speculative work from an older neighbor window."""
+
+        self._preparation_prefetch_queue.clear()
+        for entry in tuple(self._preparation_entries.values()):
+            if any(intent.reason != "prefetch" for intent in entry.intents):
+                continue
+            if any(
+                intent.window_generation == int(window_generation)
+                for intent in entry.intents
+            ):
+                continue
+            entry.worker.cancel()
+            entry.intents.clear()
+            entry.result = None
+            if self._preparation_pool.tryTake(entry.worker):
+                self._retire_preparation_entry(entry)
+            else:
+                self._detach_running_preparation_entry(entry)
+
+    def _start_next_preparation_prefetch(self) -> None:
+        """Drain at most one valid speculative intent when all workers are terminal."""
+
+        if self._preparation_shutting_down or self._preparation_entry_by_worker:
+            return
+        while self._preparation_prefetch_queue:
+            intent = self._preparation_prefetch_queue.pop(0)
+            if intent.window_generation != self._residency_window_generation:
+                continue
+            if self._schedule_adjustment_preparation(intent):
+                return
 
     def _on_scheduled_image_ready(
         self,
@@ -1315,6 +1385,7 @@ class PlayerViewController(QObject):
     def shutdown(self, *, timeout_ms: int = 1500) -> None:
         """Cancel queued preparation/decode work and flush profiling."""
 
+        self._preparation_shutting_down = True
         self.cancel_pending_image_requests()
         self._preparation_pool.clear()
         preparation_done = self._preparation_pool.waitForDone(max(0, int(timeout_ms)))
@@ -1465,6 +1536,11 @@ class PlayerViewController(QObject):
         """Discard prepared sidecar snapshots for one source path."""
 
         normalized_source = Path(source).expanduser().absolute()
+        self._preparation_prefetch_queue = [
+            intent
+            for intent in self._preparation_prefetch_queue
+            if intent.source_identity.path != normalized_source
+        ]
         for key, entry in tuple(self._preparation_entries.items()):
             if not isinstance(key, tuple) or len(key) < 2 or key[1] != normalized_source:
                 continue
@@ -1474,6 +1550,7 @@ class PlayerViewController(QObject):
             entry.worker.cancel()
             if self._preparation_pool.tryTake(entry.worker):
                 self._retire_preparation_entry(entry)
+        self._start_next_preparation_prefetch()
         pending = self._pending_layout_intent
         if pending is not None and pending[0].source_identity.path == normalized_source:
             self._pending_layout_intent = None
@@ -1694,6 +1771,7 @@ class PlayerViewController(QObject):
 
         self._request_generation += 1
         self._residency_window_generation += 1
+        self._preparation_prefetch_queue.clear()
         self._lod_timer.stop()
         self._cancel_stale_image_workers()
         self._loading_source = None

--- a/src/iPhoto/pets/repository.py
+++ b/src/iPhoto/pets/repository.py
@@ -30,7 +30,7 @@ from .repository_utils import (
     serialize_embedding,
     utc_now_iso,
 )
-from .state_repository import PetStateRepository
+from .state_repository import PetStateRepository, _IncrementalStateSnapshot
 
 LOGGER = logging.getLogger(__name__)
 
@@ -321,11 +321,16 @@ class PetRepository:
             return PetIncrementalCommitResult()
 
         staged = list(detections)
+        state_snapshot: _IncrementalStateSnapshot | None = None
         if self._state_repo is not None and staged:
-            rejected = self._state_repo.get_rejected_pet_keys(
+            state_snapshot = self._state_repo._load_incremental_state(
                 detection.pet_key for detection in staged
             )
-            staged = [detection for detection in staged if detection.pet_key not in rejected]
+            staged = [
+                detection
+                for detection in staged
+                if detection.pet_key not in state_snapshot.rejected_keys
+            ]
 
         contracts = {
             (
@@ -356,6 +361,7 @@ class PetRepository:
             existing_pets=existing_pets,
             candidate_index=candidate_index,
             match_context=match_context,
+            state_snapshot=state_snapshot,
             excluded_asset_ids=set(replaced_asset_ids),
             distance_threshold=distance_threshold,
         )
@@ -632,16 +638,26 @@ class PetRepository:
             }
             self._write_runtime_commit(conn, effective_operation_id, commit_payload)
             conn.commit()
-
-        if contract_replacement_pet_ids or consumed_migration_candidate:
-            self._invalidate_profile_indexes()
-        elif embedding_contract is not None:
-            self._update_profile_indexes(
-                embedding_contract,
-                affected_pet_ids=affected_pet_ids,
-                rebuilt_pets=rebuilt_pets,
+            if contract_replacement_pet_ids or consumed_migration_candidate:
+                self._invalidate_profile_indexes()
+            elif embedding_contract is not None:
+                self._update_profile_indexes(
+                    embedding_contract,
+                    affected_pet_ids=affected_pet_ids,
+                    rebuilt_pets=rebuilt_pets,
+                )
+            # The runtime commit is durable before state sync begins.  Reuse
+            # the already-open runtime connection for the terminal marker and
+            # pruning, while preserving the unsynced marker if state I/O fails.
+            self._sync_runtime_state_payload(
+                commit_payload,
+                rebuilt_pets,
+                runtime_detections,
             )
-        self.complete_runtime_state_sync(effective_operation_id)
+            self._mark_runtime_state_synced(conn, effective_operation_id)
+            if str(effective_operation_id).startswith("internal-"):
+                self._prune_runtime_commits_in_connection(conn)
+            conn.commit()
         return PetIncrementalCommitResult(
             changed_asset_ids=changed_asset_ids,
             retired_asset_ids=retired_asset_ids,
@@ -801,6 +817,26 @@ class PetRepository:
             detection_rows = self._select_detections_by_pet_ids(conn, affected_pet_ids)
         pets = [self._pet_from_row(row) for row in pet_rows]
         detections = [self._detection_from_row(row) for row in detection_rows]
+        self._sync_runtime_state_payload(payload, pets, detections)
+        with closing(self._connect()) as conn:
+            self._mark_runtime_state_synced(conn, operation_id)
+            if str(operation_id).startswith("internal-"):
+                self._prune_runtime_commits_in_connection(conn)
+            conn.commit()
+        payload["state_synced"] = True
+        return payload
+
+    def _sync_runtime_state_payload(
+        self,
+        payload: dict[str, object],
+        pets: list[PetRecord],
+        detections: list[PetDetectionRecord],
+    ) -> None:
+        """Apply one committed runtime payload without re-reading its rows."""
+
+        affected_pet_ids = tuple(
+            str(value) for value in payload.get("affected_pet_ids", ()) if value
+        )
         if self._state_repo is not None:
             operation_kind = str(payload.get("operation_kind") or "")
             if operation_kind == "pet_delete_detection":
@@ -839,20 +875,20 @@ class PetRepository:
                         face_index_path,
                         face_state_path,
                     ).refresh_all_group_assets()
-        with closing(self._connect()) as conn:
-            conn.execute(
-                """
-                UPDATE pet_runtime_commits
-                SET state_synced = 1, updated_at = ?
-                WHERE operation_id = ?
-                """,
-                (utc_now_iso(), str(operation_id)),
-            )
-            conn.commit()
-        payload["state_synced"] = True
-        if str(operation_id).startswith("internal-"):
-            self.prune_runtime_commits()
-        return payload
+
+    @staticmethod
+    def _mark_runtime_state_synced(
+        conn: sqlite3.Connection,
+        operation_id: str,
+    ) -> None:
+        conn.execute(
+            """
+            UPDATE pet_runtime_commits
+            SET state_synced = 1, updated_at = ?
+            WHERE operation_id = ?
+            """,
+            (utc_now_iso(), str(operation_id)),
+        )
 
     def prune_runtime_commits(
         self,
@@ -864,43 +900,62 @@ class PetRepository:
         """Bound synced commit history while retaining unfinished journal owners."""
 
         protected = tuple(dict.fromkeys(str(value) for value in protected_operation_ids if value))
-        deleted = 0
         with closing(self._connect()) as conn:
-            where = "state_synced = 1"
-            parameters: tuple[object, ...] = ()
-            if protected:
-                placeholders = ", ".join("?" for _ in protected)
-                where += f" AND operation_id NOT IN ({placeholders})"
-                parameters = protected
-            row = conn.execute(
-                f"SELECT COUNT(*) AS count FROM pet_runtime_commits WHERE {where}",
-                parameters,
-            ).fetchone()
-            if row is None or int(row["count"] or 0) <= high_watermark:
-                return 0
-            while True:
-                stale = conn.execute(
-                    f"""
-                    SELECT operation_id
-                    FROM pet_runtime_commits
-                    WHERE {where}
-                    ORDER BY rowid DESC
-                    LIMIT 500 OFFSET ?
-                    """,
-                    (*parameters, retain),
-                ).fetchall()
-                if not stale:
-                    break
-                stale_ids = tuple(str(item["operation_id"]) for item in stale)
-                placeholders = ", ".join("?" for _ in stale_ids)
-                cursor = conn.execute(
-                    f"DELETE FROM pet_runtime_commits WHERE operation_id IN ({placeholders})",
-                    stale_ids,
-                )
-                deleted += int(cursor.rowcount or 0)
-                conn.commit()
-                if len(stale_ids) < 500:
-                    break
+            deleted = self._prune_runtime_commits_in_connection(
+                conn,
+                protected_operation_ids=protected,
+                high_watermark=high_watermark,
+                retain=retain,
+            )
+            conn.commit()
+            return deleted
+
+    @staticmethod
+    def _prune_runtime_commits_in_connection(
+        conn: sqlite3.Connection,
+        *,
+        protected_operation_ids: Iterable[str] = (),
+        high_watermark: int = 1200,
+        retain: int = 1000,
+    ) -> int:
+        protected = tuple(
+            dict.fromkeys(str(value) for value in protected_operation_ids if value)
+        )
+        where = "state_synced = 1"
+        parameters: tuple[object, ...] = ()
+        if protected:
+            placeholders = ", ".join("?" for _ in protected)
+            where += f" AND operation_id NOT IN ({placeholders})"
+            parameters = protected
+        row = conn.execute(
+            f"SELECT COUNT(*) AS count FROM pet_runtime_commits WHERE {where}",
+            parameters,
+        ).fetchone()
+        if row is None or int(row["count"] or 0) <= high_watermark:
+            return 0
+        deleted = 0
+        while True:
+            stale = conn.execute(
+                f"""
+                SELECT operation_id
+                FROM pet_runtime_commits
+                WHERE {where}
+                ORDER BY rowid DESC
+                LIMIT 500 OFFSET ?
+                """,
+                (*parameters, retain),
+            ).fetchall()
+            if not stale:
+                break
+            stale_ids = tuple(str(item["operation_id"]) for item in stale)
+            placeholders = ", ".join("?" for _ in stale_ids)
+            cursor = conn.execute(
+                f"DELETE FROM pet_runtime_commits WHERE operation_id IN ({placeholders})",
+                stale_ids,
+            )
+            deleted += int(cursor.rowcount or 0)
+            if len(stale_ids) < 500:
+                break
         return deleted
 
     def _assign_incremental_pet_ids(
@@ -910,26 +965,16 @@ class PetRepository:
         existing_pets: dict[str, PetRecord],
         candidate_index: _ProfileCandidateIndex | None = None,
         match_context: _ProfileMatchContext | None = None,
+        state_snapshot: _IncrementalStateSnapshot | None = None,
         excluded_asset_ids: set[str],
         distance_threshold: float,
     ) -> _IncrementalPetAssignment:
         if not detections:
             return _IncrementalPetAssignment()
-        redirects = (
-            self._state_repo.get_merge_redirect_map() if self._state_repo is not None else {}
-        )
-        key_map = (
-            self._state_repo.get_pet_key_map(detection.pet_key for detection in detections)
-            if self._state_repo is not None
-            else {}
-        )
-        mapped_ids = tuple(
-            dict.fromkeys(
-                redirects.get(mapped_id, mapped_id) for mapped_id in key_map.values() if mapped_id
-            )
-        )
+        redirects = state_snapshot.redirects if state_snapshot is not None else {}
+        key_map = state_snapshot.key_map if state_snapshot is not None else {}
         durable_profiles = (
-            self._state_repo.get_profiles_by_ids(mapped_ids) if self._state_repo is not None else {}
+            state_snapshot.durable_profiles if state_snapshot is not None else {}
         )
         stable_profiles = {
             pet_id: pet

--- a/src/iPhoto/pets/state_repository.py
+++ b/src/iPhoto/pets/state_repository.py
@@ -242,6 +242,9 @@ class PetStateRepository:
             return _IncrementalStateSnapshot(frozenset(), {}, {}, {})
         self.initialize()
         with closing(self._connect()) as conn:
+            # Python's sqlite3 driver does not open a transaction for SELECTs.
+            # Pin all assignment inputs to one WAL snapshot explicitly.
+            conn.execute("BEGIN")
             rejected_rows: list[sqlite3.Row] = []
             key_rows: list[sqlite3.Row] = []
             for chunk in _chunked(unique_keys, 500):
@@ -299,6 +302,7 @@ class PetStateRepository:
                         chunk,
                     ).fetchall()
                 )
+            conn.rollback()
         return _IncrementalStateSnapshot(
             rejected_keys=frozenset(
                 str(row["pet_key"]) for row in rejected_rows if row["pet_key"]

--- a/src/iPhoto/pets/state_repository.py
+++ b/src/iPhoto/pets/state_repository.py
@@ -35,6 +35,14 @@ class PetCoverRecord:
     is_custom: bool
 
 
+@dataclass(frozen=True)
+class _IncrementalStateSnapshot:
+    rejected_keys: frozenset[str]
+    key_map: dict[str, str]
+    redirects: dict[str, str]
+    durable_profiles: dict[str, PetProfile]
+
+
 class PetStateRepository:
     def __init__(self, db_path: Path) -> None:
         self._db_path = Path(db_path)
@@ -223,6 +231,87 @@ class PetStateRepository:
                 )
         return {str(row["pet_key"]) for row in rows if row["pet_key"]}
 
+    def _load_incremental_state(
+        self,
+        pet_keys: Iterable[str],
+    ) -> _IncrementalStateSnapshot:
+        """Read all durable assignment inputs from one state-DB snapshot."""
+
+        unique_keys = tuple(str(key) for key in dict.fromkeys(pet_keys) if key)
+        if not unique_keys:
+            return _IncrementalStateSnapshot(frozenset(), {}, {}, {})
+        self.initialize()
+        with closing(self._connect()) as conn:
+            rejected_rows: list[sqlite3.Row] = []
+            key_rows: list[sqlite3.Row] = []
+            for chunk in _chunked(unique_keys, 500):
+                placeholders = ", ".join("?" for _ in chunk)
+                rejected_rows.extend(
+                    conn.execute(
+                        f"SELECT pet_key FROM rejected_pet_keys "
+                        f"WHERE pet_key IN ({placeholders})",
+                        chunk,
+                    ).fetchall()
+                )
+                key_rows.extend(
+                    conn.execute(
+                        f"SELECT pet_key, pet_id FROM pet_keys "
+                        f"WHERE pet_key IN ({placeholders})",
+                        chunk,
+                    ).fetchall()
+                )
+            redirect_rows = conn.execute(
+                "SELECT source_pet_id, target_pet_id FROM merge_redirects"
+            ).fetchall()
+            redirects = _canonical_redirect_map(
+                {
+                    str(row["source_pet_id"]): str(row["target_pet_id"])
+                    for row in redirect_rows
+                    if row["source_pet_id"] and row["target_pet_id"]
+                }
+            )
+            key_map = {
+                str(row["pet_key"]): str(row["pet_id"])
+                for row in key_rows
+                if row["pet_key"] and row["pet_id"]
+            }
+            mapped_ids = tuple(
+                dict.fromkeys(
+                    redirects.get(pet_id, pet_id)
+                    for pet_id in key_map.values()
+                    if pet_id
+                )
+            )
+            profile_rows: list[sqlite3.Row] = []
+            for chunk in _chunked(mapped_ids, 500):
+                placeholders = ", ".join("?" for _ in chunk)
+                profile_rows.extend(
+                    conn.execute(
+                        f"""
+                        SELECT
+                            pet_id, name, center_embedding, embedding_dim,
+                            created_at, updated_at, sample_count, profile_state,
+                            species_label, embedding_pipeline_version, generation_id,
+                            boundary_embeddings, boundary_sample_count
+                        FROM pet_profiles
+                        WHERE pet_id IN ({placeholders})
+                        """,
+                        chunk,
+                    ).fetchall()
+                )
+        return _IncrementalStateSnapshot(
+            rejected_keys=frozenset(
+                str(row["pet_key"]) for row in rejected_rows if row["pet_key"]
+            ),
+            key_map=key_map,
+            redirects=redirects,
+            durable_profiles={
+                str(row["pet_id"]): _profile_from_row(row)
+                for row in profile_rows
+                if row["pet_id"]
+            },
+        )
+
     def add_rejected_pet_key(self, pet_key: str) -> None:
         if not pet_key:
             return
@@ -270,10 +359,27 @@ class PetStateRepository:
         replaced_pet_ids: Iterable[str] = (),
     ) -> None:
         self.initialize()
-        names = self.get_profile_name_map(pet.pet_id for pet in pets)
         timestamp = utc_now_iso()
         detection_by_id = {detection.detection_id: detection for detection in detections}
         with closing(self._connect()) as conn:
+            unique_pet_ids = tuple(
+                dict.fromkeys(pet.pet_id for pet in pets if pet.pet_id)
+            )
+            name_rows: list[sqlite3.Row] = []
+            for chunk in _chunked(unique_pet_ids, 500):
+                placeholders = ", ".join("?" for _ in chunk)
+                name_rows.extend(
+                    conn.execute(
+                        f"SELECT pet_id, name FROM pet_profiles "
+                        f"WHERE pet_id IN ({placeholders})",
+                        chunk,
+                    ).fetchall()
+                )
+            names = {
+                str(row["pet_id"]): row["name"]
+                for row in name_rows
+                if row["pet_id"]
+            }
             redirect_rows = conn.execute(
                 "SELECT source_pet_id, target_pet_id FROM merge_redirects"
             ).fetchall()

--- a/tests/contracts/test_pets_scale_contract.py
+++ b/tests/contracts/test_pets_scale_contract.py
@@ -83,6 +83,60 @@ def test_production_shape_fallback_is_correct_at_1k(
     assert metrics["rss_bytes"] <= 4 * 1024 * 1024 * 1024
 
 
+def test_warm_incremental_commit_uses_bounded_sqlite_connections(tmp_path: Path) -> None:
+    repository = PetRepository(tmp_path / "pet_index.db", tmp_path / "pet_state.db")
+    warm = [
+        _detection(
+            detection_id="warm",
+            asset_id="warm-asset",
+            embedding=_synthetic_vector(0, 4),
+            pet_id=None,
+        )
+    ]
+    repository.replace_assets_incrementally(
+        ["warm-asset"],
+        warm,
+        distance_threshold=-1.0,
+    )
+    state_repository = repository.state_repository
+    assert state_repository is not None
+    connection_counts = {"runtime": 0, "state": 0}
+    runtime_connect = repository._connect
+    state_connect = state_repository._connect
+
+    def counted_runtime_connect():
+        connection_counts["runtime"] += 1
+        return runtime_connect()
+
+    def counted_state_connect():
+        connection_counts["state"] += 1
+        return state_connect()
+
+    repository._connect = counted_runtime_connect  # type: ignore[method-assign]
+    state_repository._connect = counted_state_connect  # type: ignore[method-assign]
+    batch_count = 10
+    for batch_index in range(batch_count):
+        opens_before = sum(connection_counts.values())
+        first = 1 + batch_index * 16
+        batch = [
+            _detection(
+                detection_id=f"budget-{index:04d}",
+                asset_id=f"budget-asset-{index:04d}",
+                embedding=_synthetic_vector(index, 4),
+                pet_id=None,
+            )
+            for index in range(first, first + 16)
+        ]
+        repository.replace_assets_incrementally(
+            [detection.asset_id for detection in batch],
+            batch,
+            distance_threshold=-1.0,
+        )
+        assert sum(connection_counts.values()) - opens_before <= 4
+
+    assert sum(connection_counts.values()) <= batch_count * 4
+
+
 def _benchmark_incremental(root: Path, count: int) -> dict[str, object]:
     root.mkdir(parents=True)
     repository = PetRepository(root / "pet_index.db", root / "pet_state.db")
@@ -150,8 +204,60 @@ def _benchmark_growth(
         return connection
 
     repository._connect = traced_connect  # type: ignore[method-assign]
+    phase_seconds = {
+        "assignment_seconds": 0.0,
+        "state_sync_seconds": 0.0,
+        "index_update_seconds": 0.0,
+        "synthetic_seconds": 0.0,
+    }
+    original_assignment = repository._assign_incremental_pet_ids
+    original_state_sync = repository._sync_runtime_state_payload
+    original_index_update = repository._update_profile_indexes
+    state_repository = repository.state_repository
+    original_state_snapshot = (
+        state_repository._load_incremental_state
+        if state_repository is not None
+        else None
+    )
+
+    def timed_assignment(*args, **kwargs):
+        phase_started = time.perf_counter()
+        try:
+            return original_assignment(*args, **kwargs)
+        finally:
+            phase_seconds["assignment_seconds"] += time.perf_counter() - phase_started
+
+    def timed_state_snapshot(*args, **kwargs):
+        phase_started = time.perf_counter()
+        try:
+            assert original_state_snapshot is not None
+            return original_state_snapshot(*args, **kwargs)
+        finally:
+            phase_seconds["assignment_seconds"] += time.perf_counter() - phase_started
+
+    def timed_state_sync(*args, **kwargs):
+        phase_started = time.perf_counter()
+        try:
+            return original_state_sync(*args, **kwargs)
+        finally:
+            phase_seconds["state_sync_seconds"] += time.perf_counter() - phase_started
+
+    def timed_index_update(*args, **kwargs):
+        phase_started = time.perf_counter()
+        try:
+            return original_index_update(*args, **kwargs)
+        finally:
+            phase_seconds["index_update_seconds"] += time.perf_counter() - phase_started
+
+    repository._assign_incremental_pet_ids = timed_assignment  # type: ignore[method-assign]
+    repository._sync_runtime_state_payload = timed_state_sync  # type: ignore[method-assign]
+    repository._update_profile_indexes = timed_index_update  # type: ignore[method-assign]
+    if state_repository is not None:
+        state_repository._load_incremental_state = timed_state_snapshot  # type: ignore[method-assign]
     started = time.perf_counter()
+    next_progress = 5_000
     for start in range(0, count, 16):
+        synthetic_started = time.perf_counter()
         batch = [
             _detection(
                 detection_id=f"growth-{index:06d}",
@@ -161,11 +267,21 @@ def _benchmark_growth(
             )
             for index in range(start, min(start + 16, count))
         ]
+        phase_seconds["synthetic_seconds"] += time.perf_counter() - synthetic_started
         repository.replace_assets_incrementally(
             [detection.asset_id for detection in batch],
             batch,
             distance_threshold=-1.0,
         )
+        completed = min(start + 16, count)
+        if completed >= next_progress or completed == count:
+            print(
+                "Pets production-shape progress: "
+                f"{completed}/{count} in {time.perf_counter() - started:.2f}s",
+                flush=True,
+            )
+            while next_progress <= completed:
+                next_progress += 5_000
     elapsed = time.perf_counter() - started
     rss_bytes = _peak_rss_bytes()
     full_profile_reads = sum(
@@ -179,6 +295,15 @@ def _benchmark_growth(
         "seconds": elapsed,
         "rss_bytes": rss_bytes,
         "full_profile_reads": full_profile_reads,
+        **phase_seconds,
+        "runtime_mutation_seconds": max(
+            0.0,
+            elapsed
+            - phase_seconds["synthetic_seconds"]
+            - phase_seconds["assignment_seconds"]
+            - phase_seconds["state_sync_seconds"]
+            - phase_seconds["index_update_seconds"],
+        ),
     }
     if not exercise_restart:
         return metrics

--- a/tests/test_ci_workflow_contracts.py
+++ b/tests/test_ci_workflow_contracts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEST_WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+
+
+def _job_block(workflow: str, job_name: str) -> str:
+    lines = workflow.splitlines()
+    header = f"  {job_name}:"
+    start = lines.index(header)
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def test_full_contract_workflow_covers_head_merge_ref_and_merge_push() -> None:
+    workflow = TEST_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "branches: [main, edit-base, codex/startup-chain-optimization]" in workflow
+    assert "pull_request:\n    branches: [main, edit-base]" in workflow
+    production_shape = _job_block(workflow, "pets-production-shape-contract")
+    assert "github.event_name" not in production_shape
+    assert "os: [ubuntu-latest, macos-latest, windows-latest]" in production_shape
+    assert "timeout-minutes: 30" in production_shape

--- a/tests/test_pet_service.py
+++ b/tests/test_pet_service.py
@@ -679,6 +679,76 @@ def test_pet_repository_state_persists_name_hidden_and_rejected_key(tmp_path: Pa
     assert repository.state_repository.get_rejected_pet_keys(["pet-key-a"]) == {"pet-key-a"}
 
 
+def test_incremental_state_inputs_share_one_sqlite_read_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = PetStateRepository(tmp_path / "pet_state.db")
+    detection = _detection(
+        detection_id="snapshot",
+        pet_key="snapshot-key",
+        pet_id="pet-snapshot",
+    )
+    pet = PetRecord(
+        pet_id="pet-snapshot",
+        name="Before",
+        key_detection_id=detection.detection_id,
+        detection_count=1,
+        center_embedding=detection.embedding,
+        embedding_dim=detection.embedding_dim,
+        created_at=utc_now_iso(),
+        updated_at=utc_now_iso(),
+        sample_count=1,
+        profile_state="unstable",
+    )
+    state.sync_scan_results([pet], [detection])
+    writer = PetStateRepository(state.db_path)
+    writer.initialize()
+    original_connect = state._connect
+    mutation_injected = False
+
+    class _CursorAfterFirstRead:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def fetchall(self):
+            nonlocal mutation_injected
+            rows = self._cursor.fetchall()
+            if not mutation_injected:
+                mutation_injected = True
+                writer.rename_pet("pet-snapshot", "After")
+            return rows
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class _ConnectionAfterFirstRead:
+        def __init__(self, connection):
+            self._connection = connection
+
+        def execute(self, sql, parameters=()):
+            cursor = self._connection.execute(sql, parameters)
+            if "SELECT pet_key FROM rejected_pet_keys" in str(sql):
+                return _CursorAfterFirstRead(cursor)
+            return cursor
+
+        def __getattr__(self, name):
+            return getattr(self._connection, name)
+
+    monkeypatch.setattr(
+        state,
+        "_connect",
+        lambda: _ConnectionAfterFirstRead(original_connect()),
+    )
+
+    snapshot = state._load_incremental_state(["snapshot-key"])
+
+    assert mutation_injected
+    assert snapshot.key_map == {"snapshot-key": "pet-snapshot"}
+    assert snapshot.durable_profiles["pet-snapshot"].name == "Before"
+    assert writer.get_profiles_by_ids(["pet-snapshot"])["pet-snapshot"].name == "After"
+
+
 def test_delete_detection_replaces_custom_cover_and_removes_thumbnail(tmp_path: Path) -> None:
     repository = PetRepository(tmp_path / "pet_index.db", tmp_path / "pet_state.db")
     thumbnail_dir = tmp_path / "thumbnails"

--- a/tests/ui/controllers/test_player_view_init_cover.py
+++ b/tests/ui/controllers/test_player_view_init_cover.py
@@ -326,6 +326,277 @@ class TestInitCoverTracking:
 
         assert dispatched == [source_b.absolute()]
 
+    def test_neighbor_prefetch_reserves_one_lane_for_foreground(
+        self,
+        controller,
+        qapp,
+        tmp_path,
+        mocker,
+    ):
+        sources = {
+            "A": tmp_path / "a.nef",
+            "B": tmp_path / "b.nef",
+            "C": tmp_path / "c.jpg",
+        }
+        for source in sources.values():
+            source.write_bytes(b"source")
+        started = {name: Event() for name in sources}
+        releases = {name: Event() for name in ("A", "B")}
+        dispatched: list[tuple[str, Path]] = []
+
+        def probe(identity):
+            name = identity.path.stem.upper()
+            started[name].set()
+            assert releases[name].wait(5)
+            return AssetSourceIdentity.create(identity.path, width=4000, height=3000)
+
+        class _EditService:
+            def read_adjustments(self, source):
+                started[Path(source).stem.upper()].set()
+                return {}
+
+        mocker.patch(
+            "iPhoto.gui.ui.controllers.player_view_controller.probe_raw_source_identity",
+            side_effect=probe,
+        )
+        controller._edit_service_getter = lambda: _EditService()
+        mocker.patch.object(
+            controller,
+            "_dispatch_prepared_intent",
+            side_effect=lambda intent, _adjustments: dispatched.append(
+                (intent.reason, intent.source_identity.path)
+            )
+            or True,
+        )
+
+        try:
+            assert controller.prefetch_images([sources["A"], sources["B"]])
+            assert started["A"].wait(5)
+            assert not started["B"].is_set()
+            assert len(controller._preparation_prefetch_queue) == 1
+
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent(
+                    "C",
+                    AssetSourceIdentity.create(
+                        sources["C"], width=1600, height=1200
+                    ),
+                    1,
+                    "initial",
+                )
+            )
+            assert started["C"].wait(5)
+            assert _spin_until(
+                qapp,
+                lambda: dispatched == [("initial", sources["C"].absolute())],
+            )
+            assert not releases["A"].is_set()
+            assert not started["B"].is_set()
+            assert controller._preparation_prefetch_queue == []
+        finally:
+            for release in releases.values():
+                release.set()
+            assert controller._preparation_pool.waitForDone(5000)
+            qapp.processEvents()
+
+        assert dispatched == [("initial", sources["C"].absolute())]
+        assert not started["B"].is_set()
+
+    def test_neighbor_prefetch_preparations_run_serially(
+        self,
+        controller,
+        qapp,
+        tmp_path,
+        mocker,
+    ):
+        sources = {name: tmp_path / f"{name.lower()}.nef" for name in ("A", "B")}
+        for source in sources.values():
+            source.write_bytes(b"raw")
+        started = {name: Event() for name in sources}
+        releases = {name: Event() for name in sources}
+        dispatched: list[tuple[str | None, Path]] = []
+
+        def probe(identity):
+            name = identity.path.stem.upper()
+            started[name].set()
+            assert releases[name].wait(5)
+            return AssetSourceIdentity.create(identity.path, width=4000, height=3000)
+
+        mocker.patch(
+            "iPhoto.gui.ui.controllers.player_view_controller.probe_raw_source_identity",
+            side_effect=probe,
+        )
+        mocker.patch.object(
+            controller,
+            "_dispatch_prepared_intent",
+            side_effect=lambda intent, _adjustments: dispatched.append(
+                (intent.residency_slot, intent.source_identity.path)
+            )
+            or True,
+        )
+
+        try:
+            assert controller.prefetch_images([sources["A"], sources["B"]])
+            assert started["A"].wait(5)
+            assert not started["B"].is_set()
+
+            releases["A"].set()
+            assert _spin_until(
+                qapp,
+                lambda: dispatched == [("previous", sources["A"].absolute())],
+            )
+            assert started["B"].wait(5)
+
+            releases["B"].set()
+            assert _spin_until(
+                qapp,
+                lambda: dispatched
+                == [
+                    ("previous", sources["A"].absolute()),
+                    ("next", sources["B"].absolute()),
+                ],
+            )
+        finally:
+            for release in releases.values():
+                release.set()
+            assert controller._preparation_pool.waitForDone(5000)
+            qapp.processEvents()
+
+        assert controller._preparation_prefetch_queue == []
+
+    def test_queued_neighbor_click_uses_bypass_lane_without_duplicate_worker(
+        self,
+        controller,
+        qapp,
+        tmp_path,
+        mocker,
+    ):
+        source_a = tmp_path / "a.nef"
+        source_b = tmp_path / "b.jpg"
+        source_a.write_bytes(b"raw")
+        source_b.write_bytes(b"jpeg")
+        a_started = Event()
+        release_a = Event()
+        b_reads = 0
+        dispatched: list[tuple[str, Path]] = []
+
+        def probe(identity):
+            a_started.set()
+            assert release_a.wait(5)
+            return AssetSourceIdentity.create(identity.path, width=4000, height=3000)
+
+        class _EditService:
+            def read_adjustments(self, source):
+                nonlocal b_reads
+                if Path(source) == source_b.absolute():
+                    b_reads += 1
+                return {}
+
+        mocker.patch(
+            "iPhoto.gui.ui.controllers.player_view_controller.probe_raw_source_identity",
+            side_effect=probe,
+        )
+        controller._edit_service_getter = lambda: _EditService()
+        mocker.patch.object(
+            controller,
+            "_dispatch_prepared_intent",
+            side_effect=lambda intent, _adjustments: dispatched.append(
+                (intent.reason, intent.source_identity.path)
+            )
+            or True,
+        )
+
+        try:
+            assert controller.prefetch_images([source_a, source_b])
+            assert a_started.wait(5)
+            assert len(controller._preparation_prefetch_queue) == 1
+
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent(
+                    "",
+                    AssetSourceIdentity.create(source_b, width=1600, height=1200),
+                    7,
+                    "initial",
+                )
+            )
+            assert _spin_until(
+                qapp,
+                lambda: dispatched == [("initial", source_b.absolute())],
+            )
+            assert b_reads == 1
+            assert controller._preparation_prefetch_queue == []
+            assert not release_a.is_set()
+        finally:
+            release_a.set()
+            assert controller._preparation_pool.waitForDone(5000)
+            qapp.processEvents()
+
+        assert b_reads == 1
+        assert dispatched == [("initial", source_b.absolute())]
+
+    def test_new_neighbor_window_replaces_queue_and_waits_for_old_terminal(
+        self,
+        controller,
+        tmp_path,
+    ):
+        class _Pool:
+            def __init__(self):
+                self.queued = []
+                self.starts = []
+
+            def start(self, worker, priority):
+                self.queued.append(worker)
+                self.starts.append((worker, priority))
+
+            def tryTake(self, worker):
+                if worker not in self.queued:
+                    return False
+                self.queued.remove(worker)
+                return True
+
+            def mark_running(self, worker):
+                self.queued.remove(worker)
+
+        sources = [tmp_path / f"{name}.jpg" for name in ("a", "b", "c", "d")]
+        for source in sources:
+            source.write_bytes(b"jpeg")
+        original_pool = controller._preparation_pool
+        pool = _Pool()
+        controller._preparation_pool = pool
+        workers = []
+
+        try:
+            assert controller.prefetch_images(sources[:2])
+            old_worker = next(iter(controller._preparation_entries.values())).worker
+            workers.append(old_worker)
+            pool.mark_running(old_worker)
+
+            assert controller.prefetch_images(sources[2:])
+            assert old_worker._cancelled
+            assert controller._preparation_entries == {}
+            assert [intent.source_identity.path for intent in controller._preparation_prefetch_queue] == [
+                sources[2].absolute(),
+                sources[3].absolute(),
+            ]
+            assert pool.queued == []
+
+            controller._on_adjustment_preparation_finished(old_worker)
+            new_worker = next(iter(controller._preparation_entries.values())).worker
+            workers.append(new_worker)
+            assert new_worker.source_identity.path == sources[2].absolute()
+            assert [intent.source_identity.path for intent in controller._preparation_prefetch_queue] == [
+                sources[3].absolute()
+            ]
+
+            controller.cancel_pending_image_requests()
+            assert controller._preparation_prefetch_queue == []
+            controller._on_adjustment_preparation_finished(new_worker)
+            assert len(pool.starts) == 2
+        finally:
+            for worker in workers:
+                controller._on_adjustment_preparation_finished(worker)
+            controller._preparation_pool = original_pool
+
     def test_cancelled_preparation_key_is_not_reused_for_a_b_a(
         self,
         controller,

--- a/tests/ui/controllers/test_player_view_init_cover.py
+++ b/tests/ui/controllers/test_player_view_init_cover.py
@@ -9,7 +9,9 @@ when switching to a QRhiWidget that has not yet rendered.
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
+from threading import Event
 
 import pytest
 
@@ -63,6 +65,17 @@ def _surface(path: Path, image: QImage, *, level: int = 1024) -> DecodedSurface:
         decode_level=level,
         backend="fake",
     )
+
+
+def _spin_until(qapp, predicate, *, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.005)
+    qapp.processEvents()
+    return bool(predicate())
 
 
 def _assert_ibeam_cursor() -> None:
@@ -242,6 +255,233 @@ class TestInitCoverTracking:
     def test_still_decode_uses_dedicated_bounded_pool(self, controller):
         assert controller._pool is not QThreadPool.globalInstance()
         assert controller._pool.maxThreadCount() == 2
+        assert controller._preparation_pool.maxThreadCount() == 2
+
+    def test_latest_preparation_bypasses_one_blocked_raw_worker(
+        self,
+        controller,
+        qapp,
+        tmp_path,
+        mocker,
+    ):
+        source_a = tmp_path / "a.nef"
+        source_b = tmp_path / "b.jpg"
+        source_a.write_bytes(b"raw-a")
+        source_b.write_bytes(b"jpeg-b")
+        probe_started = Event()
+        release_probe = Event()
+        b_prepared = Event()
+        dispatched: list[Path] = []
+
+        def probe(identity):
+            probe_started.set()
+            assert release_probe.wait(5)
+            return AssetSourceIdentity.create(
+                identity.path,
+                width=4000,
+                height=3000,
+            )
+
+        class _EditService:
+            def read_adjustments(self, source):
+                if Path(source) == source_b.absolute():
+                    b_prepared.set()
+                return {}
+
+        mocker.patch(
+            "iPhoto.gui.ui.controllers.player_view_controller.probe_raw_source_identity",
+            side_effect=probe,
+        )
+        controller._edit_service_getter = lambda: _EditService()
+        mocker.patch.object(
+            controller,
+            "_dispatch_prepared_intent",
+            side_effect=lambda intent, _adjustments: dispatched.append(
+                intent.source_identity.path
+            )
+            or True,
+        )
+        raw_identity = AssetSourceIdentity.create(source_a, width=0, height=0)
+        jpeg_identity = AssetSourceIdentity.create(source_b, width=1600, height=1200)
+
+        try:
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent("A", raw_identity, 1, "initial")
+            )
+            assert probe_started.wait(5)
+            first_a = next(iter(controller._preparation_entries.values())).worker
+
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent("B", jpeg_identity, 2, "initial")
+            )
+
+            assert b_prepared.wait(5)
+            assert _spin_until(qapp, lambda: dispatched == [source_b.absolute()])
+            assert first_a._cancelled
+            assert not release_probe.is_set()
+        finally:
+            release_probe.set()
+            assert controller._preparation_pool.waitForDone(5000)
+            qapp.processEvents()
+
+        assert dispatched == [source_b.absolute()]
+
+    def test_cancelled_preparation_key_is_not_reused_for_a_b_a(
+        self,
+        controller,
+        tmp_path,
+        mocker,
+    ):
+        class _Pool:
+            def __init__(self):
+                self.queued = []
+
+            def start(self, worker, _priority):
+                self.queued.append(worker)
+
+            def tryTake(self, worker):
+                if worker not in self.queued:
+                    return False
+                self.queued.remove(worker)
+                return True
+
+            def mark_running(self, worker):
+                self.queued.remove(worker)
+
+        original_pool = controller._preparation_pool
+        pool = _Pool()
+        controller._preparation_pool = pool
+        dispatch = mocker.patch.object(controller, "_dispatch_prepared_intent")
+        failure = mocker.patch.object(controller, "_on_adjusted_image_failed")
+        identity_a = AssetSourceIdentity.create(
+            tmp_path / "a.raw", width=4000, height=3000, source_mtime_ns=1
+        )
+        identity_b = AssetSourceIdentity.create(
+            tmp_path / "b.jpg", width=1600, height=1200, source_mtime_ns=1
+        )
+        workers = []
+
+        try:
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent("A", identity_a, 1, "initial")
+            )
+            first_a = next(iter(controller._preparation_entries.values())).worker
+            workers.append(first_a)
+            pool.mark_running(first_a)
+
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent("B", identity_b, 2, "initial")
+            )
+            worker_b = next(iter(controller._preparation_entries.values())).worker
+            workers.append(worker_b)
+            pool.mark_running(worker_b)
+
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent("A", identity_a, 3, "initial")
+            )
+            second_a = next(iter(controller._preparation_entries.values())).worker
+            workers.append(second_a)
+
+            assert first_a._cancelled
+            assert worker_b._cancelled
+            assert second_a is not first_a
+            assert second_a.generation == 3
+            assert controller._preparation_entries[second_a.key].worker is second_a
+
+            stale_state = PreparedStillState.create({}, identity_a)
+            controller._on_adjustment_prepared(first_a, stale_state)
+            controller._on_adjustment_preparation_failed(first_a, "stale failure")
+            controller._on_adjustment_preparation_finished(first_a)
+
+            dispatch.assert_not_called()
+            failure.assert_not_called()
+            assert controller._preparation_entries[second_a.key].worker is second_a
+        finally:
+            for worker in workers:
+                controller._on_adjustment_preparation_finished(worker)
+            controller._preparation_pool = original_pool
+
+    def test_latest_preparation_starts_when_one_of_two_stale_lanes_releases(
+        self,
+        controller,
+        qapp,
+        tmp_path,
+        mocker,
+    ):
+        sources = {
+            "A": tmp_path / "a.nef",
+            "B": tmp_path / "b.nef",
+            "C": tmp_path / "c.jpg",
+        }
+        for source in sources.values():
+            source.write_bytes(b"source")
+        started = {name: Event() for name in ("A", "B", "C")}
+        releases = {name: Event() for name in ("A", "B")}
+        dispatched: list[Path] = []
+
+        def probe(identity):
+            name = identity.path.stem.upper()
+            started[name].set()
+            assert releases[name].wait(5)
+            return AssetSourceIdentity.create(identity.path, width=4000, height=3000)
+
+        class _EditService:
+            def read_adjustments(self, source):
+                name = Path(source).stem.upper()
+                started[name].set()
+                return {}
+
+        mocker.patch(
+            "iPhoto.gui.ui.controllers.player_view_controller.probe_raw_source_identity",
+            side_effect=probe,
+        )
+        controller._edit_service_getter = lambda: _EditService()
+        mocker.patch.object(
+            controller,
+            "_dispatch_prepared_intent",
+            side_effect=lambda intent, _adjustments: dispatched.append(
+                intent.source_identity.path
+            )
+            or True,
+        )
+
+        try:
+            for generation, name in enumerate(("A", "B"), start=1):
+                assert controller._schedule_adjustment_preparation(
+                    _PreparedRequestIntent(
+                        name,
+                        AssetSourceIdentity.create(
+                            sources[name], width=0, height=0
+                        ),
+                        generation,
+                        "initial",
+                    )
+                )
+                assert started[name].wait(5)
+
+            assert controller._schedule_adjustment_preparation(
+                _PreparedRequestIntent(
+                    "C",
+                    AssetSourceIdentity.create(
+                        sources["C"], width=1600, height=1200
+                    ),
+                    3,
+                    "initial",
+                )
+            )
+            assert not started["C"].is_set()
+
+            releases["B"].set()
+            assert started["C"].wait(5)
+            assert not releases["A"].is_set()
+            assert _spin_until(qapp, lambda: dispatched == [sources["C"].absolute()])
+        finally:
+            for release in releases.values():
+                release.set()
+            assert controller._preparation_pool.waitForDone(5000)
+            qapp.processEvents()
+
+        assert dispatched == [sources["C"].absolute()]
 
     def test_hover_adjustment_preparation_is_promoted_for_click(self, controller):
         class _Pool:


### PR DESCRIPTION
## Summary

- make Detail adjustment preparation a two-lane latest-only scheduler with one-stuck-worker bypass
- bound preparation speculative work to one native lane and queue the current previous/next window
- isolate reusable entries from cancelled running worker lifecycle ownership, including safe A→B→A handling
- enable three-platform Pets production-shape contracts on strict head, merge-ref, and merge-SHA events
- reduce Pets incremental SQLite connection churn and pin assignment inputs to one WAL read snapshot
- add preparation concurrency, workflow, connection-budget, recovery, and snapshot consistency contracts

## Root cause

RAW preparation enters LibRaw before the decode scheduler. A single preparation lane blocked newer foreground work; after moving to two lanes, two speculative neighbor prefetches could occupy both lanes and break the same bypass guarantee. Key-only callbacks could also let cancelled workers interfere with later same-key requests.

The production-shape job excluded push events despite the merge-SHA policy. Windows 50k×384 also suffered repeated runtime/state SQLite connection and reread overhead, and the consolidated state reads were not explicitly pinned to one SQLite snapshot.

## Validation at head `7d0815d0`

- blocker, lifecycle, Pets recovery, connection budget, and workflow contracts: 107 passed
- Detail/Playback regression: 193 passed, 1 Windows-only skip
- complete Pets service: 52 passed
- architecture contracts: 23 passed plus `tools/check_architecture.py`
- local 50k×384 production-shape: 2 passed in 83.63s
- 50k growth 63.04s; cold restart 4.26s; mutation 13.35s; WAL delta 0
- Ruff F/I, compileall, and diff checks passed

## Exact-head remote validation

Two independent manual `Tests` workflow runs completed successfully against exact SHA `7d0815d0dfe2761ef4c0ee298b143d9283c4d398`; all 15 jobs passed in both runs.

- [run 31487772450](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31487772450): Windows production-shape job completed in about 17m21s; 50k×384 in 863.10s, state sync 420.20s, runtime mutation 414.26s, cold restart 3.83s, mutation 43.39s, WAL delta 0; 3 passed / 1 skipped in 935.76s.
- [run 31489149659](https://github.com/OliverZhaohaibin/iPhotron-LocalPhotoAlbumManager/actions/runs/31489149659): Windows production-shape job completed in about 14m47s; 50k×384 in 723.21s, state sync 351.15s, runtime mutation 343.59s, cold restart 3.90s, mutation 52.47s, WAL delta 0; 3 passed / 1 skipped in 798.06s.

This supplies two consecutive Windows completions below the unchanged 30-minute threshold with full phase metrics.

## Remaining merge-chain gates

The PR remains draft while the stacked merge chain is pending. After #905 merges, the normal `codex/startup-chain-optimization` push run must pass. #890 still requires its synthetic PR merge-ref run and the eventual `edit-base` merge-SHA push run, each including all three production-shape platforms.