### PR TITLE
Fix still playback during active scans

### DIFF
--- a/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
+++ b/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
@@ -1,0 +1,69 @@
+# Windows scan-time still playback diagnostics
+
+Use this collector when scanning eventually makes all still photos blank while videos
+continue to play, or when Edit/fullscreen stops responding for photos.
+
+The collector does not copy photos, thumbnails, the SQLite index, settings, or credentials.
+It records privacy-safe render/scan events, periodic all-thread Python stacks, GUI resource
+counts, process memory/handle counts, GPU/OS versions, and relevant Windows application events.
+Performance path fields are replaced with stable session-only hashes. Known user, application,
+repository, and optional library roots are redacted before the ZIP is created.
+Individual filenames can still appear in application diagnostics, so review the ZIP before
+sharing it if filenames are sensitive.
+
+## Run from the current source checkout
+
+Close every running iPhoto instance, open PowerShell in the repository, and run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1 `
+  -LibraryRootToRedact "D:\Path\To\Your\PhotoLibrary"
+```
+
+The script prefers `.venv\Scripts\python.exe`, ensuring the latest diagnostic probes in the
+checkout are active. Pass `-PythonExe` when the environment is elsewhere:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1 `
+  -PythonExe "D:\Python\iPhoto\.venv\Scripts\python.exe" `
+  -LibraryRootToRedact "D:\Photos"
+```
+
+## Run a newly built packaged executable
+
+Pass the executable explicitly. To obtain persistent runtime stack traces, the executable
+must be built from a revision containing this collector.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1 `
+  -AppPath ".\build\entrypoint.dist\entrypoint.exe" `
+  -LibraryRootToRedact "D:\Photos"
+```
+
+## Reproduction flow
+
+1. Let the collector launch iPhoto.
+2. Start the same scan and keep selecting normal JPG/PNG photos until the failure appears.
+3. While a blank still photo and the unresponsive Edit behavior are visible, return to the
+   PowerShell window and press `R` once. This writes a precise timestamp marker.
+4. Test fullscreen once, then close iPhoto normally. If it cannot close, press `Q` in the
+   collector window to stop it.
+5. Send back the single ZIP path printed in green. By default it is created on the Desktop.
+
+The default timeout is 30 minutes. Override it with `-MaxMinutes 60` if the scan takes longer.
+The expanded directory is retained beside the ZIP so its contents can be reviewed before
+sharing.
+
+## Bundle contents
+
+- `detail_events.jsonl`: decode, presentation, render-session, Edit/fullscreen, and selection events.
+- `stderr.log`: privacy-safe performance events and Qt graphics/multimedia diagnostics.
+- `runtime_stacks.log`: all Python thread stacks every five seconds.
+- `process_metrics.csv`: memory, handles, threads, GDI/USER objects, and hung-window state.
+- `reproduction_markers.jsonl`: application lifecycle and the user-entered `R` marker.
+- `system.json`: OS, GPU driver, memory, launcher mode, application hash, and source revision.
+- `windows_application_events.json`: bounded warning/error events generated during the run.
+- `app-logs/`: normal rotating iPhoto logs redirected into this session.
+
+Before sharing, the ZIP may be opened and reviewed. Do not edit files in the expanded directory
+after the ZIP is created unless the ZIP is regenerated, because `manifest.json` records hashes.

--- a/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
+++ b/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
@@ -52,7 +52,9 @@ Phase 2 still 采样必须同时保留以下事件，并按 `asset_id + generati
 
 - `level_selected`：检查 `suffix`、`decode_level`、物理 viewport、请求原因；`full` 必须有可解释的
   极端 crop、未知旧库尺寸或 texture-limit 原因。
-- `backend_selected`：记录格式实际使用 `qt` 或 `rawpy`，不得从扩展名推断 backend。
+- `backend_selected`：记录格式实际使用 `qt`、`wic` 或 `rawpy` 以及 worker 解码耗时，
+  不得从扩展名推断 backend。Windows JPEG 路由变更必须在同一台机器、同一批样本上与变更前基线比较；
+  `jpeg-cold` 和 `jpeg-hot-gpu` 的 `click_to_image` P50/P95 均不得回退，并继续满足 150/80ms 绝对门槛。
 - `decode_fallback`：统计 `pillow`、`qt_full_scale`、`half`、`full`、`full_level`；没有 fallback
   的样本也要计入分母。
 - `surface_ready`：核对最终 detached surface 的宽高与 decode level。

--- a/src/iPhoto/bootstrap/library_probe.py
+++ b/src/iPhoto/bootstrap/library_probe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import subprocess
@@ -51,6 +52,7 @@ MAX_STDERR_BYTES = 16 * 1024
 MAX_ALBUMS = 10_000
 MAX_REQUEST_BYTES = 256 * 1024
 ALBUM_SNAPSHOT_BUDGET_MS = 750.0
+_LOGGER = logging.getLogger(__name__)
 
 _FAILURE_MESSAGES = {
     "db_locked": (
@@ -775,9 +777,11 @@ class LibraryProbeController(QObject):
         if status == QProcess.ExitStatus.CrashExit:
             self.failed.emit(_failure(request.request_id, "process_crashed"))
             return
+        response_protocol: int | None = None
         try:
             envelope = json.loads(stdout)
-            if int(envelope.get("protocol_version", -1)) != PROBE_PROTOCOL_VERSION:
+            response_protocol = int(envelope.get("protocol_version", -1))
+            if response_protocol != PROBE_PROTOCOL_VERSION:
                 raise ValueError("protocol version mismatch")
             if envelope.get("request_path") != request.path:
                 self.failed.emit(_failure(request.request_id, "root_mismatch"))
@@ -819,7 +823,17 @@ class LibraryProbeController(QObject):
             ):
                 self.failed.emit(_failure(request.request_id, "root_mismatch"))
                 return
-        except Exception:  # noqa: BLE001 - child-process protocol boundary
+        except Exception as exc:  # noqa: BLE001 - child-process protocol boundary
+            _LOGGER.warning(
+                "Library helper protocol rejected: expected=%s response=%s "
+                "exit_code=%s stdout_bytes=%s stderr_bytes=%s exception=%s",
+                PROBE_PROTOCOL_VERSION,
+                response_protocol,
+                exit_code,
+                len(self._stdout),
+                len(self._stderr),
+                type(exc).__name__,
+            )
             self.failed.emit(_failure(request.request_id, "invalid_protocol"))
             return
         try:
@@ -837,6 +851,16 @@ class LibraryProbeController(QObject):
             self._on_finished(process, exit_code, status)
 
 
+def _source_probe_entrypoint() -> Path | None:
+    """Return the checkout entrypoint that imports the same source tree."""
+
+    candidate = Path(__file__).resolve().parents[2] / "entrypoint.py"
+    try:
+        return candidate if candidate.is_file() else None
+    except OSError:
+        return None
+
+
 def _probe_process_command() -> tuple[str, list[str]]:
     """Return a helper command that survives renamed packaged executables.
 
@@ -849,6 +873,13 @@ def _probe_process_command() -> tuple[str, list[str]]:
     if getattr(sys, "frozen", False) or "__compiled__" in globals():
         application_path = os.fspath(QCoreApplication.applicationFilePath())
         return application_path or sys.executable, [
+            "--startup-library-probe",
+            "--stdin",
+        ]
+    source_entrypoint = _source_probe_entrypoint()
+    if source_entrypoint is not None:
+        return sys.executable, [
+            os.fspath(source_entrypoint),
             "--startup-library-probe",
             "--stdin",
         ]

--- a/src/iPhoto/bootstrap/startup_orchestrator.py
+++ b/src/iPhoto/bootstrap/startup_orchestrator.py
@@ -192,6 +192,10 @@ class StartupOrchestrator(QObject):
 
     @staticmethod
     def _cancel_hang_diagnostics() -> None:
+        from iPhoto.runtime_diagnostics import runtime_diagnostics_active
+
+        if runtime_diagnostics_active():
+            return
         try:
             import faulthandler
 

--- a/src/iPhoto/cache/index_store/engine.py
+++ b/src/iPhoto/cache/index_store/engine.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional
 
+from ...sqlite_utils import configure_sqlite_connection
 from ...utils.logging import get_logger
 
 logger = get_logger()
@@ -56,8 +57,7 @@ class DatabaseManager:
     def _create_connection(self) -> sqlite3.Connection:
         """Create a new database connection with optimised PRAGMA settings."""
         conn = sqlite3.connect(self.db_path, timeout=10.0)
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA synchronous=NORMAL")
+        configure_sqlite_connection(conn, self.db_path, wal=True)
         conn.execute("PRAGMA cache_size=-8000")  # 8 MB cache
         return conn
 

--- a/src/iPhoto/cache/index_store/engine.py
+++ b/src/iPhoto/cache/index_store/engine.py
@@ -15,6 +15,7 @@ from ...sqlite_utils import configure_sqlite_connection
 from ...utils.logging import get_logger
 
 logger = get_logger()
+INDEX_SQLITE_BUSY_TIMEOUT_MS = 10_000
 
 
 class DatabaseManager:
@@ -56,8 +57,16 @@ class DatabaseManager:
 
     def _create_connection(self) -> sqlite3.Connection:
         """Create a new database connection with optimised PRAGMA settings."""
-        conn = sqlite3.connect(self.db_path, timeout=10.0)
-        configure_sqlite_connection(conn, self.db_path, wal=True)
+        conn = sqlite3.connect(
+            self.db_path,
+            timeout=INDEX_SQLITE_BUSY_TIMEOUT_MS / 1000,
+        )
+        configure_sqlite_connection(
+            conn,
+            self.db_path,
+            wal=True,
+            busy_timeout_ms=INDEX_SQLITE_BUSY_TIMEOUT_MS,
+        )
         conn.execute("PRAGMA cache_size=-8000")  # 8 MB cache
         return conn
 

--- a/src/iPhoto/cache/index_store/repository.py
+++ b/src/iPhoto/cache/index_store/repository.py
@@ -1641,54 +1641,73 @@ class AssetRepository:
     def find_row_by_path(self, query: CollectionQuery, path: Path) -> int | None:
         """Return a path's row number within *query* without scanning rows in Python."""
 
-        rel = self._library_relative_path(path)
-        row = self.get_rows_by_rels([rel]).get(rel)
-        if row is None:
-            return None
-        asset_id = str(row.get("id") or "")
-        asset_rel = str(row.get("rel") or "")
-        sort_col = QueryBuilder._collection_sort_column(query)
-        sort_value = row.get(sort_col)
-        if sort_value is None and sort_col == "sort_ts":
-            sort_value = row.get("ts")
-        if not asset_id or not asset_rel or sort_value is None:
-            return None
-
-        match_sql, match_params = QueryBuilder.build_collection_query(
-            query,
-            select_clause="SELECT COUNT(*)",
-            include_order=False,
-        )
-        match_sql += " AND rel = ?" if " WHERE " in match_sql else " WHERE rel = ?"
-        match_params.append(rel)
-
-        conn = self._db_manager.get_connection()
-        should_close = conn != self._db_manager._conn
+        started = monotonic_ms()
+        outcome = "missing"
         try:
-            matched = conn.execute(match_sql, match_params).fetchone()
-            if not matched or int(matched[0] or 0) == 0:
+            rel = self._library_relative_path(path)
+            row = self.get_rows_by_rels([rel]).get(rel)
+            if row is None:
+                return None
+            asset_id = str(row.get("id") or "")
+            asset_rel = str(row.get("rel") or "")
+            sort_col = QueryBuilder._collection_sort_column(query)
+            sort_value = row.get(sort_col)
+            if sort_value is None and sort_col == "sort_ts":
+                sort_value = row.get("ts")
+            if not asset_id or not asset_rel or sort_value is None:
                 return None
 
-            before_where, before_params = QueryBuilder.build_collection_where(query)
-            if query.sort_direction.value == "ASC":
-                before_where.append(
-                    f"({sort_col} < ? OR ({sort_col} = ? AND "
-                    "(id < ? OR (id = ? AND rel < ?))))"
-                )
-            else:
-                before_where.append(
-                    f"({sort_col} > ? OR ({sort_col} = ? AND "
-                    "(id > ? OR (id = ? AND rel > ?))))"
-                )
-            before_params.extend(
-                [sort_value, sort_value, asset_id, asset_id, asset_rel]
+            match_sql, match_params = QueryBuilder.build_collection_query(
+                query,
+                select_clause="SELECT COUNT(*)",
+                include_order=False,
             )
-            before_sql = "SELECT COUNT(*) FROM assets WHERE " + " AND ".join(before_where)
-            before = conn.execute(before_sql, before_params).fetchone()
-            return int(before[0] if before else 0)
+            match_sql += " AND rel = ?" if " WHERE " in match_sql else " WHERE rel = ?"
+            match_params.append(rel)
+
+            conn = self._db_manager.get_connection()
+            should_close = conn != self._db_manager._conn
+            try:
+                matched = conn.execute(match_sql, match_params).fetchone()
+                if not matched or int(matched[0] or 0) == 0:
+                    return None
+
+                before_where, before_params = QueryBuilder.build_collection_where(query)
+                if query.sort_direction.value == "ASC":
+                    before_where.append(
+                        f"({sort_col} < ? OR ({sort_col} = ? AND "
+                        "(id < ? OR (id = ? AND rel < ?))))"
+                    )
+                else:
+                    before_where.append(
+                        f"({sort_col} > ? OR ({sort_col} = ? AND "
+                        "(id > ? OR (id = ? AND rel > ?))))"
+                    )
+                before_params.extend(
+                    [sort_value, sort_value, asset_id, asset_id, asset_rel]
+                )
+                before_sql = "SELECT COUNT(*) FROM assets WHERE " + " AND ".join(before_where)
+                before = conn.execute(before_sql, before_params).fetchone()
+                resolved_row = int(before[0] if before else 0)
+                outcome = "resolved"
+                return resolved_row
+            finally:
+                if should_close:
+                    conn.close()
+        except sqlite3.Error:
+            outcome = "sqlite_error"
+            raise
+        except Exception:
+            outcome = "error"
+            raise
         finally:
-            if should_close:
-                conn.close()
+            emit_perf_event(
+                "find_row_by_path_finished",
+                elapsed_ms=round(monotonic_ms() - started, 3),
+                outcome=outcome,
+                on_main_thread=threading.current_thread() is threading.main_thread(),
+                thread=threading.current_thread().name,
+            )
 
     def find_live_partner(self, asset_id: str) -> Dict[str, Any] | None:
         """Return the row for an asset's Live Photo partner, if indexed."""

--- a/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
+++ b/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
@@ -439,6 +439,7 @@ class DesktopCoordinatorRuntime(QObject):
             zoom_handler=self._playback.zoom_handler,
         )
         self._edit.stillEditFinished.connect(self._playback.handle_still_edit_finished)
+        self._edit.editUnavailable.connect(self._status_bar.show_message)
         self._shortcut_manager.set_edit_coordinator(self._edit)
         return self._edit
 

--- a/src/iPhoto/gui/coordinators/edit_coordinator.py
+++ b/src/iPhoto/gui/coordinators/edit_coordinator.py
@@ -1,6 +1,7 @@
 """Coordinator for the Edit View workflow."""
 
 from __future__ import annotations
+
 import logging
 import math
 from pathlib import Path
@@ -9,9 +10,9 @@ from typing import TYPE_CHECKING, Callable, Optional
 from PySide6.QtCore import QObject, QSize, Qt, QThreadPool, QTimer, Signal
 from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
-    QApplication,
     QAbstractSlider,
     QAbstractSpinBox,
+    QApplication,
     QComboBox,
     QLineEdit,
     QPlainTextEdit,
@@ -20,27 +21,6 @@ from PySide6.QtWidgets import (
 )
 
 from iPhoto.application.ports import EditServicePort
-from iPhoto.gui.coordinators.view_router import ViewRouter
-from iPhoto.events.bus import EventBus
-from iPhoto.gui.ui.models.edit_session import EditSession
-from iPhoto.gui.ui.controllers.edit_history_manager import EditHistoryManager
-from iPhoto.gui.ui.controllers.edit_pipeline_loader import EditPipelineLoader
-from iPhoto.gui.ui.controllers.edit_zoom_handler import EditZoomHandler
-from iPhoto.gui.ui.controllers.edit_modes import AdjustModeState, CropModeState
-from iPhoto.gui.ui.controllers.header_controller import HeaderController
-from iPhoto.gui.ui.controllers.edit_fullscreen_manager import EditFullscreenManager
-from iPhoto.gui.ui.controllers.edit_view_transition import EditViewTransitionManager
-from iPhoto.gui.ui.tasks.video_trim_thumbnail_worker import VideoTrimThumbnailWorker
-from iPhoto.gui.ui.tasks.video_sidebar_preview_worker import (
-    VideoSidebarPreviewResult,
-    VideoSidebarPreviewWorker,
-)
-from iPhoto.gui.ui.palette import viewer_surface_color
-from iPhoto.gui.ui.media import MediaRestoreRequest
-from iPhoto.io.metadata import read_video_meta
-from iPhoto.media_classifier import VIDEO_EXTENSIONS
-from iPhoto.utils.logging import get_logger
-from iPhoto.utils.ffmpeg import probe_video_rotation
 from iPhoto.core.adjustment_mapping import (
     VIDEO_TRIM_IN_KEY,
     VIDEO_TRIM_OUT_KEY,
@@ -50,12 +30,34 @@ from iPhoto.core.adjustment_mapping import (
 from iPhoto.core.curve_resolver import DEFAULT_CURVE_POINTS
 from iPhoto.core.levels_resolver import DEFAULT_LEVELS_HANDLES
 from iPhoto.core.selective_color_resolver import DEFAULT_SELECTIVE_COLOR_RANGES
+from iPhoto.events.bus import EventBus
+from iPhoto.gui.coordinators.view_router import ViewRouter
+from iPhoto.gui.detail_profile import emit_detail_event
+from iPhoto.gui.ui.controllers.edit_fullscreen_manager import EditFullscreenManager
+from iPhoto.gui.ui.controllers.edit_history_manager import EditHistoryManager
+from iPhoto.gui.ui.controllers.edit_modes import AdjustModeState, CropModeState
+from iPhoto.gui.ui.controllers.edit_pipeline_loader import EditPipelineLoader
+from iPhoto.gui.ui.controllers.edit_view_transition import EditViewTransitionManager
+from iPhoto.gui.ui.controllers.edit_zoom_handler import EditZoomHandler
+from iPhoto.gui.ui.controllers.header_controller import HeaderController
+from iPhoto.gui.ui.media import MediaRestoreRequest
+from iPhoto.gui.ui.models.edit_session import EditSession
+from iPhoto.gui.ui.palette import viewer_surface_color
+from iPhoto.gui.ui.tasks.video_sidebar_preview_worker import (
+    VideoSidebarPreviewResult,
+    VideoSidebarPreviewWorker,
+)
+from iPhoto.gui.ui.tasks.video_trim_thumbnail_worker import VideoTrimThumbnailWorker
+from iPhoto.io.metadata import read_video_meta
+from iPhoto.media_classifier import VIDEO_EXTENSIONS
+from iPhoto.utils.ffmpeg import probe_video_rotation
+from iPhoto.utils.logging import get_logger
 
 if TYPE_CHECKING:
-    from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAdapter
-    from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeController
     from iPhoto.gui.coordinators.navigation_coordinator import NavigationCoordinator
+    from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeController
     from iPhoto.gui.ui.media import MediaAdjustmentCommitter, MediaSelectionSession
+    from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAdapter
 
 _LOGGER = logging.getLogger(__name__)
 _APP_LOGGER = get_logger().getChild("video_trim")
@@ -69,6 +71,7 @@ class EditCoordinator(QObject):
     """
 
     stillEditFinished = Signal(Path, str)
+    editUnavailable = Signal(str)
 
     def __init__(
         self,
@@ -381,6 +384,16 @@ class EditCoordinator(QObject):
             render_handle = acquire(asset_path) if callable(acquire) else None
             if render_handle is None:
                 _LOGGER.warning("No resident render session is available for %s", asset_path)
+                emit_detail_event(
+                    "render_session_unavailable",
+                    generation=int(
+                        getattr(self._render_session_controller, "_request_generation", 0)
+                    ),
+                    asset_id=asset_path.name,
+                )
+                self.editUnavailable.emit(
+                    "The photo is still loading. Try Edit again when it appears."
+                )
                 self._current_source = None
                 return
             self._render_session_handle = render_handle

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from PySide6.QtCore import (
-    QItemSelectionModel,
     QLocale,
     QModelIndex,
     QObject,
@@ -2220,9 +2219,7 @@ class PlaybackCoordinator(QObject):
         if hasattr(model, "mapFromSource"):
             idx = model.mapFromSource(idx)
         if idx.isValid():
-            self._filmstrip_view.selectionModel().setCurrentIndex(
-                idx, QItemSelectionModel.ClearAndSelect
-            )
+            self._filmstrip_view.select_index_for_centering(idx)
         return idx
 
     def _center_filmstrip_if_current(self, row: int, generation: int) -> None:

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -1018,10 +1018,18 @@ class PlaybackCoordinator(QObject):
         self._current_presentation = presentation
         self._detail_request_generation = int(presentation.request_generation)
         row = presentation.row
-        self._asset_model.set_current_asset(row, presentation.path)
-        self.assetChanged.emit(row)
+        authoritative_row = row if row >= 0 else None
+        visual_row = self._asset_model.set_current_asset(
+            authoritative_row,
+            presentation.path,
+        )
+        if not isinstance(visual_row, int) or visual_row < 0:
+            visual_row = authoritative_row
+        if authoritative_row is not None:
+            self.assetChanged.emit(authoritative_row)
         self._update_header(presentation)
-        self._select_filmstrip_row(row)
+        if visual_row is not None:
+            self._select_filmstrip_row(visual_row)
         same_render_request = (
             previous is not None
             and previous.render_key == presentation.render_key
@@ -1034,9 +1042,7 @@ class PlaybackCoordinator(QObject):
                 asset_id=presentation.asset_id,
                 row=row,
             )
-            favorite_button = getattr(self, "_favorite_button", None)
-            if favorite_button is not None:
-                favorite_button.setEnabled(presentation.can_toggle_favorite)
+            self._reconcile_action_capabilities(presentation)
             self._update_favorite_icon(presentation.is_favorite)
             if self._info_panel and presentation.info_panel_visible:
                 self._refresh_info_panel(presentation.info)
@@ -1173,11 +1179,8 @@ class PlaybackCoordinator(QObject):
         self._active_live_still = None
         self._active_live_asset_id = ""
 
-        self._favorite_button.setEnabled(presentation.can_toggle_favorite)
+        self._reconcile_action_capabilities(presentation)
         self._info_button.setEnabled(True)
-        self._share_button.setEnabled(presentation.can_share)
-        self._edit_button.setEnabled(presentation.can_edit and presentation.is_video)
-        self._rotate_button.setEnabled(presentation.can_rotate)
         self._update_favorite_icon(presentation.is_favorite)
 
         self._zoom_slider.blockSignals(True)
@@ -1264,7 +1267,11 @@ class PlaybackCoordinator(QObject):
         if self._info_panel and presentation.info_panel_visible:
             self._refresh_info_panel(presentation.info)
             self._info_panel.show()
-        elif self._info_panel and self._info_panel.isVisible() and not presentation.info_panel_visible:
+        elif (
+            self._info_panel
+            and self._info_panel.isVisible()
+            and not presentation.info_panel_visible
+        ):
             self._info_panel.close()
         log_detail_profile(
             "playback",
@@ -1275,6 +1282,33 @@ class PlaybackCoordinator(QObject):
         )
         self._clear_play_profile(presentation.row)
         self._schedule_deferred_location(presentation)
+
+    def _reconcile_action_capabilities(
+        self,
+        presentation: DetailPresentation,
+    ) -> None:
+        """Apply one capability snapshot without changing the render session."""
+
+        capability_buttons = (
+            ("_favorite_button", presentation.can_toggle_favorite),
+            ("_share_button", presentation.can_share),
+            ("_rotate_button", presentation.can_rotate),
+        )
+        for attribute, enabled in capability_buttons:
+            button = getattr(self, attribute, None)
+            if button is not None:
+                button.setEnabled(bool(enabled))
+
+        edit_enabled = bool(presentation.can_edit)
+        if not presentation.is_video:
+            edit_enabled = edit_enabled and (
+                getattr(self, "_presented_still_source", None) == presentation.path
+                and getattr(self, "_presented_still_generation", 0)
+                == int(presentation.request_generation)
+            )
+        edit_button = getattr(self, "_edit_button", None)
+        if edit_button is not None:
+            edit_button.setEnabled(edit_enabled)
 
     def _schedule_deferred_location(self, presentation: DetailPresentation) -> None:
         if (
@@ -1575,9 +1609,7 @@ class PlaybackCoordinator(QObject):
             return
         self._presented_still_source = presented_source
         self._presented_still_generation = int(generation)
-        edit_button = getattr(self, "_edit_button", None)
-        if edit_button is not None:
-            edit_button.setEnabled(presentation.can_edit)
+        self._reconcile_action_capabilities(presentation)
         self._schedule_recognition_overlay(presentation, int(generation))
         if not getattr(self, "_active_live_motion", None):
             self._prefetch_neighbor_stills(presentation.row)

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -1018,7 +1018,7 @@ class PlaybackCoordinator(QObject):
         self._current_presentation = presentation
         self._detail_request_generation = int(presentation.request_generation)
         row = presentation.row
-        self._asset_model.set_current_row(row)
+        self._asset_model.set_current_asset(row, presentation.path)
         self.assetChanged.emit(row)
         self._update_header(presentation)
         self._select_filmstrip_row(row)

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -38,6 +38,7 @@ from iPhoto.gui.detail_pipeline import (
 from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
 from iPhoto.gui.detail_render_coordinator import (
     DetailRenderCoordinator,
+    DetailRenderState,
     DetailSurfacePresentationResult,
 )
 from iPhoto.gui.i18n import tr
@@ -514,6 +515,28 @@ class PlaybackCoordinator(QObject):
             source_identity=identity,
         )
 
+    @staticmethod
+    def _transaction_for_presentation(
+        presentation: DetailPresentation,
+    ) -> DetailRenderTransaction:
+        identity = presentation.source_identity or AssetSourceIdentity.from_info(
+            presentation.path,
+            presentation.info,
+        )
+        media_kind = "video" if presentation.is_video else "image"
+        if (
+            media_kind == "image"
+            and presentation.is_live
+            and presentation.live_motion_abs is not None
+        ):
+            media_kind = "live_motion"
+        return DetailRenderTransaction(
+            generation=presentation.request_generation,
+            asset_id=presentation.asset_id,
+            media_kind=media_kind,
+            source_identity=identity,
+        )
+
     def _async_token_is_current(
         self,
         token: object,
@@ -683,6 +706,41 @@ class PlaybackCoordinator(QObject):
         target_row = current_row if current_row >= 0 else 0
         if current_row < 0 or not self._router.is_detail_view_active():
             self.play_asset(target_row)
+            return True
+        presentation = getattr(self, "_current_presentation", None)
+        if presentation is None:
+            self.play_asset(target_row)
+            return True
+        if presentation.is_video or getattr(self, "_active_live_motion", None):
+            return True
+
+        has_session = getattr(self._player_view, "has_current_render_session", None)
+        if callable(has_session) and has_session(presentation.path):
+            return True
+
+        expected = self._transaction_for_presentation(presentation)
+        snapshot = self._render_transaction_coordinator().snapshot
+        if (
+            snapshot is not None
+            and snapshot.transaction == expected
+            and snapshot.state
+            in {
+                DetailRenderState.CREATED,
+                DetailRenderState.ROUTED,
+                DetailRenderState.PREPARING,
+            }
+        ):
+            # Fullscreen will emit viewportMetricsChanged; keep the one active
+            # decode rather than starting a competing request.
+            return True
+
+        emit_detail_event(
+            "fullscreen_still_recovery",
+            generation=presentation.request_generation,
+            asset_id=presentation.asset_id,
+            state=snapshot.state.value if snapshot is not None else "missing",
+        )
+        self._detail_vm.show_current()
         return True
 
     def show_placeholder_in_viewer(self) -> None:
@@ -699,6 +757,9 @@ class PlaybackCoordinator(QObject):
         still_presented = getattr(self._player_view, "stillFramePresented", None)
         if still_presented is not None:
             still_presented.connect(self._on_still_frame_presented)
+        still_failed = getattr(self._player_view, "imageLoadingFailed", None)
+        if still_failed is not None:
+            still_failed.connect(self._on_still_loading_failed)
         self._player_view.video_area.playbackStateChanged.connect(self._sync_playback_state)
         self._player_view.video_area.playbackFinished.connect(self._handle_playback_finished)
         self._player_view.video_area.durationChanged.connect(self._on_video_duration_changed)
@@ -959,47 +1020,70 @@ class PlaybackCoordinator(QObject):
         self._asset_model.set_current_row(row)
         self.assetChanged.emit(row)
         self._update_header(presentation)
-        same_asset = (
+        self._select_filmstrip_row(row)
+        same_render_request = (
             previous is not None
-            and previous.row == presentation.row
-            and previous.path == presentation.path
-            and previous.reload_token == presentation.reload_token
+            and previous.render_key == presentation.render_key
             and previous.request_generation == presentation.request_generation
         )
-        if same_asset:
+        if same_render_request:
+            emit_detail_event(
+                "render_transaction_reused",
+                generation=presentation.request_generation,
+                asset_id=presentation.asset_id,
+                row=row,
+            )
             self._update_favorite_icon(presentation.is_favorite)
             if self._info_panel and presentation.info_panel_visible:
                 self._refresh_info_panel(presentation.info)
                 self._info_panel.show()
-            elif self._info_panel and self._info_panel.isVisible() and not presentation.info_panel_visible:
+            elif (
+                self._info_panel
+                and self._info_panel.isVisible()
+                and not presentation.info_panel_visible
+            ):
                 self._info_panel.close()
             self._clear_play_profile(presentation.row)
             return
-        identity = presentation.source_identity or AssetSourceIdentity.from_info(
-            presentation.path,
-            presentation.info,
-        )
-        media_kind = "video" if presentation.is_video else "image"
+        transaction = self._transaction_for_presentation(presentation)
+        lifecycle = self._render_transaction_coordinator()
+        active_snapshot = lifecycle.snapshot
         if (
-            media_kind == "image"
-            and presentation.is_live
-            and presentation.live_motion_abs is not None
+            active_snapshot is not None
+            and active_snapshot.transaction.generation == transaction.generation
+            and active_snapshot.transaction != transaction
         ):
-            media_kind = "live_motion"
-        transaction = DetailRenderTransaction(
-            generation=presentation.request_generation,
-            asset_id=presentation.asset_id,
-            media_kind=media_kind,
-            source_identity=identity,
-        )
+            emit_detail_event(
+                "render_generation_collision",
+                generation=transaction.generation,
+                asset_id=transaction.asset_id,
+                state=active_snapshot.state.value,
+            )
+            # A generation may identify only one immutable render input.  Ask
+            # the ViewModel for a new click-generation instead of letting old
+            # and new decoder results share an acceptance token.
+            QTimer.singleShot(0, self._detail_vm.show_current)
+            self._clear_play_profile(presentation.row)
+            return
+        if not lifecycle.begin(transaction):
+            snapshot = lifecycle.snapshot
+            emit_detail_event(
+                "render_transaction_duplicate",
+                generation=presentation.request_generation,
+                asset_id=presentation.asset_id,
+                state=snapshot.state.value if snapshot is not None else "missing",
+            )
+            # The current transaction already owns the decode/presentation.
+            # Never cover its surface or invalidate its async token merely
+            # because Gallery published another view of the same asset.
+            self._clear_play_profile(presentation.row)
+            return
         self._detail_render_transaction = transaction
         self._asset_generation = int(getattr(self, "_asset_generation", 0)) + 1
         self._library_epoch = self._read_library_epoch()
         self._active_async_token = self._token_for_presentation(presentation)
         self._pending_video_token = None
         self._pending_location_token = None
-        self._render_transaction_coordinator().begin(transaction)
-        self._select_filmstrip_row(row)
         self._player_view.show_placeholder("")
         QTimer.singleShot(
             0,
@@ -1048,7 +1132,7 @@ class PlaybackCoordinator(QObject):
         displayed asset instead of transiently degrading it to a still image.
         """
 
-        if previous.row != current.row or previous.path != current.path:
+        if previous.asset_id != current.asset_id or previous.path != current.path:
             return current
         if current.is_live and current.live_motion_abs is not None:
             return current
@@ -1088,7 +1172,7 @@ class PlaybackCoordinator(QObject):
         self._favorite_button.setEnabled(presentation.can_toggle_favorite)
         self._info_button.setEnabled(True)
         self._share_button.setEnabled(presentation.can_share)
-        self._edit_button.setEnabled(presentation.can_edit)
+        self._edit_button.setEnabled(presentation.can_edit and presentation.is_video)
         self._rotate_button.setEnabled(presentation.can_rotate)
         self._update_favorite_icon(presentation.is_favorite)
 
@@ -1487,9 +1571,34 @@ class PlaybackCoordinator(QObject):
             return
         self._presented_still_source = presented_source
         self._presented_still_generation = int(generation)
+        edit_button = getattr(self, "_edit_button", None)
+        if edit_button is not None:
+            edit_button.setEnabled(presentation.can_edit)
         self._schedule_recognition_overlay(presentation, int(generation))
         if not getattr(self, "_active_live_motion", None):
             self._prefetch_neighbor_stills(presentation.row)
+
+    @Slot(object, str)
+    def _on_still_loading_failed(self, source: object, message: str) -> None:
+        presentation = getattr(self, "_current_presentation", None)
+        if presentation is None or presentation.is_video:
+            return
+        try:
+            failed_source = Path(source)
+        except TypeError:
+            return
+        if failed_source != presentation.path:
+            return
+        transaction = getattr(self, "_detail_render_transaction", None)
+        if transaction is None or transaction.source_identity.path != failed_source:
+            return
+        self._render_transaction_coordinator().mark_failed(
+            transaction.generation,
+            str(message),
+        )
+        edit_button = getattr(self, "_edit_button", None)
+        if edit_button is not None:
+            edit_button.setEnabled(False)
 
     def _prefetch_neighbor_stills(self, row: int) -> None:
         descriptor_getter = getattr(

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -45,6 +45,7 @@ from iPhoto.gui.i18n import tr
 from iPhoto.gui.ui.controllers.edit_zoom_handler import EditZoomHandler
 from iPhoto.gui.ui.controllers.header_controller import HeaderController
 from iPhoto.gui.ui.icons import load_icon
+from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
 from iPhoto.gui.ui.widgets import dialogs
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailPresentation, DetailViewModel
 from iPhoto.utils.ffmpeg import probe_video_rotation_info
@@ -704,7 +705,7 @@ class PlaybackCoordinator(QObject):
             return False
         current_row = self.current_row()
         target_row = current_row if current_row >= 0 else 0
-        if current_row < 0 or not self._router.is_detail_view_active():
+        if not self._router.is_detail_view_active():
             self.play_asset(target_row)
             return True
         presentation = getattr(self, "_current_presentation", None)
@@ -1033,6 +1034,9 @@ class PlaybackCoordinator(QObject):
                 asset_id=presentation.asset_id,
                 row=row,
             )
+            favorite_button = getattr(self, "_favorite_button", None)
+            if favorite_button is not None:
+                favorite_button.setEnabled(presentation.can_toggle_favorite)
             self._update_favorite_icon(presentation.is_favorite)
             if self._info_panel and presentation.info_panel_visible:
                 self._refresh_info_panel(presentation.info)
@@ -2333,6 +2337,18 @@ class PlaybackCoordinator(QObject):
 
         row_count = self._asset_model.rowCount()
         if row_count <= 0 or delta == 0:
+            return
+        detail_vm = getattr(self, "_detail_vm", None)
+        state_property = getattr(detail_vm, "selection_state", None)
+        selection_state = getattr(state_property, "value", None)
+        if selection_state in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            if delta > 0:
+                detail_vm.next()
+            else:
+                detail_vm.previous()
             return
         pending_row = self._pending_play_row
         requested_row = getattr(self, "_requested_play_row", None)

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -740,6 +740,15 @@ class PlaybackCoordinator(QObject):
             asset_id=presentation.asset_id,
             state=snapshot.state.value if snapshot is not None else "missing",
         )
+        selection_state_property = getattr(self._detail_vm, "selection_state", None)
+        selection_state = getattr(selection_state_property, "value", None)
+        if selection_state in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.ANCHOR_UNRESOLVED,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            recover = getattr(self._detail_vm, "recover_current_presentation", None)
+            return bool(recover()) if callable(recover) else False
         self._detail_vm.show_current()
         return True
 
@@ -2372,6 +2381,7 @@ class PlaybackCoordinator(QObject):
         selection_state = getattr(state_property, "value", None)
         if selection_state in {
             MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.ANCHOR_UNRESOLVED,
             MediaSelectionState.FALLBACK_PENDING,
         }:
             if delta > 0:

--- a/src/iPhoto/gui/detail_decode_backend.py
+++ b/src/iPhoto/gui/detail_decode_backend.py
@@ -27,6 +27,7 @@ from iPhoto.gui.detail_surface_residency import (
 from iPhoto.utils.deps import load_pillow
 
 _MAX_DETAIL_SURFACE_BYTES = 192 * 1024 * 1024
+_WINDOWS_QT_PREFERRED_SUFFIXES = frozenset({".jpe", ".jpeg", ".jfif", ".jpg"})
 
 
 class DecodeCancelledError(RuntimeError):
@@ -79,7 +80,12 @@ class StillDecodeBackendRegistry:
                 self._qt,
                 fallback_name="imageio_to_qt",
             )
-        if self._platform == "win32" and self._windows is not None:
+        if (
+            self._platform == "win32"
+            and self._windows is not None
+            and request.source_identity.path.suffix.lower()
+            not in _WINDOWS_QT_PREFERRED_SUFFIXES
+        ):
             return FallbackStillDecodeBackend(
                 self._windows,
                 self._qt,

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -334,6 +334,10 @@ def _startup_hang_diagnostics_enabled() -> bool:
 def _enable_startup_hang_diagnostics() -> None:
     """Enable opt-in traceback dumps for startup freezes."""
 
+    from iPhoto.runtime_diagnostics import enable_runtime_diagnostics
+
+    if enable_runtime_diagnostics():
+        return
     if not _startup_hang_diagnostics_enabled():
         return
     try:

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -838,6 +838,14 @@ class PlayerViewController(QObject):
         if metrics is None:
             if intent.reason != "prefetch" and intent.generation == self._request_generation:
                 self._pending_layout_intent = (intent, dict(adjustments))
+                emit_detail_event(
+                    "viewport_waiting",
+                    generation=int(intent.generation),
+                    asset_id=intent.asset_id,
+                )
+                # One queued retry covers the route/layout turn.  If the
+                # viewport is still zero-sized, viewportMetricsChanged wakes
+                # the request later without an unbounded 16 ms timer loop.
                 QTimer.singleShot(0, self._retry_pending_layout_intent)
                 return True
             return False
@@ -1000,6 +1008,9 @@ class PlayerViewController(QObject):
                 self._lod_timer.start()
 
     def _on_viewport_metrics_changed(self) -> None:
+        if self._pending_layout_intent is not None:
+            self._retry_pending_layout_intent()
+            return
         if self._active_source_identity is None:
             return
         zoom_getter = getattr(self._image_viewer, "zoom_factor", None)
@@ -1038,7 +1049,6 @@ class PlayerViewController(QObject):
             self._pending_layout_intent = None
             return
         if self._viewport_metrics() is None:
-            QTimer.singleShot(16, self._retry_pending_layout_intent)
             return
         self._pending_layout_intent = None
         self._dispatch_prepared_intent(intent, adjustments)
@@ -1445,15 +1455,26 @@ class PlayerViewController(QObject):
                     release_observations()
         self._render_sessions.clear()
         if current is not None:
-            self._render_sessions[self._render_session_key_for_surface(current.current_surface)] = current
+            current_key = self._render_session_key_for_surface(current.current_surface)
+            self._render_sessions[current_key] = current
+
+    def has_current_render_session(self, source: Path) -> bool:
+        """Return whether the source owns the currently drawn still texture."""
+
+        session = self._current_render_session
+        if session is None or session.source != Path(source).expanduser().absolute():
+            return False
+        if self._image_viewer.current_image_source() != session.current_texture_key:
+            return False
+        return True
 
     def acquire_render_session(self, source: Path) -> PhotoRenderSessionHandle | None:
         """Acquire the current still session without reading or decoding the source."""
 
-        session = self._current_render_session
-        if session is None or session.source != Path(source).expanduser().absolute():
+        if not self.has_current_render_session(source):
             return None
-        if self._image_viewer.current_image_source() != session.current_texture_key:
+        session = self._current_render_session
+        if session is None:  # Defensive narrowing for static type checkers.
             return None
         session.edit_references += 1
         self._touch_render_session(session)

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -121,10 +121,11 @@ class _StillSurfaceDecodeWorker(QRunnable):
         try:
             decode_started = time.perf_counter()
             surface = self._backend.decode(self._request, self)
+            decode_elapsed_ms = (time.perf_counter() - decode_started) * 1000.0
             log_detail_profile(
                 "still_worker",
                 "decode",
-                (time.perf_counter() - decode_started) * 1000.0,
+                decode_elapsed_ms,
                 path=self._source.name,
             )
         except DecodeCancelledError:
@@ -168,6 +169,7 @@ class _StillSurfaceDecodeWorker(QRunnable):
             suffix=self._source.suffix.lower(),
             backend=surface.backend,
             decode_level=surface.decode_level,
+            duration_ms=decode_elapsed_ms,
         )
         if surface.fallback:
             emit_detail_event(

--- a/src/iPhoto/gui/ui/media/__init__.py
+++ b/src/iPhoto/gui/ui/media/__init__.py
@@ -1,20 +1,27 @@
 """Media playback helpers for the Qt UI."""
 
+from .media_adjustment_committer import MediaAdjustmentCommitter
 from .media_controller import (
     MediaController,
     is_multimedia_available,
     require_multimedia,
 )
-from .media_adjustment_committer import MediaAdjustmentCommitter
 from .media_restore_request import MediaRestoreRequest
+from .media_selection_session import (
+    MediaSelectionChangeReason,
+    MediaSelectionSession,
+    MediaSelectionSnapshot,
+    MediaSelectionState,
+)
 from .playlist_controller import PlaylistController
-from .media_selection_session import MediaSelectionSession, MediaSelectionState
 
 __all__ = [
-    "MediaController",
     "MediaAdjustmentCommitter",
+    "MediaController",
     "MediaRestoreRequest",
+    "MediaSelectionChangeReason",
     "MediaSelectionSession",
+    "MediaSelectionSnapshot",
     "MediaSelectionState",
     "PlaylistController",
     "is_multimedia_available",

--- a/src/iPhoto/gui/ui/media/__init__.py
+++ b/src/iPhoto/gui/ui/media/__init__.py
@@ -8,13 +8,14 @@ from .media_controller import (
 from .media_adjustment_committer import MediaAdjustmentCommitter
 from .media_restore_request import MediaRestoreRequest
 from .playlist_controller import PlaylistController
-from .media_selection_session import MediaSelectionSession
+from .media_selection_session import MediaSelectionSession, MediaSelectionState
 
 __all__ = [
     "MediaController",
     "MediaAdjustmentCommitter",
     "MediaRestoreRequest",
     "MediaSelectionSession",
+    "MediaSelectionState",
     "PlaylistController",
     "is_multimedia_available",
     "require_multimedia",

--- a/src/iPhoto/gui/ui/media/media_selection_session.py
+++ b/src/iPhoto/gui/ui/media/media_selection_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 from typing import Optional, Protocol
 
@@ -21,18 +22,31 @@ class _CollectionReader(Protocol):
     def selection_anchor_status(self, path: Path) -> str | None: ...
 
 
+class MediaSelectionState(str, Enum):
+    """Describe whether the selected asset currently has an authoritative row."""
+
+    NONE = "none"
+    RESOLVED = "resolved"
+    ANCHOR_RESOLVING = "anchor_resolving"
+    FALLBACK_PENDING = "fallback_pending"
+
+
 class MediaSelectionSession:
     """Own the current selected media across detail-related UI."""
 
     def __init__(self) -> None:
         self.currentChanged = Signal()
+        self.selectionStateChanged = Signal()
+        self.navigationRequested = Signal()
         self.restoreRequested = Signal()
 
         self._collection: _CollectionReader | None = None
         self._current_row = -1
         self._current_source: Optional[Path] = None
+        self._selection_state = MediaSelectionState.NONE
         self._last_resolved_row = -1
         self._pending_fallback_row: int | None = None
+        self._pending_navigation_delta = 0
 
     def bind_collection(self, store_or_reader: _CollectionReader) -> None:
         if self._collection is store_or_reader:
@@ -70,8 +84,10 @@ class MediaSelectionSession:
             return None
         self._current_row = row
         self._current_source = dto.abs_path
+        self._set_selection_state(MediaSelectionState.RESOLVED)
         self._last_resolved_row = row
         self._pending_fallback_row = None
+        self._pending_navigation_delta = 0
         pin_path = getattr(self._collection, "pin_path", None)
         if callable(pin_path):
             pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=row)
@@ -92,11 +108,20 @@ class MediaSelectionSession:
     def current_source(self) -> Optional[Path]:
         return self._current_source
 
+    def selection_state(self) -> MediaSelectionState:
+        return self._selection_state
+
     def request_restore(self, request: MediaRestoreRequest) -> None:
         self.restoreRequested.emit(request)
 
     def next_row(self) -> Optional[int]:
         if self._collection is None:
+            return None
+        if self._selection_state in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            self._pending_navigation_delta += 1
             return None
         if self._current_row < 0:
             return 0 if self._collection.count() > 0 else None
@@ -108,6 +133,12 @@ class MediaSelectionSession:
     def previous_row(self) -> Optional[int]:
         if self._collection is None:
             return None
+        if self._selection_state in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            self._pending_navigation_delta -= 1
+            return None
         if self._current_row <= 0:
             return None
         return self._current_row - 1
@@ -116,6 +147,8 @@ class MediaSelectionSession:
         if self._collection is None:
             self._current_row = -1
             self._current_source = None
+            self._set_selection_state(MediaSelectionState.NONE)
+            self._pending_navigation_delta = 0
             self.currentChanged.emit(-1, None)
             return
         if self._current_source is not None:
@@ -126,6 +159,7 @@ class MediaSelectionSession:
             if anchor_status in {"pending", "retry"}:
                 self._current_row = -1
                 self._pending_fallback_row = None
+                self._set_selection_state(MediaSelectionState.ANCHOR_RESOLVING)
                 return
 
             cached_row_for_path = getattr(self._collection, "cached_row_for_path", None)
@@ -141,18 +175,23 @@ class MediaSelectionSession:
                 self._current_row = row
                 self._last_resolved_row = row
                 self._pending_fallback_row = None
+                self._set_selection_state(MediaSelectionState.RESOLVED)
                 self.currentChanged.emit(row, self._current_source)
+                self._dispatch_pending_navigation(row)
                 return
             if callable(cached_row_for_path) and anchor_status != "missing":
                 self._current_row = -1
                 self._pending_fallback_row = None
+                self._set_selection_state(MediaSelectionState.ANCHOR_RESOLVING)
                 return
         count = self._collection.count()
         if count <= 0:
             self._current_row = -1
             self._current_source = None
+            self._set_selection_state(MediaSelectionState.NONE)
             self._last_resolved_row = -1
             self._pending_fallback_row = None
+            self._pending_navigation_delta = 0
             self.currentChanged.emit(-1, None)
             return
         row_hint = self._last_resolved_row if self._last_resolved_row >= 0 else self._current_row
@@ -169,16 +208,35 @@ class MediaSelectionSession:
                 ensure_row_loaded(fallback_row)
             self._current_row = -1
             self._pending_fallback_row = fallback_row
+            self._set_selection_state(MediaSelectionState.FALLBACK_PENDING)
             return
         self._current_row = fallback_row
         self._current_source = dto.abs_path
+        self._set_selection_state(MediaSelectionState.RESOLVED)
         self._last_resolved_row = fallback_row
         self._pending_fallback_row = None
         pin_path = getattr(self._collection, "pin_path", None)
         if callable(pin_path):
             pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=fallback_row)
         self.currentChanged.emit(fallback_row, dto.abs_path)
+        self._dispatch_pending_navigation(fallback_row)
 
     def _handle_row_loaded(self, row: int) -> None:
         if self._pending_fallback_row == row:
             self._select_fallback_row(row)
+
+    def _set_selection_state(self, state: MediaSelectionState) -> None:
+        if self._selection_state is state:
+            return
+        self._selection_state = state
+        self.selectionStateChanged.emit(state)
+
+    def _dispatch_pending_navigation(self, resolved_row: int) -> None:
+        if self._collection is None or self._pending_navigation_delta == 0:
+            return
+        delta = self._pending_navigation_delta
+        self._pending_navigation_delta = 0
+        target_row = resolved_row + delta
+        if target_row < 0 or target_row >= self._collection.count():
+            return
+        self.navigationRequested.emit(target_row)

--- a/src/iPhoto/gui/ui/media/media_selection_session.py
+++ b/src/iPhoto/gui/ui/media/media_selection_session.py
@@ -233,17 +233,6 @@ class MediaSelectionSession:
                 )
                 self._dispatch_pending_navigation(row)
                 return
-            if callable(cached_row_for_path) and anchor_status != "missing":
-                self._pending_fallback_row = None
-                self._publish_snapshot(
-                    state=MediaSelectionState.ANCHOR_RESOLVING,
-                    row=None,
-                    path=stable_path,
-                    asset_id=stable_asset_id,
-                    reason=MediaSelectionChangeReason.ANCHOR_PENDING,
-                )
-                return
-
         count = self._collection.count()
         if count <= 0:
             self._clear_selection()

--- a/src/iPhoto/gui/ui/media/media_selection_session.py
+++ b/src/iPhoto/gui/ui/media/media_selection_session.py
@@ -29,6 +29,7 @@ class MediaSelectionState(str, Enum):
     NONE = "none"
     RESOLVED = "resolved"
     ANCHOR_RESOLVING = "anchor_resolving"
+    ANCHOR_UNRESOLVED = "anchor_unresolved"
     FALLBACK_PENDING = "fallback_pending"
 
 
@@ -38,6 +39,7 @@ class MediaSelectionChangeReason(str, Enum):
     USER_SELECTED = "user_selected"
     ANCHOR_PENDING = "anchor_pending"
     ANCHOR_RESOLVED = "anchor_resolved"
+    ANCHOR_UNRESOLVED = "anchor_unresolved"
     FALLBACK_PENDING = "fallback_pending"
     FALLBACK_RESOLVED = "fallback_resolved"
     CLEARED = "cleared"
@@ -165,6 +167,8 @@ class MediaSelectionSession:
         }:
             self._pending_navigation_delta += 1
             return None
+        if self._snapshot.state is MediaSelectionState.ANCHOR_UNRESOLVED:
+            return self._relative_row_from_last_resolved(1)
         current_row = self.current_row()
         if current_row < 0:
             return 0 if self._collection.count() > 0 else None
@@ -182,6 +186,8 @@ class MediaSelectionSession:
         }:
             self._pending_navigation_delta -= 1
             return None
+        if self._snapshot.state is MediaSelectionState.ANCHOR_UNRESOLVED:
+            return self._relative_row_from_last_resolved(-1)
         current_row = self.current_row()
         if current_row <= 0:
             return None
@@ -208,6 +214,17 @@ class MediaSelectionSession:
                     asset_id=stable_asset_id,
                     reason=MediaSelectionChangeReason.ANCHOR_PENDING,
                 )
+                return
+            if anchor_status == "unresolved":
+                self._pending_fallback_row = None
+                self._publish_snapshot(
+                    state=MediaSelectionState.ANCHOR_UNRESOLVED,
+                    row=None,
+                    path=stable_path,
+                    asset_id=stable_asset_id,
+                    reason=MediaSelectionChangeReason.ANCHOR_UNRESOLVED,
+                )
+                self._dispatch_pending_navigation(self._last_resolved_row)
                 return
 
             cached_row_for_path = getattr(self._collection, "cached_row_for_path", None)
@@ -324,7 +341,25 @@ class MediaSelectionSession:
             return
         delta = self._pending_navigation_delta
         self._pending_navigation_delta = 0
-        target_row = resolved_row + delta
-        if target_row < 0 or target_row >= self._collection.count():
+        count = self._collection.count()
+        if count <= 0:
+            return
+        base_row = min(max(resolved_row, 0), count - 1)
+        target_row = min(max(base_row + delta, 0), count - 1)
+        if target_row == base_row:
             return
         self.navigationRequested.emit(target_row)
+
+    def _relative_row_from_last_resolved(self, delta: int) -> int | None:
+        """Navigate from the last authoritative position after anchor exhaustion."""
+
+        if self._collection is None or delta == 0:
+            return None
+        count = self._collection.count()
+        if count <= 0:
+            return None
+        if self._last_resolved_row < 0:
+            return 0 if delta > 0 else None
+        base_row = min(max(self._last_resolved_row, 0), count - 1)
+        target_row = min(max(base_row + delta, 0), count - 1)
+        return target_row if target_row != base_row else None

--- a/src/iPhoto/gui/ui/media/media_selection_session.py
+++ b/src/iPhoto/gui/ui/media/media_selection_session.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional, Protocol
 
-from .media_restore_request import MediaRestoreRequest
 from iPhoto.gui.viewmodels.signal import Signal
+
+from .media_restore_request import MediaRestoreRequest
 
 
 class _CollectionReader(Protocol):
@@ -16,6 +17,8 @@ class _CollectionReader(Protocol):
     def asset_at(self, row: int): ...
     def ensure_row_loaded(self, row: int, *, emit_signals: bool = True) -> bool: ...
     def row_for_path(self, path: Path) -> int | None: ...
+    def cached_row_for_path(self, path: Path) -> int | None: ...
+    def selection_anchor_status(self, path: Path) -> str | None: ...
 
 
 class MediaSelectionSession:
@@ -28,6 +31,8 @@ class MediaSelectionSession:
         self._collection: _CollectionReader | None = None
         self._current_row = -1
         self._current_source: Optional[Path] = None
+        self._last_resolved_row = -1
+        self._pending_fallback_row: int | None = None
 
     def bind_collection(self, store_or_reader: _CollectionReader) -> None:
         if self._collection is store_or_reader:
@@ -37,8 +42,17 @@ class MediaSelectionSession:
                 self._collection.data_changed.disconnect(self._handle_collection_changed)
             except ValueError:
                 pass
+            row_loaded = getattr(self._collection, "row_loaded", None)
+            if row_loaded is not None:
+                try:
+                    row_loaded.disconnect(self._handle_row_loaded)
+                except ValueError:
+                    pass
         self._collection = store_or_reader
         self._collection.data_changed.connect(self._handle_collection_changed)
+        row_loaded = getattr(self._collection, "row_loaded", None)
+        if row_loaded is not None:
+            row_loaded.connect(self._handle_row_loaded)
         self._handle_collection_changed()
 
     def set_current_row(self, row: int) -> Optional[Path]:
@@ -56,6 +70,11 @@ class MediaSelectionSession:
             return None
         self._current_row = row
         self._current_source = dto.abs_path
+        self._last_resolved_row = row
+        self._pending_fallback_row = None
+        pin_path = getattr(self._collection, "pin_path", None)
+        if callable(pin_path):
+            pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=row)
         self.currentChanged.emit(row, dto.abs_path)
         return dto.abs_path
 
@@ -100,24 +119,66 @@ class MediaSelectionSession:
             self.currentChanged.emit(-1, None)
             return
         if self._current_source is not None:
-            row = self._collection.row_for_path(self._current_source)
+            anchor_status = None
+            anchor_status_for = getattr(self._collection, "selection_anchor_status", None)
+            if callable(anchor_status_for):
+                anchor_status = anchor_status_for(self._current_source)
+            if anchor_status in {"pending", "retry"}:
+                self._current_row = -1
+                self._pending_fallback_row = None
+                return
+
+            cached_row_for_path = getattr(self._collection, "cached_row_for_path", None)
+            if anchor_status == "missing":
+                row = None
+            elif callable(cached_row_for_path):
+                row = cached_row_for_path(self._current_source)
+            else:
+                # Compatibility collections keep all rows in memory. The real
+                # Gallery store always takes the cache-only branch above.
+                row = self._collection.row_for_path(self._current_source)
             if row is not None:
                 self._current_row = row
+                self._last_resolved_row = row
+                self._pending_fallback_row = None
                 self.currentChanged.emit(row, self._current_source)
+                return
+            if callable(cached_row_for_path) and anchor_status != "missing":
+                self._current_row = -1
+                self._pending_fallback_row = None
                 return
         count = self._collection.count()
         if count <= 0:
             self._current_row = -1
             self._current_source = None
+            self._last_resolved_row = -1
+            self._pending_fallback_row = None
             self.currentChanged.emit(-1, None)
             return
-        fallback_row = min(max(self._current_row, 0), count - 1)
+        row_hint = self._last_resolved_row if self._last_resolved_row >= 0 else self._current_row
+        fallback_row = min(max(row_hint, 0), count - 1)
+        self._select_fallback_row(fallback_row)
+
+    def _select_fallback_row(self, fallback_row: int) -> None:
+        if self._collection is None:
+            return
         dto = self._collection.asset_at(fallback_row)
         if dto is None:
+            ensure_row_loaded = getattr(self._collection, "ensure_row_loaded", None)
+            if callable(ensure_row_loaded):
+                ensure_row_loaded(fallback_row)
             self._current_row = -1
-            self._current_source = None
-            self.currentChanged.emit(-1, None)
+            self._pending_fallback_row = fallback_row
             return
         self._current_row = fallback_row
         self._current_source = dto.abs_path
+        self._last_resolved_row = fallback_row
+        self._pending_fallback_row = None
+        pin_path = getattr(self._collection, "pin_path", None)
+        if callable(pin_path):
+            pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=fallback_row)
         self.currentChanged.emit(fallback_row, dto.abs_path)
+
+    def _handle_row_loaded(self, row: int) -> None:
+        if self._pending_fallback_row == row:
+            self._select_fallback_row(row)

--- a/src/iPhoto/gui/ui/media/media_selection_session.py
+++ b/src/iPhoto/gui/ui/media/media_selection_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Protocol
@@ -31,19 +32,53 @@ class MediaSelectionState(str, Enum):
     FALLBACK_PENDING = "fallback_pending"
 
 
+class MediaSelectionChangeReason(str, Enum):
+    """Describe why one coherent selection snapshot was published."""
+
+    USER_SELECTED = "user_selected"
+    ANCHOR_PENDING = "anchor_pending"
+    ANCHOR_RESOLVED = "anchor_resolved"
+    FALLBACK_PENDING = "fallback_pending"
+    FALLBACK_RESOLVED = "fallback_resolved"
+    CLEARED = "cleared"
+
+
+@dataclass(frozen=True, slots=True)
+class MediaSelectionSnapshot:
+    """Immutable selection state shared by Detail-related consumers.
+
+    ``row`` is authoritative only for :attr:`MediaSelectionState.RESOLVED`.
+    Pending snapshots retain the stable asset identity solely so the resident
+    presentation can remain visible while Gallery resolves its new position.
+    """
+
+    version: int
+    state: MediaSelectionState
+    row: int | None
+    path: Path | None
+    asset_id: str | None
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.state is MediaSelectionState.RESOLVED and self.row is not None
+
+
 class MediaSelectionSession:
     """Own the current selected media across detail-related UI."""
 
     def __init__(self) -> None:
-        self.currentChanged = Signal()
-        self.selectionStateChanged = Signal()
+        self.selectionChanged = Signal()
         self.navigationRequested = Signal()
         self.restoreRequested = Signal()
 
         self._collection: _CollectionReader | None = None
-        self._current_row = -1
-        self._current_source: Optional[Path] = None
-        self._selection_state = MediaSelectionState.NONE
+        self._snapshot = MediaSelectionSnapshot(
+            version=0,
+            state=MediaSelectionState.NONE,
+            row=None,
+            path=None,
+            asset_id=None,
+        )
         self._last_resolved_row = -1
         self._pending_fallback_row: int | None = None
         self._pending_navigation_delta = 0
@@ -82,16 +117,20 @@ class MediaSelectionSession:
                 dto = self._collection.asset_at(row)
         if dto is None:
             return None
-        self._current_row = row
-        self._current_source = dto.abs_path
-        self._set_selection_state(MediaSelectionState.RESOLVED)
         self._last_resolved_row = row
         self._pending_fallback_row = None
         self._pending_navigation_delta = 0
         pin_path = getattr(self._collection, "pin_path", None)
         if callable(pin_path):
             pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=row)
-        self.currentChanged.emit(row, dto.abs_path)
+        self._publish_snapshot(
+            state=MediaSelectionState.RESOLVED,
+            row=row,
+            path=dto.abs_path,
+            asset_id=str(dto.id),
+            reason=MediaSelectionChangeReason.USER_SELECTED,
+            force=True,
+        )
         return dto.abs_path
 
     def set_current_by_path(self, path: Path) -> bool:
@@ -102,14 +141,17 @@ class MediaSelectionSession:
             return False
         return self.set_current_row(row) is not None
 
+    def selection_snapshot(self) -> MediaSelectionSnapshot:
+        return self._snapshot
+
     def current_row(self) -> int:
-        return self._current_row
+        return self._snapshot.row if self._snapshot.row is not None else -1
 
     def current_source(self) -> Optional[Path]:
-        return self._current_source
+        return self._snapshot.path
 
     def selection_state(self) -> MediaSelectionState:
-        return self._selection_state
+        return self._snapshot.state
 
     def request_restore(self, request: MediaRestoreRequest) -> None:
         self.restoreRequested.emit(request)
@@ -117,15 +159,16 @@ class MediaSelectionSession:
     def next_row(self) -> Optional[int]:
         if self._collection is None:
             return None
-        if self._selection_state in {
+        if self._snapshot.state in {
             MediaSelectionState.ANCHOR_RESOLVING,
             MediaSelectionState.FALLBACK_PENDING,
         }:
             self._pending_navigation_delta += 1
             return None
-        if self._current_row < 0:
+        current_row = self.current_row()
+        if current_row < 0:
             return 0 if self._collection.count() > 0 else None
-        next_row = self._current_row + 1
+        next_row = current_row + 1
         if next_row >= self._collection.count():
             return None
         return next_row
@@ -133,68 +176,80 @@ class MediaSelectionSession:
     def previous_row(self) -> Optional[int]:
         if self._collection is None:
             return None
-        if self._selection_state in {
+        if self._snapshot.state in {
             MediaSelectionState.ANCHOR_RESOLVING,
             MediaSelectionState.FALLBACK_PENDING,
         }:
             self._pending_navigation_delta -= 1
             return None
-        if self._current_row <= 0:
+        current_row = self.current_row()
+        if current_row <= 0:
             return None
-        return self._current_row - 1
+        return current_row - 1
 
     def _handle_collection_changed(self) -> None:
         if self._collection is None:
-            self._current_row = -1
-            self._current_source = None
-            self._set_selection_state(MediaSelectionState.NONE)
-            self._pending_navigation_delta = 0
-            self.currentChanged.emit(-1, None)
+            self._clear_selection()
             return
-        if self._current_source is not None:
+
+        stable_path = self._snapshot.path
+        stable_asset_id = self._snapshot.asset_id
+        if stable_path is not None:
             anchor_status = None
             anchor_status_for = getattr(self._collection, "selection_anchor_status", None)
             if callable(anchor_status_for):
-                anchor_status = anchor_status_for(self._current_source)
+                anchor_status = anchor_status_for(stable_path)
             if anchor_status in {"pending", "retry"}:
-                self._current_row = -1
                 self._pending_fallback_row = None
-                self._set_selection_state(MediaSelectionState.ANCHOR_RESOLVING)
+                self._publish_snapshot(
+                    state=MediaSelectionState.ANCHOR_RESOLVING,
+                    row=None,
+                    path=stable_path,
+                    asset_id=stable_asset_id,
+                    reason=MediaSelectionChangeReason.ANCHOR_PENDING,
+                )
                 return
 
             cached_row_for_path = getattr(self._collection, "cached_row_for_path", None)
             if anchor_status == "missing":
                 row = None
             elif callable(cached_row_for_path):
-                row = cached_row_for_path(self._current_source)
+                row = cached_row_for_path(stable_path)
             else:
                 # Compatibility collections keep all rows in memory. The real
                 # Gallery store always takes the cache-only branch above.
-                row = self._collection.row_for_path(self._current_source)
+                row = self._collection.row_for_path(stable_path)
             if row is not None:
-                self._current_row = row
+                dto = self._collection.asset_at(row)
+                asset_id = str(dto.id) if dto is not None else stable_asset_id
                 self._last_resolved_row = row
                 self._pending_fallback_row = None
-                self._set_selection_state(MediaSelectionState.RESOLVED)
-                self.currentChanged.emit(row, self._current_source)
+                self._publish_snapshot(
+                    state=MediaSelectionState.RESOLVED,
+                    row=row,
+                    path=stable_path,
+                    asset_id=asset_id,
+                    reason=MediaSelectionChangeReason.ANCHOR_RESOLVED,
+                )
                 self._dispatch_pending_navigation(row)
                 return
             if callable(cached_row_for_path) and anchor_status != "missing":
-                self._current_row = -1
                 self._pending_fallback_row = None
-                self._set_selection_state(MediaSelectionState.ANCHOR_RESOLVING)
+                self._publish_snapshot(
+                    state=MediaSelectionState.ANCHOR_RESOLVING,
+                    row=None,
+                    path=stable_path,
+                    asset_id=stable_asset_id,
+                    reason=MediaSelectionChangeReason.ANCHOR_PENDING,
+                )
                 return
+
         count = self._collection.count()
         if count <= 0:
-            self._current_row = -1
-            self._current_source = None
-            self._set_selection_state(MediaSelectionState.NONE)
-            self._last_resolved_row = -1
-            self._pending_fallback_row = None
-            self._pending_navigation_delta = 0
-            self.currentChanged.emit(-1, None)
+            self._clear_selection()
             return
-        row_hint = self._last_resolved_row if self._last_resolved_row >= 0 else self._current_row
+        current_row = self.current_row()
+        row_hint = self._last_resolved_row if self._last_resolved_row >= 0 else current_row
         fallback_row = min(max(row_hint, 0), count - 1)
         self._select_fallback_row(fallback_row)
 
@@ -206,30 +261,74 @@ class MediaSelectionSession:
             ensure_row_loaded = getattr(self._collection, "ensure_row_loaded", None)
             if callable(ensure_row_loaded):
                 ensure_row_loaded(fallback_row)
-            self._current_row = -1
             self._pending_fallback_row = fallback_row
-            self._set_selection_state(MediaSelectionState.FALLBACK_PENDING)
+            self._publish_snapshot(
+                state=MediaSelectionState.FALLBACK_PENDING,
+                row=None,
+                path=self._snapshot.path,
+                asset_id=self._snapshot.asset_id,
+                reason=MediaSelectionChangeReason.FALLBACK_PENDING,
+            )
             return
-        self._current_row = fallback_row
-        self._current_source = dto.abs_path
-        self._set_selection_state(MediaSelectionState.RESOLVED)
         self._last_resolved_row = fallback_row
         self._pending_fallback_row = None
         pin_path = getattr(self._collection, "pin_path", None)
         if callable(pin_path):
             pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=fallback_row)
-        self.currentChanged.emit(fallback_row, dto.abs_path)
+        self._publish_snapshot(
+            state=MediaSelectionState.RESOLVED,
+            row=fallback_row,
+            path=dto.abs_path,
+            asset_id=str(dto.id),
+            reason=MediaSelectionChangeReason.FALLBACK_RESOLVED,
+        )
         self._dispatch_pending_navigation(fallback_row)
 
     def _handle_row_loaded(self, row: int) -> None:
         if self._pending_fallback_row == row:
             self._select_fallback_row(row)
 
-    def _set_selection_state(self, state: MediaSelectionState) -> None:
-        if self._selection_state is state:
+    def _clear_selection(self) -> None:
+        self._last_resolved_row = -1
+        self._pending_fallback_row = None
+        self._pending_navigation_delta = 0
+        self._publish_snapshot(
+            state=MediaSelectionState.NONE,
+            row=None,
+            path=None,
+            asset_id=None,
+            reason=MediaSelectionChangeReason.CLEARED,
+        )
+
+    def _publish_snapshot(
+        self,
+        *,
+        state: MediaSelectionState,
+        row: int | None,
+        path: Path | None,
+        asset_id: str | None,
+        reason: MediaSelectionChangeReason,
+        force: bool = False,
+    ) -> None:
+        previous = self._snapshot
+        semantic_state = (state, row, path, asset_id)
+        previous_semantic_state = (
+            previous.state,
+            previous.row,
+            previous.path,
+            previous.asset_id,
+        )
+        if not force and semantic_state == previous_semantic_state:
             return
-        self._selection_state = state
-        self.selectionStateChanged.emit(state)
+        snapshot = MediaSelectionSnapshot(
+            version=previous.version + 1,
+            state=state,
+            row=row,
+            path=Path(path) if path is not None else None,
+            asset_id=str(asset_id) if asset_id is not None else None,
+        )
+        self._snapshot = snapshot
+        self.selectionChanged.emit(snapshot, reason)
 
     def _dispatch_pending_navigation(self, resolved_row: int) -> None:
         if self._collection is None or self._pending_navigation_delta == 0:

--- a/src/iPhoto/gui/ui/widgets/filmstrip_view.py
+++ b/src/iPhoto/gui/ui/widgets/filmstrip_view.py
@@ -61,6 +61,10 @@ class FilmstripView(AssetGrid):
         self._last_known_center_asset_id: str | None = None
         self._last_known_anchor_x: int | None = None
         self._restore_scheduled = False
+        self._restore_reason = "unknown"
+        self._restore_timer = QTimer(self)
+        self._restore_timer.setSingleShot(True)
+        self._restore_timer.timeout.connect(self._run_scheduled_restore)
         self._apply_scrollbar_style()
 
     def changeEvent(self, event: QEvent) -> None:
@@ -217,7 +221,11 @@ class FilmstripView(AssetGrid):
         ):
             return
         self._restore_scheduled = True
-        QTimer.singleShot(0, lambda: self._restore_scroll_state(reason or "unknown"))
+        self._restore_reason = reason or "unknown"
+        self._restore_timer.start(0)
+
+    def _run_scheduled_restore(self) -> None:
+        self._restore_scroll_state(self._restore_reason)
 
     def _restore_scroll_state(self, reason: str) -> None:
         self._restore_scheduled = False
@@ -513,6 +521,22 @@ class FilmstripView(AssetGrid):
     # ------------------------------------------------------------------
     # Programmatic scrolling helpers
     # ------------------------------------------------------------------
+    def select_index_for_centering(self, index: QModelIndex) -> bool:
+        """Select *index* and invalidate restoration from an older view state."""
+
+        if not index.isValid() or bool(index.data(Roles.IS_SPACER)):
+            return False
+        self._clear_pending_scroll_restore()
+        selection_model = self.selectionModel()
+        if selection_model is None:
+            return False
+        if selection_model.currentIndex() != index:
+            selection_model.setCurrentIndex(
+                index,
+                QItemSelectionModel.ClearAndSelect,
+            )
+        return True
+
     def center_on_index(self, index: QModelIndex) -> None:
         """Scroll the view so *index* is visually centred in the viewport."""
         if not index.isValid():
@@ -520,11 +544,7 @@ class FilmstripView(AssetGrid):
 
         # Programmatic centering (e.g. entering playback from gallery) should
         # win over any delayed restore from a previous detail session.
-        self._pending_scroll_value = None
-        self._pending_center_row = None
-        self._pending_center_path = None
-        self._pending_center_asset_id = None
-        self._pending_anchor_x = None
+        self._clear_pending_scroll_restore()
 
         item_rect = self.visualRect(index)
         if not item_rect.isValid():
@@ -538,3 +558,14 @@ class FilmstripView(AssetGrid):
         scroll_delta = item_rect.left() - target_left
         scrollbar = self.horizontalScrollBar()
         scrollbar.setValue(scrollbar.value() + int(scroll_delta))
+
+    def _clear_pending_scroll_restore(self) -> None:
+        """Cancel one stale restore transaction and discard its captured state."""
+
+        self._restore_timer.stop()
+        self._restore_scheduled = False
+        self._pending_scroll_value = None
+        self._pending_center_row = None
+        self._pending_center_path = None
+        self._pending_center_asset_id = None
+        self._pending_anchor_x = None

--- a/src/iPhoto/gui/ui/widgets/filmstrip_view.py
+++ b/src/iPhoto/gui/ui/widgets/filmstrip_view.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from PySide6.QtCore import QEvent, QModelIndex, QSize, Qt, Signal, QTimer, QItemSelectionModel
+import os
+from pathlib import Path
+
+from PySide6.QtCore import QEvent, QItemSelectionModel, QModelIndex, QSize, Qt, QTimer, Signal
 from PySide6.QtGui import QPalette, QResizeEvent, QWheelEvent
 from PySide6.QtWidgets import QListView, QSizePolicy, QStyleOptionViewItem
 
-from .asset_grid import AssetGrid
 from ..models.roles import Roles
 from ..styles import modern_scrollbar_style
+from .asset_grid import AssetGrid
 
 
 class FilmstripView(AssetGrid):
@@ -50,7 +53,13 @@ class FilmstripView(AssetGrid):
         self._updating_style = False
         self._pending_scroll_value: int | None = None
         self._pending_center_row: int | None = None
+        self._pending_center_path: Path | None = None
+        self._pending_center_asset_id: str | None = None
+        self._pending_anchor_x: int | None = None
         self._last_known_center_row: int | None = None
+        self._last_known_center_path: Path | None = None
+        self._last_known_center_asset_id: str | None = None
+        self._last_known_anchor_x: int | None = None
         self._restore_scheduled = False
         self._apply_scrollbar_style()
 
@@ -163,22 +172,37 @@ class FilmstripView(AssetGrid):
         """Remember scroll position and current selection before model/layout changes."""
         scrollbar = self.horizontalScrollBar()
         current_row = None
+        anchor_x = None
         selection_model = self.selectionModel()
         if selection_model is not None:
             current = selection_model.currentIndex()
             if current.isValid() and not bool(current.data(Roles.IS_SPACER)):
                 current_row = current.row()
+                rect = self.visualRect(current)
+                if rect.isValid():
+                    anchor_x = int(rect.center().x())
         scroll_value = scrollbar.value()
         if current_row is None and self._last_known_center_row is not None:
             current_row = self._last_known_center_row
+        if anchor_x is None:
+            anchor_x = self._last_known_anchor_x
 
-        if current_row is None and scroll_value == 0:
+        if (
+            current_row is None
+            and self._last_known_center_path is None
+            and scroll_value == 0
+        ):
             return
 
         self._pending_scroll_value = scroll_value
         self._pending_center_row = current_row
+        self._pending_center_path = self._last_known_center_path
+        self._pending_center_asset_id = self._last_known_center_asset_id
+        self._pending_anchor_x = anchor_x
         if current_row is not None:
             self._last_known_center_row = current_row
+        if anchor_x is not None:
+            self._last_known_anchor_x = anchor_x
 
     def _on_rows_removed(self, parent: QModelIndex, start: int, end: int) -> None:
         self._schedule_restore_scroll("rows_removed")
@@ -186,7 +210,11 @@ class FilmstripView(AssetGrid):
     def _schedule_restore_scroll(self, reason: str | None = None) -> None:
         if self._restore_scheduled:
             return
-        if self._pending_scroll_value is None and self._pending_center_row is None:
+        if (
+            self._pending_scroll_value is None
+            and self._pending_center_row is None
+            and self._pending_center_path is None
+        ):
             return
         self._restore_scheduled = True
         QTimer.singleShot(0, lambda: self._restore_scroll_state(reason or "unknown"))
@@ -194,16 +222,30 @@ class FilmstripView(AssetGrid):
     def _restore_scroll_state(self, reason: str) -> None:
         self._restore_scheduled = False
         model = self.model()
-        if self._pending_scroll_value is None and self._pending_center_row is None:
+        if (
+            self._pending_scroll_value is None
+            and self._pending_center_row is None
+            and self._pending_center_path is None
+        ):
             return
         if model is None or model.rowCount() == 0:
             return
 
         scroll_value = self._pending_scroll_value
         center_row = self._pending_center_row
+        center_path = self._pending_center_path
+        center_asset_id = self._pending_center_asset_id
+        anchor_x = self._pending_anchor_x
         scrollbar = self.horizontalScrollBar()
-        restored = False
-        if center_row is not None and 0 <= center_row < model.rowCount():
+        identity_index = self._cached_index_for_path(center_path, center_asset_id)
+        if identity_index.isValid():
+            self._restore_identity_at_anchor(identity_index, anchor_x)
+        elif center_path is not None:
+            # An unresolved scan anchor must never fall through to the old
+            # numeric row: that row may now represent a different photo.
+            if scroll_value is not None:
+                scrollbar.setValue(scroll_value)
+        elif center_row is not None and 0 <= center_row < model.rowCount():
             index = model.index(center_row, 0)
             if index.isValid() and not bool(index.data(Roles.IS_SPACER)):
                 selection_model = self.selectionModel()
@@ -218,6 +260,78 @@ class FilmstripView(AssetGrid):
 
         self._pending_scroll_value = None
         self._pending_center_row = None
+        self._pending_center_path = None
+        self._pending_center_asset_id = None
+        self._pending_anchor_x = None
+
+    def _cached_index_for_path(
+        self,
+        path: Path | None,
+        asset_id: str | None,
+    ) -> QModelIndex:
+        """Resolve a visual anchor through the model's in-memory row cache."""
+
+        model = self.model()
+        if path is None or model is None:
+            return QModelIndex()
+
+        source_model = model
+        source_getter = getattr(model, "sourceModel", None)
+        map_from_source = getattr(model, "mapFromSource", None)
+        if callable(source_getter):
+            candidate = source_getter()
+            if candidate is not None:
+                source_model = candidate
+
+        resolver = getattr(source_model, "cached_row_for_path", None)
+        if not callable(resolver):
+            return QModelIndex()
+        row = resolver(path)
+        if row is None or row < 0 or row >= source_model.rowCount():
+            return QModelIndex()
+
+        source_index = source_model.index(row, 0)
+        if not source_index.isValid():
+            return QModelIndex()
+        index = (
+            map_from_source(source_index)
+            if source_model is not model and callable(map_from_source)
+            else source_index
+        )
+        if not index.isValid() or bool(index.data(Roles.IS_SPACER)):
+            return QModelIndex()
+        resolved_path = index.data(Roles.ABS)
+        if not resolved_path or os.path.normcase(
+            os.path.abspath(str(resolved_path))
+        ) != os.path.normcase(os.path.abspath(str(path))):
+            return QModelIndex()
+        resolved_asset_id = index.data(Roles.ASSET_ID)
+        if (
+            asset_id is not None
+            and resolved_asset_id is not None
+            and str(resolved_asset_id) != asset_id
+        ):
+            return QModelIndex()
+        return index
+
+    def _restore_identity_at_anchor(
+        self,
+        index: QModelIndex,
+        anchor_x: int | None,
+    ) -> None:
+        selection_model = self.selectionModel()
+        if selection_model is not None and selection_model.currentIndex() != index:
+            selection_model.setCurrentIndex(index, QItemSelectionModel.ClearAndSelect)
+
+        if anchor_x is None:
+            self.center_on_index(index)
+            return
+        item_rect = self.visualRect(index)
+        if not item_rect.isValid():
+            return
+        scrollbar = self.horizontalScrollBar()
+        scrollbar.setValue(scrollbar.value() + int(item_rect.center().x()) - anchor_x)
+        self._last_known_anchor_x = anchor_x
 
     def refresh_spacers(self, current_proxy_index: QModelIndex | None = None) -> None:
         """Recalculate spacer padding and optionally use the provided index.
@@ -348,6 +462,16 @@ class FilmstripView(AssetGrid):
         """Track the last non-spacer current row for capture/restore centering logic."""
         if current.isValid() and not bool(current.data(Roles.IS_SPACER)):
             self._last_known_center_row = current.row()
+            path = current.data(Roles.ABS)
+            if path:
+                self._last_known_center_path = Path(str(path))
+                asset_id = current.data(Roles.ASSET_ID)
+                self._last_known_center_asset_id = (
+                    str(asset_id) if asset_id is not None else None
+                )
+            rect = self.visualRect(current)
+            if rect.isValid():
+                self._last_known_anchor_x = int(rect.center().x())
 
     # ------------------------------------------------------------------
     # Event handling
@@ -398,6 +522,9 @@ class FilmstripView(AssetGrid):
         # win over any delayed restore from a previous detail session.
         self._pending_scroll_value = None
         self._pending_center_row = None
+        self._pending_center_path = None
+        self._pending_center_asset_id = None
+        self._pending_anchor_x = None
 
         item_rect = self.visualRect(index)
         if not item_rect.isValid():

--- a/src/iPhoto/gui/ui/widgets/filmstrip_view.py
+++ b/src/iPhoto/gui/ui/widgets/filmstrip_view.py
@@ -157,7 +157,15 @@ class FilmstripView(AssetGrid):
             # Re-calculating layout is expensive, so check if we need it.
             # QListView with uniformItemSizes=False might need a nudge.
             self.scheduleDelayedItemsLayout()
-            self.refresh_spacers(top)
+            # Gallery publishes the old and new current rows separately. The
+            # old row is already narrow when its notification arrives, so using
+            # it as the active width briefly grows both spacers by half the
+            # selected-tile width delta. Windows QListView may commit that
+            # intermediate layout after centering, causing a second jump.
+            # Only the row whose semantic role is current may drive spacers;
+            # select_index_for_centering() supplies the final fallback.
+            if top == bottom and bool(top.data(Roles.IS_CURRENT)):
+                self.refresh_spacers(top)
 
     def resizeEvent(self, event: QResizeEvent) -> None:  # type: ignore[override]
         super().resizeEvent(event)
@@ -334,6 +342,7 @@ class FilmstripView(AssetGrid):
         if anchor_x is None:
             self.center_on_index(index)
             return
+        self._settle_index_geometry(index)
         item_rect = self.visualRect(index)
         if not item_rect.isValid():
             return
@@ -469,17 +478,7 @@ class FilmstripView(AssetGrid):
     ) -> None:
         """Track the last non-spacer current row for capture/restore centering logic."""
         if current.isValid() and not bool(current.data(Roles.IS_SPACER)):
-            self._last_known_center_row = current.row()
-            path = current.data(Roles.ABS)
-            if path:
-                self._last_known_center_path = Path(str(path))
-                asset_id = current.data(Roles.ASSET_ID)
-                self._last_known_center_asset_id = (
-                    str(asset_id) if asset_id is not None else None
-                )
-            rect = self.visualRect(current)
-            if rect.isValid():
-                self._last_known_anchor_x = int(rect.center().x())
+            self._remember_center_identity(current)
 
     # ------------------------------------------------------------------
     # Event handling
@@ -535,6 +534,10 @@ class FilmstripView(AssetGrid):
                 index,
                 QItemSelectionModel.ClearAndSelect,
             )
+        # The source model updates IS_CURRENT before Playback updates Qt's
+        # selection model. Reconcile spacer geometry from the target index so
+        # there is only one stable width during this selection transaction.
+        self.refresh_spacers(index)
         return True
 
     def center_on_index(self, index: QModelIndex) -> None:
@@ -545,6 +548,12 @@ class FilmstripView(AssetGrid):
         # Programmatic centering (e.g. entering playback from gallery) should
         # win over any delayed restore from a previous detail session.
         self._clear_pending_scroll_restore()
+
+        # SizeHintRole and spacer changes are delivered through QListView's
+        # delayed layout machinery. Force that pending geometry to settle in
+        # this callback, before reading visualRect and writing the scrollbar.
+        # No paint can occur between the layout and the final scroll position.
+        self._settle_index_geometry(index)
 
         item_rect = self.visualRect(index)
         if not item_rect.isValid():
@@ -558,6 +567,30 @@ class FilmstripView(AssetGrid):
         scroll_delta = item_rect.left() - target_left
         scrollbar = self.horizontalScrollBar()
         scrollbar.setValue(scrollbar.value() + int(scroll_delta))
+        self._remember_center_identity(index)
+
+    def _settle_index_geometry(self, index: QModelIndex) -> None:
+        """Commit pending tile/spacer size changes before a scroll calculation."""
+
+        self.refresh_spacers(index)
+        self.executeDelayedItemsLayout()
+
+    def _remember_center_identity(self, index: QModelIndex) -> None:
+        """Record the stable identity and its actual post-layout viewport anchor."""
+
+        if not index.isValid() or bool(index.data(Roles.IS_SPACER)):
+            return
+        self._last_known_center_row = index.row()
+        path = index.data(Roles.ABS)
+        if path:
+            self._last_known_center_path = Path(str(path))
+            asset_id = index.data(Roles.ASSET_ID)
+            self._last_known_center_asset_id = (
+                str(asset_id) if asset_id is not None else None
+            )
+        rect = self.visualRect(index)
+        if rect.isValid():
+            self._last_known_anchor_x = int(rect.center().x())
 
     def _clear_pending_scroll_restore(self) -> None:
         """Cancel one stale restore transaction and discard its captured state."""

--- a/src/iPhoto/gui/viewmodels/detail_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/detail_viewmodel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Optional, Protocol
 
@@ -55,6 +55,38 @@ class DetailPresentation:
     request_generation: int = 0
     video_duration_hint: float | None = None
     source_identity: AssetSourceIdentity | None = None
+
+    @property
+    def render_key(self) -> tuple[object, ...]:
+        """Return the stable media identity for one visible render transaction.
+
+        Gallery rows are positional and can move whenever a scan publishes a
+        newly sorted batch.  They must therefore never participate in render
+        identity.  Metadata-only changes (favorite, title, location, and
+        similar chrome) also intentionally stay outside this key.
+        """
+
+        identity = self.source_identity or AssetSourceIdentity.from_info(
+            self.path,
+            self.info,
+        )
+        media_kind = "video" if self.is_video else "image"
+        if media_kind == "image" and self.is_live and self.live_motion_abs is not None:
+            media_kind = "live_motion"
+        live_motion = (
+            Path(self.live_motion_abs).expanduser().absolute()
+            if self.live_motion_abs is not None
+            else None
+        )
+        return (
+            str(self.asset_id),
+            identity.path,
+            media_kind,
+            identity.revision,
+            int(identity.orientation),
+            int(self.reload_token),
+            live_motion,
+        )
 
 
 class DetailViewModel(BaseViewModel):
@@ -240,6 +272,27 @@ class DetailViewModel(BaseViewModel):
             dto,
             request_generation=self._request_generation,
         )
+        previous = self.presentation.value
+        if (
+            isinstance(previous, DetailPresentation)
+            and previous.render_key != presentation.render_key
+        ):
+            # A store refresh normally changes only row/chrome metadata.  If a
+            # real render input changed, give it a fresh generation so a late
+            # result from the old source revision cannot be accepted as current.
+            self._request_generation = max(
+                int(self._request_generation),
+                int(previous.request_generation),
+            ) + 1
+            presentation = replace(
+                presentation,
+                request_generation=self._request_generation,
+            )
+            emit_detail_event(
+                "render_input_changed",
+                generation=self._request_generation,
+                asset_id=presentation.asset_id,
+            )
         self.presentation.value = presentation
         self.presentation_changed.emit(presentation)
 

--- a/src/iPhoto/gui/viewmodels/detail_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/detail_viewmodel.py
@@ -11,7 +11,11 @@ from iPhoto.application.ports import AssetStateServicePort, EditServicePort
 from iPhoto.gui.detail_pipeline import AssetSourceIdentity
 from iPhoto.gui.detail_profile import emit_detail_event
 from iPhoto.gui.ui.media.media_restore_request import MediaRestoreRequest
-from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
+from iPhoto.gui.ui.media.media_selection_session import (
+    MediaSelectionChangeReason,
+    MediaSelectionSnapshot,
+    MediaSelectionState,
+)
 
 from .base import BaseViewModel
 from .gallery_collection_store import GalleryCollectionStore
@@ -23,8 +27,11 @@ class AdjustmentCommitPort(Protocol):
 
 
 class MediaSelectionPort(Protocol):
+    selectionChanged: Signal
+
     def set_current_row(self, row: int) -> Optional[Path]: ...
     def set_current_by_path(self, path: Path) -> bool: ...
+    def selection_snapshot(self) -> MediaSelectionSnapshot: ...
     def current_row(self) -> int: ...
     def current_source(self) -> Optional[Path]: ...
     def selection_state(self) -> MediaSelectionState: ...
@@ -114,20 +121,14 @@ class DetailViewModel(BaseViewModel):
         self._pending_restore_requests: dict[Path, MediaRestoreRequest] = {}
         self._pending_show_row: int | None = None
         self._request_generation = 0
-        self._store.data_changed.connect(self._handle_store_changed)
-        self._store.row_changed.connect(self._handle_row_changed)
-        row_loaded = getattr(self._store, "row_loaded", None)
-        if row_loaded is not None:
-            row_loaded.connect(self._handle_row_loaded)
-        restore_signal = getattr(self._media_session, "restoreRequested", None)
-        if restore_signal is not None:
-            restore_signal.connect(self._handle_restore_requested)
-        navigation_signal = getattr(self._media_session, "navigationRequested", None)
-        if navigation_signal is not None:
-            navigation_signal.connect(self._handle_navigation_requested)
-        committed_signal = getattr(self._adjustment_commit_port, "adjustmentsCommitted", None)
-        if committed_signal is not None:
-            committed_signal.connect(self._handle_adjustments_committed)
+        self._last_selection_version = 0
+        self._selection_snapshot = MediaSelectionSnapshot(
+            version=0,
+            state=MediaSelectionState.NONE,
+            row=None,
+            path=None,
+            asset_id=None,
+        )
 
         self.current_row = ObservableProperty(-1)
         self.current_path = ObservableProperty(None)
@@ -139,6 +140,24 @@ class DetailViewModel(BaseViewModel):
         self.edit_requested = Signal()
         self.rotate_requested = Signal()
 
+        self._store.data_changed.connect(self._handle_store_changed)
+        self._store.row_changed.connect(self._handle_row_changed)
+        row_loaded = getattr(self._store, "row_loaded", None)
+        if row_loaded is not None:
+            row_loaded.connect(self._handle_row_loaded)
+        restore_signal = getattr(self._media_session, "restoreRequested", None)
+        if restore_signal is not None:
+            restore_signal.connect(self._handle_restore_requested)
+        navigation_signal = getattr(self._media_session, "navigationRequested", None)
+        if navigation_signal is not None:
+            navigation_signal.connect(self._handle_navigation_requested)
+        selection_signal = getattr(self._media_session, "selectionChanged", None)
+        if selection_signal is not None:
+            selection_signal.connect(self._handle_selection_changed)
+        committed_signal = getattr(self._adjustment_commit_port, "adjustmentsCommitted", None)
+        if committed_signal is not None:
+            committed_signal.connect(self._handle_adjustments_committed)
+
     def bind_asset_state_service(
         self,
         asset_state_service: AssetStateServicePort | None,
@@ -148,36 +167,71 @@ class DetailViewModel(BaseViewModel):
 
     def show_row(self, row: int) -> None:
         self._request_generation += 1
-        request_generation = self._request_generation
+        self._request_selection_row(row)
+
+    def _request_selection_row(self, row: int) -> None:
+        """Submit one selection command without creating a second generation."""
+
+        count = self._store.count()
+        row_in_collection = row >= 0 and (
+            not isinstance(count, int) or row < count
+        )
+        self._pending_show_row = row if row_in_collection else None
+        previous_version = self._last_selection_version
         source = self._media_session.set_current_row(row)
         if source is None:
-            self._pending_show_row = row if 0 <= row < self._store.count() else None
             return
-        self._pending_show_row = None
-        self._store.pin_row(row)
+
+        # Real MediaSelectionSession publishes synchronously. Older embedders
+        # and narrow test doubles may only implement the read API, so reconcile
+        # a coherent compatibility snapshot when no event arrived.
+        if self._last_selection_version != previous_version:
+            return
         dto = self._store.asset_at(row)
         if dto is None:
             return
-        self.current_row.value = row
-        self.current_path.value = source
-        self.selection_state.value = MediaSelectionState.RESOLVED
+        self._handle_selection_changed(
+            MediaSelectionSnapshot(
+                version=previous_version + 1,
+                state=MediaSelectionState.RESOLVED,
+                row=row,
+                path=dto.abs_path,
+                asset_id=str(dto.id),
+            ),
+            MediaSelectionChangeReason.USER_SELECTED,
+            dto,
+        )
+
+    def _publish_user_selection(
+        self,
+        snapshot: MediaSelectionSnapshot,
+        dto: AssetDTO,
+    ) -> None:
         emit_detail_event(
             "click_received",
-            generation=request_generation,
-            row=row,
+            generation=self._request_generation,
+            row=snapshot.row,
             media_type="video" if dto.is_video else "image",
         )
         # Route before constructing even the lightweight presentation. The
         # coordinator starts all file I/O on a later event-loop turn, allowing
         # the opaque Detail loading surface to paint first.
         self.route_requested.emit("detail")
-        presentation = self._build_presentation(
-            row,
-            dto,
-            request_generation=request_generation,
+        self._refresh_presentation(
+            render_change_already_versioned=True,
+            dto_override=dto,
         )
-        self.presentation.value = presentation
-        self.presentation_changed.emit(presentation)
+
+    def _publish_passive_selection(
+        self,
+        snapshot: MediaSelectionSnapshot,
+        dto: AssetDTO,
+    ) -> None:
+        del snapshot
+        self._refresh_presentation(
+            render_change_already_versioned=False,
+            dto_override=dto,
+        )
 
     def show_current(self) -> None:
         row = self._media_session.current_row()
@@ -195,18 +249,15 @@ class DetailViewModel(BaseViewModel):
             self.show_row(row)
 
     def toggle_favorite(self) -> None:
-        if (
-            self._asset_state_service is None
-            or self._media_selection_state() is not MediaSelectionState.RESOLVED
-        ):
+        if self._asset_state_service is None:
             return
-        row = self._media_session.current_row()
-        if not isinstance(row, int) or row < 0:
-            row = self.current_row.value
-        if not isinstance(row, int) or row < 0:
-            return
-        presentation = self.presentation.value
-        if not isinstance(presentation, DetailPresentation):
+        presentation = self._actionable_presentation(
+            capability="can_toggle_favorite",
+            require_resolved=True,
+        )
+        snapshot = self._media_selection_snapshot()
+        row = snapshot.row
+        if presentation is None or row is None:
             return
         dto = self._store.asset_at(row)
         if (
@@ -233,16 +284,17 @@ class DetailViewModel(BaseViewModel):
             self._refresh_presentation()
 
     def rotate_current(self) -> None:
-        presentation = self.presentation.value
+        presentation = self._actionable_presentation(capability="can_rotate")
         if presentation is None:
             return
         self.rotate_requested.emit(presentation.path, presentation.is_video)
 
     def request_edit(self) -> None:
-        path = self.current_path.value
-        if isinstance(path, Path):
-            self.hide_info_panel(refresh_presentation=True)
-            self.edit_requested.emit(path)
+        presentation = self._actionable_presentation(capability="can_edit")
+        if presentation is None:
+            return
+        self.hide_info_panel(refresh_presentation=True)
+        self.edit_requested.emit(presentation.path)
 
     def back_to_gallery(self) -> None:
         self.hide_info_panel(refresh_presentation=True)
@@ -275,17 +327,22 @@ class DetailViewModel(BaseViewModel):
         return dict(presentation.info)
 
     def current_asset_path(self) -> Optional[Path]:
-        path = self.current_path.value
-        return path if isinstance(path, Path) else None
+        presentation = self._actionable_presentation(capability="can_share")
+        return presentation.path if presentation is not None else None
 
     def refresh_current(self) -> None:
         self._refresh_presentation()
 
-    def _refresh_presentation(self) -> None:
+    def _refresh_presentation(
+        self,
+        *,
+        render_change_already_versioned: bool = False,
+        dto_override: AssetDTO | None = None,
+    ) -> None:
         row = self.current_row.value
         if row is None or row < 0:
             return
-        dto = self._store.asset_at(row)
+        dto = dto_override or self._store.asset_at(row)
         if dto is None:
             return
         presentation = self._build_presentation(
@@ -297,6 +354,7 @@ class DetailViewModel(BaseViewModel):
         if (
             isinstance(previous, DetailPresentation)
             and previous.render_key != presentation.render_key
+            and not render_change_already_versioned
         ):
             # A store refresh normally changes only row/chrome metadata.  If a
             # real render input changed, give it a fresh generation so a late
@@ -314,20 +372,20 @@ class DetailViewModel(BaseViewModel):
                 generation=self._request_generation,
                 asset_id=presentation.asset_id,
             )
+        if presentation == previous:
+            return
         self.presentation.value = presentation
         self.presentation_changed.emit(presentation)
 
     def _handle_store_changed(self) -> None:
-        current_row = self._media_session.current_row()
-        current_path = self._media_session.current_source()
-        selection_state = self._media_selection_state()
+        snapshot = self._media_selection_snapshot()
         presentation = self.presentation.value
         emit_detail_event(
             "detail_store_refresh",
             generation=self._request_generation,
-            current_row=current_row,
-            selection_state=selection_state.value,
-            has_current_source=isinstance(current_path, Path),
+            current_row=snapshot.row,
+            selection_state=snapshot.state.value,
+            has_current_source=isinstance(snapshot.path, Path),
             presentation_row=(
                 presentation.row if isinstance(presentation, DetailPresentation) else None
             ),
@@ -337,32 +395,13 @@ class DetailViewModel(BaseViewModel):
                 else None
             ),
         )
-        self.selection_state.value = selection_state
-        if selection_state in {
-            MediaSelectionState.ANCHOR_RESOLVING,
-            MediaSelectionState.FALLBACK_PENDING,
-        }:
-            self.current_row.value = -1
-            if isinstance(current_path, Path):
-                self.current_path.value = current_path
-            if (
-                isinstance(presentation, DetailPresentation)
-                and isinstance(current_path, Path)
-                and presentation.path == current_path
-            ):
-                pending_presentation = replace(
-                    presentation,
-                    row=-1,
-                    can_toggle_favorite=False,
-                )
-                if pending_presentation != presentation:
-                    self.presentation.value = pending_presentation
-                    self.presentation_changed.emit(pending_presentation)
+        # Selection transitions arrive through MediaSelectionSession's atomic
+        # snapshot event. Store refreshes only update chrome/metadata for the
+        # already reconciled resolved asset.
+        if not snapshot.is_resolved:
             return
-        if current_row < 0 or not isinstance(current_path, Path):
+        if not self._snapshot_matches_current_presentation(snapshot):
             return
-        self.current_row.value = current_row
-        self.current_path.value = current_path
         self._refresh_presentation()
 
     def _handle_row_changed(self, row: int) -> None:
@@ -372,10 +411,197 @@ class DetailViewModel(BaseViewModel):
 
     def _handle_row_loaded(self, row: int) -> None:
         if self._pending_show_row == row:
-            self.show_row(row)
+            self._request_selection_row(row)
 
     def _handle_navigation_requested(self, row: int) -> None:
         self.show_row(row)
+
+    def _handle_selection_changed(
+        self,
+        snapshot: MediaSelectionSnapshot,
+        reason: MediaSelectionChangeReason,
+        dto_hint: AssetDTO | None = None,
+    ) -> None:
+        """Atomically reconcile Detail state from the Session source of truth."""
+
+        if not isinstance(snapshot, MediaSelectionSnapshot):
+            return
+        if snapshot.version <= self._last_selection_version:
+            return
+        self._last_selection_version = snapshot.version
+        self._selection_snapshot = snapshot
+        self.selection_state.value = snapshot.state
+        self.current_row.value = snapshot.row if snapshot.row is not None else -1
+        self.current_path.value = snapshot.path
+
+        if snapshot.state in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            self._publish_pending_presentation(snapshot)
+            return
+        if snapshot.state is MediaSelectionState.NONE:
+            self._pending_show_row = None
+            self._publish_disabled_presentation(snapshot)
+            return
+        if not snapshot.is_resolved or snapshot.path is None:
+            return
+
+        row = snapshot.row
+        if row is None:
+            return
+        dto = dto_hint or self._store.asset_at(row)
+        if (
+            dto is None
+            or dto.abs_path != snapshot.path
+            or (snapshot.asset_id is not None and str(dto.id) != snapshot.asset_id)
+        ):
+            emit_detail_event(
+                "selection_snapshot_dto_mismatch",
+                generation=self._request_generation,
+                asset_id=snapshot.asset_id,
+                row=row,
+            )
+            return
+
+        self._pending_show_row = None
+        if reason is MediaSelectionChangeReason.USER_SELECTED:
+            self._publish_user_selection(snapshot, dto)
+        else:
+            self._publish_passive_selection(snapshot, dto)
+
+    def _publish_pending_presentation(
+        self,
+        snapshot: MediaSelectionSnapshot,
+    ) -> None:
+        presentation = self.presentation.value
+        if (
+            not isinstance(presentation, DetailPresentation)
+            or snapshot.path is None
+            or presentation.path != snapshot.path
+            or (
+                snapshot.asset_id is not None
+                and str(presentation.asset_id) != snapshot.asset_id
+            )
+        ):
+            return
+        capabilities = {"can_toggle_favorite": False}
+        if snapshot.state is MediaSelectionState.FALLBACK_PENDING:
+            capabilities.update(
+                can_edit=False,
+                can_rotate=False,
+                can_share=False,
+            )
+        pending_presentation = replace(presentation, row=-1, **capabilities)
+        self._publish_presentation_if_changed(pending_presentation)
+
+    def _publish_disabled_presentation(
+        self,
+        snapshot: MediaSelectionSnapshot,
+    ) -> None:
+        del snapshot
+        presentation = self.presentation.value
+        if not isinstance(presentation, DetailPresentation):
+            return
+        self._publish_presentation_if_changed(
+            replace(
+                presentation,
+                row=-1,
+                can_edit=False,
+                can_rotate=False,
+                can_share=False,
+                can_toggle_favorite=False,
+            )
+        )
+
+    def _publish_presentation_if_changed(
+        self,
+        presentation: DetailPresentation,
+    ) -> None:
+        if presentation == self.presentation.value:
+            return
+        self.presentation.value = presentation
+        self.presentation_changed.emit(presentation)
+
+    def _media_selection_snapshot(self) -> MediaSelectionSnapshot:
+        getter = getattr(self._media_session, "selection_snapshot", None)
+        if callable(getter):
+            snapshot = getter()
+            if isinstance(snapshot, MediaSelectionSnapshot):
+                return snapshot
+
+        if self._selection_snapshot.version > 0:
+            return self._selection_snapshot
+
+        state = self._media_selection_state()
+        row_value = getattr(self._media_session, "current_row", lambda: -1)()
+        row = row_value if isinstance(row_value, int) and row_value >= 0 else None
+        path_value = getattr(self._media_session, "current_source", lambda: None)()
+        path = path_value if isinstance(path_value, Path) else self.current_path.value
+        presentation = self.presentation.value
+        asset_id = (
+            str(presentation.asset_id)
+            if isinstance(presentation, DetailPresentation)
+            and isinstance(path, Path)
+            and presentation.path == path
+            else None
+        )
+        return MediaSelectionSnapshot(
+            version=self._last_selection_version,
+            state=state,
+            row=row,
+            path=path if isinstance(path, Path) else None,
+            asset_id=asset_id,
+        )
+
+    def _snapshot_matches_current_presentation(
+        self,
+        snapshot: MediaSelectionSnapshot,
+    ) -> bool:
+        presentation = self.presentation.value
+        return bool(
+            isinstance(presentation, DetailPresentation)
+            and snapshot.path == presentation.path
+            and (
+                not snapshot.is_resolved
+                or snapshot.row == presentation.row
+            )
+            and (
+                snapshot.asset_id is None
+                or snapshot.asset_id == str(presentation.asset_id)
+            )
+        )
+
+    def _actionable_presentation(
+        self,
+        *,
+        capability: str,
+        require_resolved: bool = False,
+    ) -> DetailPresentation | None:
+        snapshot = self._media_selection_snapshot()
+        if snapshot.state in {
+            MediaSelectionState.NONE,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            return None
+        if require_resolved and not snapshot.is_resolved:
+            return None
+        presentation = self.presentation.value
+        if (
+            not isinstance(presentation, DetailPresentation)
+            or snapshot.path != presentation.path
+            or (
+                snapshot.asset_id is not None
+                and snapshot.asset_id != str(presentation.asset_id)
+            )
+            or (
+                snapshot.is_resolved
+                and snapshot.row != presentation.row
+            )
+            or not bool(getattr(presentation, capability, False))
+        ):
+            return None
+        return presentation
 
     def _media_selection_state(self) -> MediaSelectionState:
         getter = getattr(self._media_session, "selection_state", None)

--- a/src/iPhoto/gui/viewmodels/detail_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/detail_viewmodel.py
@@ -299,6 +299,21 @@ class DetailViewModel(BaseViewModel):
     def _handle_store_changed(self) -> None:
         current_row = self._media_session.current_row()
         current_path = self._media_session.current_source()
+        presentation = self.presentation.value
+        emit_detail_event(
+            "detail_store_refresh",
+            generation=self._request_generation,
+            current_row=current_row,
+            has_current_source=isinstance(current_path, Path),
+            presentation_row=(
+                presentation.row if isinstance(presentation, DetailPresentation) else None
+            ),
+            presentation_generation=(
+                presentation.request_generation
+                if isinstance(presentation, DetailPresentation)
+                else None
+            ),
+        )
         if current_row < 0 or not isinstance(current_path, Path):
             return
         self.current_row.value = current_row

--- a/src/iPhoto/gui/viewmodels/detail_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/detail_viewmodel.py
@@ -238,6 +238,56 @@ class DetailViewModel(BaseViewModel):
         if row >= 0:
             self.show_row(row)
 
+    def recover_current_presentation(self) -> bool:
+        """Restart the stable visible asset without requiring an authoritative row.
+
+        Fullscreen may need to recover a terminal still render while Gallery is
+        resolving (or has exhausted) the asset's new row. Re-versioning the
+        immutable presentation starts a fresh render transaction without adding
+        database or filesystem work to the GUI path.
+        """
+
+        snapshot = self._media_selection_snapshot()
+        presentation = self.presentation.value
+        if (
+            not isinstance(presentation, DetailPresentation)
+            or presentation.is_video
+            or snapshot.state is MediaSelectionState.NONE
+            or snapshot.path != presentation.path
+            or (
+                snapshot.asset_id is not None
+                and snapshot.asset_id != str(presentation.asset_id)
+            )
+        ):
+            return False
+        if snapshot.is_resolved:
+            self.show_current()
+            return True
+        if snapshot.state not in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.ANCHOR_UNRESOLVED,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            return False
+
+        self._request_generation = max(
+            int(self._request_generation),
+            int(presentation.request_generation),
+        ) + 1
+        recovered = replace(
+            presentation,
+            row=-1,
+            request_generation=self._request_generation,
+        )
+        emit_detail_event(
+            "stable_presentation_recovery_requested",
+            generation=self._request_generation,
+            asset_id=presentation.asset_id,
+            selection_state=snapshot.state.value,
+        )
+        self._publish_presentation_if_changed(recovered)
+        return True
+
     def next(self) -> None:
         row = self._media_session.next_row()
         if row is not None:
@@ -436,6 +486,7 @@ class DetailViewModel(BaseViewModel):
 
         if snapshot.state in {
             MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.ANCHOR_UNRESOLVED,
             MediaSelectionState.FALLBACK_PENDING,
         }:
             self._publish_pending_presentation(snapshot)
@@ -486,7 +537,10 @@ class DetailViewModel(BaseViewModel):
         ):
             return
         capabilities = {"can_toggle_favorite": False}
-        if snapshot.state is MediaSelectionState.FALLBACK_PENDING:
+        if snapshot.state in {
+            MediaSelectionState.ANCHOR_UNRESOLVED,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
             capabilities.update(
                 can_edit=False,
                 can_rotate=False,
@@ -581,6 +635,7 @@ class DetailViewModel(BaseViewModel):
         snapshot = self._media_selection_snapshot()
         if snapshot.state in {
             MediaSelectionState.NONE,
+            MediaSelectionState.ANCHOR_UNRESOLVED,
             MediaSelectionState.FALLBACK_PENDING,
         }:
             return None

--- a/src/iPhoto/gui/viewmodels/detail_viewmodel.py
+++ b/src/iPhoto/gui/viewmodels/detail_viewmodel.py
@@ -11,6 +11,7 @@ from iPhoto.application.ports import AssetStateServicePort, EditServicePort
 from iPhoto.gui.detail_pipeline import AssetSourceIdentity
 from iPhoto.gui.detail_profile import emit_detail_event
 from iPhoto.gui.ui.media.media_restore_request import MediaRestoreRequest
+from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
 
 from .base import BaseViewModel
 from .gallery_collection_store import GalleryCollectionStore
@@ -26,6 +27,7 @@ class MediaSelectionPort(Protocol):
     def set_current_by_path(self, path: Path) -> bool: ...
     def current_row(self) -> int: ...
     def current_source(self) -> Optional[Path]: ...
+    def selection_state(self) -> MediaSelectionState: ...
     def next_row(self) -> Optional[int]: ...
     def previous_row(self) -> Optional[int]: ...
 
@@ -120,12 +122,16 @@ class DetailViewModel(BaseViewModel):
         restore_signal = getattr(self._media_session, "restoreRequested", None)
         if restore_signal is not None:
             restore_signal.connect(self._handle_restore_requested)
+        navigation_signal = getattr(self._media_session, "navigationRequested", None)
+        if navigation_signal is not None:
+            navigation_signal.connect(self._handle_navigation_requested)
         committed_signal = getattr(self._adjustment_commit_port, "adjustmentsCommitted", None)
         if committed_signal is not None:
             committed_signal.connect(self._handle_adjustments_committed)
 
         self.current_row = ObservableProperty(-1)
         self.current_path = ObservableProperty(None)
+        self.selection_state = ObservableProperty(MediaSelectionState.NONE)
         self.presentation = ObservableProperty(None)
 
         self.route_requested = Signal()
@@ -154,6 +160,7 @@ class DetailViewModel(BaseViewModel):
             return
         self.current_row.value = row
         self.current_path.value = source
+        self.selection_state.value = MediaSelectionState.RESOLVED
         emit_detail_event(
             "click_received",
             generation=request_generation,
@@ -188,13 +195,27 @@ class DetailViewModel(BaseViewModel):
             self.show_row(row)
 
     def toggle_favorite(self) -> None:
-        row = self.current_row.value
-        if row is None or row < 0 or self._asset_state_service is None:
+        if (
+            self._asset_state_service is None
+            or self._media_selection_state() is not MediaSelectionState.RESOLVED
+        ):
+            return
+        row = self._media_session.current_row()
+        if not isinstance(row, int) or row < 0:
+            row = self.current_row.value
+        if not isinstance(row, int) or row < 0:
+            return
+        presentation = self.presentation.value
+        if not isinstance(presentation, DetailPresentation):
             return
         dto = self._store.asset_at(row)
-        if dto is None:
+        if (
+            dto is None
+            or dto.abs_path != presentation.path
+            or str(dto.id) != str(presentation.asset_id)
+        ):
             return
-        new_state = self._asset_state_service.toggle_favorite(dto.abs_path)
+        new_state = self._asset_state_service.toggle_favorite(presentation.path)
         self._store.update_favorite_status(row, new_state)
         self._refresh_presentation()
 
@@ -299,11 +320,13 @@ class DetailViewModel(BaseViewModel):
     def _handle_store_changed(self) -> None:
         current_row = self._media_session.current_row()
         current_path = self._media_session.current_source()
+        selection_state = self._media_selection_state()
         presentation = self.presentation.value
         emit_detail_event(
             "detail_store_refresh",
             generation=self._request_generation,
             current_row=current_row,
+            selection_state=selection_state.value,
             has_current_source=isinstance(current_path, Path),
             presentation_row=(
                 presentation.row if isinstance(presentation, DetailPresentation) else None
@@ -314,6 +337,28 @@ class DetailViewModel(BaseViewModel):
                 else None
             ),
         )
+        self.selection_state.value = selection_state
+        if selection_state in {
+            MediaSelectionState.ANCHOR_RESOLVING,
+            MediaSelectionState.FALLBACK_PENDING,
+        }:
+            self.current_row.value = -1
+            if isinstance(current_path, Path):
+                self.current_path.value = current_path
+            if (
+                isinstance(presentation, DetailPresentation)
+                and isinstance(current_path, Path)
+                and presentation.path == current_path
+            ):
+                pending_presentation = replace(
+                    presentation,
+                    row=-1,
+                    can_toggle_favorite=False,
+                )
+                if pending_presentation != presentation:
+                    self.presentation.value = pending_presentation
+                    self.presentation_changed.emit(pending_presentation)
+            return
         if current_row < 0 or not isinstance(current_path, Path):
             return
         self.current_row.value = current_row
@@ -328,6 +373,24 @@ class DetailViewModel(BaseViewModel):
     def _handle_row_loaded(self, row: int) -> None:
         if self._pending_show_row == row:
             self.show_row(row)
+
+    def _handle_navigation_requested(self, row: int) -> None:
+        self.show_row(row)
+
+    def _media_selection_state(self) -> MediaSelectionState:
+        getter = getattr(self._media_session, "selection_state", None)
+        if callable(getter):
+            state = getter()
+            if isinstance(state, MediaSelectionState):
+                return state
+            try:
+                return MediaSelectionState(str(state))
+            except ValueError:
+                pass
+        row = self.current_row.value
+        if isinstance(row, int) and row >= 0:
+            return MediaSelectionState.RESOLVED
+        return MediaSelectionState.NONE
 
     def _handle_restore_requested(self, request: object) -> None:
         if not isinstance(request, MediaRestoreRequest):

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -335,6 +335,26 @@ class GalleryCollectionStore:
     def snapshot_signature(self) -> tuple[int, Optional[tuple[int, int]], int]:
         return (self._total_count, self._window_range, self._collection_revision)
 
+    def diagnostic_snapshot(self) -> dict[str, object]:
+        """Return privacy-safe in-memory state for opt-in runtime diagnostics."""
+
+        anchor = self._selection_anchor
+        return {
+            "row_count": self._total_count,
+            "cached_rows": len(self._row_cache),
+            "window": self._window_range,
+            "visible": self._visible_range,
+            "collection_revision": self._collection_revision,
+            "pinned_row": self._pinned_row,
+            "anchor_status": self._selection_anchor_status,
+            "anchor_previous_row": anchor.previous_row if anchor is not None else None,
+            "pending_window_requests": len(self._pending_window_generations),
+            "pending_row_loads": len(self._pending_row_loads),
+            "pending_scan_refresh": self._pending_scan_refresh,
+            "pending_scan_rows": len(self._pending_scan_rels),
+            "pending_moves": len(self._pending_moves),
+        }
+
     def live_partner_for(self, asset_id: str, root: Optional[Path] = None) -> Optional[AssetDTO]:
         find_live_partner = getattr(self._asset_query_service, "find_live_partner", None)
         if not callable(find_live_partner):

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -11,6 +11,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Protocol
 
 from iPhoto.application.dtos import AssetDTO
 from iPhoto.domain.models.query import AssetQuery, WindowResult
+from iPhoto.gui.detail_profile import emit_detail_event
 from iPhoto.gui.gallery_demand import (
     MICRO_QUERY_CHUNK,
     MICRO_WARM_LIMIT,
@@ -34,7 +35,12 @@ from iPhoto.gui.viewmodels.asset_dto_converter import (
 from iPhoto.gui.viewmodels.asset_paging import (
     should_validate_paths as _should_validate_paths_fn,
 )
-from iPhoto.gui.viewmodels.gallery_window_loader import GalleryWindowRequest, GalleryWindowResult
+from iPhoto.gui.viewmodels.gallery_window_loader import (
+    GallerySelectionAnchor,
+    GallerySelectionAnchorResult,
+    GalleryWindowRequest,
+    GalleryWindowResult,
+)
 from iPhoto.gui.viewmodels.path_cache import PathExistsCache
 from iPhoto.gui.viewmodels.pending_move_buffer import (
     _PendingMove,
@@ -123,6 +129,7 @@ class GalleryCollectionStore:
         self.row_changed = Signal()
         self.row_loaded = Signal()
         self.thumbnail_backfill_scheduled = Signal()
+        self.selection_anchor_changed = Signal()
 
         self._asset_query_service = asset_query_service
         self._library_root = library_root or getattr(asset_query_service, "library_root", None)
@@ -140,6 +147,8 @@ class GalleryCollectionStore:
         self._pending_moves: List[_PendingMove] = []
         self._pending_paths: set[str] = set()
         self._pinned_row: Optional[int] = None
+        self._selection_anchor: GallerySelectionAnchor | None = None
+        self._selection_anchor_status: str | None = None
         self._pending_scan_refresh = False
         self._pending_scan_rels: set[str] = set()
         self._pending_scan_sort_keys: set[tuple[str, str]] = set()
@@ -279,6 +288,7 @@ class GalleryCollectionStore:
         if self._total_count > 0:
             self._window_range = (0, self._total_count - 1)
             self._visible_range = self._window_range
+        self._resolve_selection_anchor_from_cache(missing_if_absent=True)
 
         self._emit_refresh(old_total)
 
@@ -457,9 +467,23 @@ class GalleryCollectionStore:
         if self._pinned_row is not None:
             if self._pinned_row in removed_set:
                 self._pinned_row = None
+                if self._selection_anchor is not None:
+                    self._publish_selection_anchor_status(
+                        "missing",
+                        generation=self._request_generation,
+                        collection_revision=self._collection_revision,
+                        row=None,
+                        elapsed_ms=0.0,
+                    )
             else:
                 shift = sum(1 for row in removed if row < self._pinned_row)
                 self._pinned_row -= shift
+                if self._selection_anchor is not None:
+                    self._selection_anchor = GallerySelectionAnchor(
+                        path=self._selection_anchor.path,
+                        asset_id=self._selection_anchor.asset_id,
+                        previous_row=self._pinned_row,
+                    )
 
         if emit:
             self.count_changed.emit(old_total, self._total_count)
@@ -697,6 +721,11 @@ class GalleryCollectionStore:
             )
         ):
             return False
+        anchor_result = result.selection_anchor_result
+        anchor_is_current = (
+            result.collection_revision >= self._collection_revision
+            and self._anchor_result_matches_current(anchor_result)
+        )
         if (
             self._demand_generation > 0
             and result.demand_generation < self._demand_generation
@@ -706,16 +735,67 @@ class GalleryCollectionStore:
                 for row, dto in result.rows.items()
                 if self._row_is_currently_relevant(row)
             }
-            if not relevant_rows:
+            if not relevant_rows and not anchor_is_current:
                 return False
         else:
-            relevant_rows = result.rows
+            relevant_rows = dict(result.rows)
         old_total = self._total_count
+        old_revision = self._collection_revision
+        revision_advanced = result.collection_revision > old_revision
         if (
-            self._collection_revision > 0
-            and result.collection_revision > self._collection_revision
+            old_revision > 0
+            and revision_advanced
         ):
             self._row_cache.clear()
+
+        anchor_state_changed = False
+        request_anchor_followup = False
+        if anchor_is_current and anchor_result is not None:
+            if anchor_result.status == "resolved":
+                if anchor_result.row is not None and anchor_result.dto is not None:
+                    resolved_row = int(anchor_result.row)
+                    relevant_rows[resolved_row] = anchor_result.dto
+                    self._pinned_row = resolved_row
+                    self._selection_anchor = GallerySelectionAnchor(
+                        path=anchor_result.anchor.path,
+                        asset_id=anchor_result.anchor.asset_id,
+                        previous_row=resolved_row,
+                    )
+                    anchor_state_changed = self._selection_anchor_status != "resolved"
+                    anchor_state_changed = (
+                        anchor_state_changed
+                        or anchor_result.anchor.previous_row != resolved_row
+                    )
+                    self._publish_selection_anchor_status(
+                        "resolved",
+                        generation=result.generation,
+                        collection_revision=result.collection_revision,
+                        row=resolved_row,
+                        elapsed_ms=anchor_result.elapsed_ms,
+                    )
+            elif anchor_result.status in {"retry", "missing"}:
+                self._pinned_row = None
+                anchor_state_changed = self._selection_anchor_status != anchor_result.status
+                self._publish_selection_anchor_status(
+                    anchor_result.status,
+                    generation=result.generation,
+                    collection_revision=result.collection_revision,
+                    row=None,
+                    elapsed_ms=anchor_result.elapsed_ms,
+                )
+        elif revision_advanced and self._selection_anchor is not None:
+            # This request predates the current selection. Do not attach the
+            # current path to a stale numeric row while its own request catches up.
+            self._pinned_row = None
+            anchor_state_changed = self._selection_anchor_status != "pending"
+            request_anchor_followup = anchor_state_changed
+            self._publish_selection_anchor_status(
+                "pending",
+                generation=result.generation,
+                collection_revision=result.collection_revision,
+                row=None,
+                elapsed_ms=0.0,
+            )
         for row, dto in relevant_rows.items():
             self._row_cache[row] = dto
             self._row_cache.move_to_end(row)
@@ -741,11 +821,81 @@ class GalleryCollectionStore:
         if old_total != self._total_count:
             self.count_changed.emit(old_total, self._total_count)
             self.data_changed.emit()
+        elif revision_advanced or anchor_state_changed:
+            self.data_changed.emit()
+            if relevant_rows:
+                self.window_changed.emit(min(relevant_rows), max(relevant_rows))
         elif relevant_rows:
             self.window_changed.emit(min(relevant_rows), max(relevant_rows))
         for row in loaded_rows:
             self.row_loaded.emit(row)
+        if request_anchor_followup and self._window_request_handler is not None:
+            anchor = self._selection_anchor
+            if anchor is not None:
+                row = max(0, anchor.previous_row)
+                self._request_async_chunk(
+                    row,
+                    row,
+                    demand_generation=0,
+                    priority=0,
+                )
         return True
+
+    def _anchor_result_matches_current(
+        self,
+        result: GallerySelectionAnchorResult | None,
+    ) -> bool:
+        anchor = self._selection_anchor
+        if anchor is None or result is None:
+            return False
+        if self._normalize_abs_key(anchor.path) != self._normalize_abs_key(result.anchor.path):
+            return False
+        if anchor.asset_id and result.anchor.asset_id:
+            return anchor.asset_id == result.anchor.asset_id
+        return True
+
+    def _publish_selection_anchor_status(
+        self,
+        status: str,
+        *,
+        generation: int,
+        collection_revision: int,
+        row: int | None,
+        elapsed_ms: float,
+    ) -> None:
+        anchor = self._selection_anchor
+        if anchor is None:
+            return
+        self._selection_anchor_status = status
+        self.selection_anchor_changed.emit(status, anchor, row)
+        emit_detail_event(
+            f"selection_anchor_{status}",
+            generation=generation,
+            asset_id=anchor.asset_id,
+            collection_revision=int(collection_revision),
+            elapsed_ms=round(float(elapsed_ms), 3),
+        )
+
+    def _resolve_selection_anchor_from_cache(self, *, missing_if_absent: bool) -> None:
+        anchor = self._selection_anchor
+        if anchor is None:
+            return
+        row = self.cached_row_for_path(anchor.path)
+        if row is None:
+            if missing_if_absent:
+                self._pinned_row = None
+                self._selection_anchor_status = "missing"
+                self.selection_anchor_changed.emit("missing", anchor, None)
+            return
+        dto = self._row_cache.get(row)
+        self._pinned_row = row
+        self._selection_anchor = GallerySelectionAnchor(
+            path=anchor.path,
+            asset_id=anchor.asset_id or (str(dto.id) if dto is not None else ""),
+            previous_row=row,
+        )
+        self._selection_anchor_status = "resolved"
+        self.selection_anchor_changed.emit("resolved", self._selection_anchor, row)
 
     def discard_window_requests(self, generations: Iterable[int]) -> None:
         """Forget queued requests canceled before their worker started."""
@@ -767,6 +917,43 @@ class GalleryCollectionStore:
             if self._normalize_abs_key(dto.abs_path) == target:
                 return row
         return None
+
+    def selection_anchor_status(self, path: Path) -> str | None:
+        """Return the in-memory resolution state for *path* without querying."""
+
+        anchor = self._selection_anchor
+        if anchor is None:
+            return None
+        if self._normalize_abs_key(anchor.path) != self._normalize_abs_key(path):
+            return None
+        return self._selection_anchor_status
+
+    def pin_path(
+        self,
+        path: Path,
+        *,
+        asset_id: str = "",
+        previous_row: int | None = None,
+    ) -> None:
+        """Pin a path-stable selection anchor using only cached state."""
+
+        cached_row = self.cached_row_for_path(path)
+        row = cached_row if cached_row is not None else previous_row
+        if row is None:
+            row = self._pinned_row if self._pinned_row is not None else -1
+        anchor = GallerySelectionAnchor(
+            path=Path(path),
+            asset_id=str(asset_id),
+            previous_row=int(row),
+        )
+        self._selection_anchor = anchor
+        self._selection_anchor_status = "resolved" if cached_row is not None else "pending"
+        self._pinned_row = cached_row if cached_row is not None else None
+        self.selection_anchor_changed.emit(
+            self._selection_anchor_status,
+            anchor,
+            cached_row,
+        )
 
     def _request_async_window(
         self,
@@ -814,11 +1001,17 @@ class GalleryCollectionStore:
         self._request_generation += 1
         generation = self._request_generation
         self._pending_window_generations.add(generation)
-        raw_first = (
-            self._pending_adjusted_raw_offset_for_view_offset(self._current_query, view_first)
+        pending_source_rows = tuple(
+            self._pending_source_rows_for_query(self._current_query)
             if self._pending_moves
-            else view_first
+            else ()
         )
+        raw_first = view_first
+        for source_row in pending_source_rows:
+            if source_row <= raw_first:
+                raw_first += 1
+                continue
+            break
         pending_sources = tuple(
             pending
             for pending in self._pending_moves
@@ -842,12 +1035,22 @@ class GalleryCollectionStore:
                     if pending.source_id is not None
                 ),
                 pending_source_count=len(pending_sources),
+                pending_source_rows=pending_source_rows,
                 pending_insertions=pending_insertions,
+                selection_anchor=self._selection_anchor,
                 collection_revision=self._collection_revision,
                 demand_generation=int(demand_generation),
                 priority=int(priority),
             )
         )
+        if self._selection_anchor is not None:
+            emit_detail_event(
+                "selection_anchor_pending",
+                generation=generation,
+                asset_id=self._selection_anchor.asset_id,
+                collection_revision=self._collection_revision,
+                elapsed_ms=0.0,
+            )
 
     def _row_is_currently_relevant(self, row: int) -> bool:
         if row == self._pinned_row:
@@ -924,9 +1127,14 @@ class GalleryCollectionStore:
     def pin_row(self, row: int) -> None:
         if row < 0 or row >= self._total_count:
             self._pinned_row = None
+            self._selection_anchor = None
+            self._selection_anchor_status = None
             return
         self._pinned_row = row
         self.ensure_row_loaded(row, emit_signals=True)
+        dto = self._row_cache.get(row)
+        if dto is not None:
+            self.pin_path(dto.abs_path, asset_id=str(dto.id), previous_row=row)
 
     def _record_scan_rows(self, scan_root: Path, rows: List[dict]) -> bool:
         """Record ready batch rows and defer the visible-window refresh."""
@@ -1784,6 +1992,8 @@ class GalleryCollectionStore:
         self._visible_range = None
         self._warm_range = None
         self._pinned_row = None
+        self._selection_anchor = None
+        self._selection_anchor_status = None
         self._path_cache.clear()
         if clear_pending:
             self._pending_moves.clear()

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -203,8 +203,21 @@ class GalleryCollectionStore:
         asset_query_service: GalleryAssetQuerySurface | None,
         library_root: Optional[Path],
     ) -> None:
-        self.set_asset_query_service(asset_query_service)
-        self.set_library_root(library_root)
+        service_changed = self._asset_query_service is not asset_query_service
+        library_changed = not self._library_roots_match(
+            self._library_root,
+            library_root,
+        )
+        if not service_changed and not library_changed:
+            return
+
+        self._asset_query_service = asset_query_service
+        self._library_root = library_root
+        self._reset_window_state(
+            clear_pending=library_changed,
+            preserve_selection_anchor=not library_changed,
+        )
+        self.data_changed.emit()
 
     @property
     def asset_query_service(self) -> GalleryAssetQuerySurface | None:
@@ -253,19 +266,30 @@ class GalleryCollectionStore:
             self._load_direct_assets(
                 list(self._selection_direct_assets),
                 self._selection_library_root or self._library_root,
+                preserve_selection_anchor=True,
             )
             return
         if self._selection_query is not None:
-            self._load_query(self._selection_query)
+            self._load_query(
+                self._selection_query,
+                preserve_selection_anchor=True,
+            )
 
-    def _load_query(self, query: AssetQuery) -> None:
+    def _load_query(
+        self,
+        query: AssetQuery,
+        *,
+        preserve_selection_anchor: bool = False,
+    ) -> None:
         old_total = self._total_count
         self._selection_query = self._clone_query(query)
         self._selection_direct_assets = None
         self._selection_library_root = self._library_root
         self._current_query = self._clone_query(query)
         self._direct_mode = False
-        self._reset_window_state()
+        self._reset_window_state(
+            preserve_selection_anchor=preserve_selection_anchor,
+        )
         if self._window_request_handler is None:
             self._load_initial_window()
         else:
@@ -277,7 +301,13 @@ class GalleryCollectionStore:
             )
         self._emit_refresh(old_total)
 
-    def _load_direct_assets(self, assets: list, library_root: Path) -> None:
+    def _load_direct_assets(
+        self,
+        assets: list,
+        library_root: Path,
+        *,
+        preserve_selection_anchor: bool = False,
+    ) -> None:
         old_total = self._total_count
         stored_assets = list(assets)
         self._selection_query = None
@@ -286,7 +316,9 @@ class GalleryCollectionStore:
         self._current_query = None
         self._library_root = library_root
         self._direct_mode = True
-        self._reset_window_state()
+        self._reset_window_state(
+            preserve_selection_anchor=preserve_selection_anchor,
+        )
 
         next_index = 0
         for asset in stored_assets:
@@ -761,8 +793,12 @@ class GalleryCollectionStore:
         ):
             return False
         anchor_result = result.selection_anchor_result
+        anchor_request_is_current = (
+            result.requested_revision == self._collection_revision
+            or result.collection_revision >= self._collection_revision
+        )
         anchor_is_current = (
-            result.collection_revision >= self._collection_revision
+            anchor_request_is_current
             and self._anchor_result_matches_current(anchor_result)
             and result.generation >= self._selection_anchor_latest_result_generation
         )
@@ -1936,7 +1972,8 @@ class GalleryCollectionStore:
     ) -> Optional[AssetDTO]:
         return _scan_row_to_dto_fn(view_root, view_rel, row)
 
-    def _normalize_abs_key(self, path: Path) -> str:
+    @staticmethod
+    def _normalize_abs_key(path: Path) -> str:
         return os.path.normcase(os.path.abspath(os.fspath(path)))
 
     @staticmethod
@@ -2159,7 +2196,15 @@ class GalleryCollectionStore:
     def _iter_cached_rows(self) -> List[tuple[int, AssetDTO]]:
         return sorted(self._row_cache.items(), key=lambda item: item[0])
 
-    def _reset_window_state(self, *, clear_pending: bool = False) -> None:
+    def _reset_window_state(
+        self,
+        *,
+        clear_pending: bool = False,
+        preserve_selection_anchor: bool = False,
+    ) -> None:
+        preserved_anchor = (
+            self._selection_anchor if preserve_selection_anchor else None
+        )
         self._cancel_selection_anchor_retry()
         self._selection_version += 1
         self._selection_anchor_latest_result_generation = 0
@@ -2169,8 +2214,19 @@ class GalleryCollectionStore:
         self._visible_range = None
         self._warm_range = None
         self._pinned_row = None
-        self._selection_anchor = None
-        self._selection_anchor_status = None
+        self._selection_anchor = (
+            GallerySelectionAnchor(
+                path=preserved_anchor.path,
+                asset_id=preserved_anchor.asset_id,
+                previous_row=preserved_anchor.previous_row,
+                selection_version=self._selection_version,
+            )
+            if preserved_anchor is not None
+            else None
+        )
+        self._selection_anchor_status = (
+            "pending" if self._selection_anchor is not None else None
+        )
         self._path_cache.clear()
         if clear_pending:
             self._pending_moves.clear()
@@ -2185,3 +2241,21 @@ class GalleryCollectionStore:
         self._demand_generation = 0
         self._collection_revision += 1
         self._request_generation += 1
+        if self._selection_anchor is not None:
+            self.selection_anchor_changed.emit(
+                "pending",
+                self._selection_anchor,
+                None,
+            )
+
+    @classmethod
+    def _library_roots_match(
+        cls,
+        first: Path | None,
+        second: Path | None,
+    ) -> bool:
+        if first is None or second is None:
+            return first is second
+        return cls._normalize_abs_key(Path(first)) == cls._normalize_abs_key(
+            Path(second)
+        )

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -38,6 +38,7 @@ from iPhoto.gui.viewmodels.asset_paging import (
 from iPhoto.gui.viewmodels.gallery_window_loader import (
     GallerySelectionAnchor,
     GallerySelectionAnchorResult,
+    GallerySelectionAnchorRetryTicket,
     GalleryWindowRequest,
     GalleryWindowResult,
 )
@@ -117,6 +118,7 @@ class GalleryCollectionStore:
     LOOKBEHIND_SCREENS = 1
     LOOKAHEAD_SCREENS = 2
     HYSTERESIS_RATIO = 0.25
+    ANCHOR_RETRY_DELAYS_MS = (100, 250, 500)
 
     def __init__(
         self,
@@ -130,6 +132,7 @@ class GalleryCollectionStore:
         self.row_loaded = Signal()
         self.thumbnail_backfill_scheduled = Signal()
         self.selection_anchor_changed = Signal()
+        self.selection_anchor_retry_requested = Signal()
 
         self._asset_query_service = asset_query_service
         self._library_root = library_root or getattr(asset_query_service, "library_root", None)
@@ -149,6 +152,14 @@ class GalleryCollectionStore:
         self._pinned_row: Optional[int] = None
         self._selection_anchor: GallerySelectionAnchor | None = None
         self._selection_anchor_status: str | None = None
+        self._selection_version = 0
+        self._selection_anchor_retry_ticket: (
+            GallerySelectionAnchorRetryTicket | None
+        ) = None
+        self._selection_anchor_retry_inflight: (
+            GallerySelectionAnchorRetryTicket | None
+        ) = None
+        self._selection_anchor_latest_result_generation = 0
         self._pending_scan_refresh = False
         self._pending_scan_rels: set[str] = set()
         self._pending_scan_sort_keys: set[tuple[str, str]] = set()
@@ -348,6 +359,13 @@ class GalleryCollectionStore:
             "pinned_row": self._pinned_row,
             "anchor_status": self._selection_anchor_status,
             "anchor_previous_row": anchor.previous_row if anchor is not None else None,
+            "anchor_retry_attempt": (
+                self._selection_anchor_retry_ticket.attempt
+                if self._selection_anchor_retry_ticket is not None
+                else self._selection_anchor_retry_inflight.attempt
+                if self._selection_anchor_retry_inflight is not None
+                else None
+            ),
             "pending_window_requests": len(self._pending_window_generations),
             "pending_row_loads": len(self._pending_row_loads),
             "pending_scan_refresh": self._pending_scan_refresh,
@@ -503,6 +521,7 @@ class GalleryCollectionStore:
                         path=self._selection_anchor.path,
                         asset_id=self._selection_anchor.asset_id,
                         previous_row=self._pinned_row,
+                        selection_version=self._selection_anchor.selection_version,
                     )
 
         if emit:
@@ -745,6 +764,7 @@ class GalleryCollectionStore:
         anchor_is_current = (
             result.collection_revision >= self._collection_revision
             and self._anchor_result_matches_current(anchor_result)
+            and result.generation >= self._selection_anchor_latest_result_generation
         )
         if (
             self._demand_generation > 0
@@ -762,16 +782,19 @@ class GalleryCollectionStore:
         old_total = self._total_count
         old_revision = self._collection_revision
         revision_advanced = result.collection_revision > old_revision
-        if (
-            old_revision > 0
-            and revision_advanced
-        ):
+        retry_inflight_before_revision = self._selection_anchor_retry_inflight
+        if revision_advanced:
+            self._cancel_selection_anchor_retry()
+        if old_revision > 0 and revision_advanced:
             self._row_cache.clear()
 
         anchor_state_changed = False
         request_anchor_followup = False
+        schedule_anchor_retry_attempt: int | None = None
         if anchor_is_current and anchor_result is not None:
+            self._selection_anchor_latest_result_generation = result.generation
             if anchor_result.status == "resolved":
+                self._cancel_selection_anchor_retry()
                 if anchor_result.row is not None and anchor_result.dto is not None:
                     resolved_row = int(anchor_result.row)
                     relevant_rows[resolved_row] = anchor_result.dto
@@ -780,6 +803,7 @@ class GalleryCollectionStore:
                         path=anchor_result.anchor.path,
                         asset_id=anchor_result.anchor.asset_id,
                         previous_row=resolved_row,
+                        selection_version=anchor_result.anchor.selection_version,
                     )
                     anchor_state_changed = self._selection_anchor_status != "resolved"
                     anchor_state_changed = (
@@ -803,6 +827,31 @@ class GalleryCollectionStore:
                     row=None,
                     elapsed_ms=anchor_result.elapsed_ms,
                 )
+                if anchor_result.status == "missing":
+                    self._cancel_selection_anchor_retry()
+                else:
+                    if result.purpose == "selection_anchor_retry":
+                        inflight = (
+                            self._selection_anchor_retry_inflight
+                            or retry_inflight_before_revision
+                        )
+                        completed_attempt = int(
+                            result.selection_anchor_retry_attempt
+                        )
+                        if (
+                            inflight is not None
+                            and inflight.anchor == anchor_result.anchor
+                            and inflight.attempt == completed_attempt
+                        ):
+                            self._selection_anchor_retry_inflight = None
+                            schedule_anchor_retry_attempt = (
+                                1 if revision_advanced else completed_attempt + 1
+                            )
+                    elif (
+                        self._selection_anchor_retry_ticket is None
+                        and self._selection_anchor_retry_inflight is None
+                    ):
+                        schedule_anchor_retry_attempt = 1
         elif revision_advanced and self._selection_anchor is not None:
             # This request predates the current selection. Do not attach the
             # current path to a stale numeric row while its own request catches up.
@@ -858,7 +907,10 @@ class GalleryCollectionStore:
                     row,
                     demand_generation=0,
                     priority=0,
+                    request_backfill=False,
                 )
+        if schedule_anchor_retry_attempt is not None:
+            self._schedule_selection_anchor_retry(schedule_anchor_retry_attempt)
         return True
 
     def _anchor_result_matches_current(
@@ -869,6 +921,8 @@ class GalleryCollectionStore:
         if anchor is None or result is None:
             return False
         if self._normalize_abs_key(anchor.path) != self._normalize_abs_key(result.anchor.path):
+            return False
+        if anchor.selection_version != result.anchor.selection_version:
             return False
         if anchor.asset_id and result.anchor.asset_id:
             return anchor.asset_id == result.anchor.asset_id
@@ -886,6 +940,8 @@ class GalleryCollectionStore:
         anchor = self._selection_anchor
         if anchor is None:
             return
+        if status in {"resolved", "missing"}:
+            self._cancel_selection_anchor_retry()
         self._selection_anchor_status = status
         self.selection_anchor_changed.emit(status, anchor, row)
         emit_detail_event(
@@ -896,6 +952,84 @@ class GalleryCollectionStore:
             elapsed_ms=round(float(elapsed_ms), 3),
         )
 
+    def _schedule_selection_anchor_retry(self, attempt: int) -> None:
+        anchor = self._selection_anchor
+        if anchor is None or self._selection_anchor_status != "retry":
+            return
+        if attempt > len(self.ANCHOR_RETRY_DELAYS_MS):
+            self._selection_anchor_retry_ticket = None
+            self._selection_anchor_retry_inflight = None
+            emit_detail_event(
+                "selection_anchor_retry_exhausted",
+                generation=self._request_generation,
+                asset_id=anchor.asset_id,
+                collection_revision=self._collection_revision,
+                attempt=len(self.ANCHOR_RETRY_DELAYS_MS),
+            )
+            return
+
+        active_ticket = (
+            self._selection_anchor_retry_ticket
+            or self._selection_anchor_retry_inflight
+        )
+        if (
+            active_ticket is not None
+            and active_ticket.anchor == anchor
+            and active_ticket.collection_revision == self._collection_revision
+        ):
+            return
+
+        self._cancel_selection_anchor_retry()
+        ticket = GallerySelectionAnchorRetryTicket(
+            anchor=anchor,
+            collection_revision=self._collection_revision,
+            attempt=attempt,
+            delay_ms=self.ANCHOR_RETRY_DELAYS_MS[attempt - 1],
+        )
+        self._selection_anchor_retry_ticket = ticket
+        self.selection_anchor_retry_requested.emit(ticket)
+
+    def retry_selection_anchor(
+        self,
+        ticket: GallerySelectionAnchorRetryTicket,
+    ) -> bool:
+        """Submit a still-valid retry ticket without querying on the GUI thread."""
+
+        if ticket != self._selection_anchor_retry_ticket:
+            return False
+        self._selection_anchor_retry_ticket = None
+        anchor = self._selection_anchor
+        if (
+            anchor is None
+            or anchor != ticket.anchor
+            or self._selection_anchor_status != "retry"
+            or self._collection_revision != ticket.collection_revision
+            or ticket.attempt < 1
+            or ticket.attempt > len(self.ANCHOR_RETRY_DELAYS_MS)
+        ):
+            return False
+
+        self._selection_anchor_retry_inflight = ticket
+        submitted = self._request_async_chunk(
+            max(0, anchor.previous_row),
+            max(0, anchor.previous_row),
+            demand_generation=0,
+            priority=0,
+            request_backfill=False,
+            purpose="selection_anchor_retry",
+            selection_anchor_retry_attempt=ticket.attempt,
+        )
+        if not submitted:
+            self._selection_anchor_retry_inflight = None
+        return submitted
+
+    def _cancel_selection_anchor_retry(self) -> None:
+        had_pending_ticket = self._selection_anchor_retry_ticket is not None
+        self._selection_anchor_retry_ticket = None
+        self._selection_anchor_retry_inflight = None
+        if had_pending_ticket:
+            self.selection_anchor_retry_requested.emit(None)
+
     def _resolve_selection_anchor_from_cache(self, *, missing_if_absent: bool) -> None:
         anchor = self._selection_anchor
         if anchor is None:
@@ -904,15 +1038,18 @@ class GalleryCollectionStore:
         if row is None:
             if missing_if_absent:
                 self._pinned_row = None
+                self._cancel_selection_anchor_retry()
                 self._selection_anchor_status = "missing"
                 self.selection_anchor_changed.emit("missing", anchor, None)
             return
         dto = self._row_cache.get(row)
         self._pinned_row = row
+        self._cancel_selection_anchor_retry()
         self._selection_anchor = GallerySelectionAnchor(
             path=anchor.path,
             asset_id=anchor.asset_id or (str(dto.id) if dto is not None else ""),
             previous_row=row,
+            selection_version=anchor.selection_version,
         )
         self._selection_anchor_status = "resolved"
         self.selection_anchor_changed.emit("resolved", self._selection_anchor, row)
@@ -957,6 +1094,8 @@ class GalleryCollectionStore:
     ) -> None:
         """Pin a path-stable selection anchor using only cached state."""
 
+        self._cancel_selection_anchor_retry()
+        self._selection_version += 1
         cached_row = self.cached_row_for_path(path)
         row = cached_row if cached_row is not None else previous_row
         if row is None:
@@ -965,6 +1104,7 @@ class GalleryCollectionStore:
             path=Path(path),
             asset_id=str(asset_id),
             previous_row=int(row),
+            selection_version=self._selection_version,
         )
         self._selection_anchor = anchor
         self._selection_anchor_status = "resolved" if cached_row is not None else "pending"
@@ -1004,20 +1144,23 @@ class GalleryCollectionStore:
         *,
         demand_generation: int,
         priority: int,
-    ) -> None:
+        request_backfill: bool = True,
+        purpose: str = "viewport",
+        selection_anchor_retry_attempt: int = 0,
+    ) -> bool:
         if (
             self._window_request_handler is None
             or self._current_query is None
             or self._asset_query_service is None
         ):
-            return
+            return False
         root = self._active_root or self._library_root
         if root is None:
-            return
+            return False
         view_first = max(0, int(first))
         limit = max(0, int(last) - view_first + 1)
         if limit <= 0:
-            return
+            return False
         self._request_generation += 1
         generation = self._request_generation
         self._pending_window_generations.add(generation)
@@ -1058,9 +1201,18 @@ class GalleryCollectionStore:
                 pending_source_rows=pending_source_rows,
                 pending_insertions=pending_insertions,
                 selection_anchor=self._selection_anchor,
+                request_backfill=bool(request_backfill),
                 collection_revision=self._collection_revision,
                 demand_generation=int(demand_generation),
                 priority=int(priority),
+                purpose=(
+                    "selection_anchor_retry"
+                    if purpose == "selection_anchor_retry"
+                    else "viewport"
+                ),
+                selection_anchor_retry_attempt=int(
+                    selection_anchor_retry_attempt
+                ),
             )
         )
         if self._selection_anchor is not None:
@@ -1071,6 +1223,7 @@ class GalleryCollectionStore:
                 collection_revision=self._collection_revision,
                 elapsed_ms=0.0,
             )
+        return True
 
     def _row_is_currently_relevant(self, row: int) -> bool:
         if row == self._pinned_row:
@@ -1149,6 +1302,7 @@ class GalleryCollectionStore:
             self._pinned_row = None
             self._selection_anchor = None
             self._selection_anchor_status = None
+            self._cancel_selection_anchor_retry()
             return
         self._pinned_row = row
         self.ensure_row_loaded(row, emit_signals=True)
@@ -2006,6 +2160,9 @@ class GalleryCollectionStore:
         return sorted(self._row_cache.items(), key=lambda item: item[0])
 
     def _reset_window_state(self, *, clear_pending: bool = False) -> None:
+        self._cancel_selection_anchor_retry()
+        self._selection_version += 1
+        self._selection_anchor_latest_result_generation = 0
         self._row_cache.clear()
         self._total_count = 0
         self._window_range = None

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -995,13 +995,29 @@ class GalleryCollectionStore:
         if attempt > len(self.ANCHOR_RETRY_DELAYS_MS):
             self._selection_anchor_retry_ticket = None
             self._selection_anchor_retry_inflight = None
+            resolved_from_cache = self._resolve_selection_anchor_from_cache(
+                missing_if_absent=False,
+            )
+            if not resolved_from_cache:
+                self._pinned_row = None
+                self._selection_anchor_status = "unresolved"
+                self.selection_anchor_changed.emit(
+                    "unresolved",
+                    anchor,
+                    None,
+                )
             emit_detail_event(
                 "selection_anchor_retry_exhausted",
                 generation=self._request_generation,
                 asset_id=anchor.asset_id,
                 collection_revision=self._collection_revision,
                 attempt=len(self.ANCHOR_RETRY_DELAYS_MS),
+                resolved_from_cache=resolved_from_cache,
             )
+            # The Session consumes the Store's coherent in-memory state from
+            # data_changed. Exhaustion happens after apply_window_result has
+            # already emitted its refresh, so publish this terminal transition.
+            self.data_changed.emit()
             return
 
         active_ticket = (
@@ -1066,29 +1082,35 @@ class GalleryCollectionStore:
         if had_pending_ticket:
             self.selection_anchor_retry_requested.emit(None)
 
-    def _resolve_selection_anchor_from_cache(self, *, missing_if_absent: bool) -> None:
+    def _resolve_selection_anchor_from_cache(self, *, missing_if_absent: bool) -> bool:
         anchor = self._selection_anchor
         if anchor is None:
-            return
+            return False
         row = self.cached_row_for_path(anchor.path)
-        if row is None:
+        dto = self._row_cache.get(row) if row is not None else None
+        identity_mismatch = bool(
+            dto is not None
+            and anchor.asset_id
+            and str(dto.id) != anchor.asset_id
+        )
+        if row is None or dto is None or identity_mismatch:
             if missing_if_absent:
                 self._pinned_row = None
                 self._cancel_selection_anchor_retry()
                 self._selection_anchor_status = "missing"
                 self.selection_anchor_changed.emit("missing", anchor, None)
-            return
-        dto = self._row_cache.get(row)
+            return False
         self._pinned_row = row
         self._cancel_selection_anchor_retry()
         self._selection_anchor = GallerySelectionAnchor(
             path=anchor.path,
-            asset_id=anchor.asset_id or (str(dto.id) if dto is not None else ""),
+            asset_id=anchor.asset_id or str(dto.id),
             previous_row=row,
             selection_version=anchor.selection_version,
         )
         self._selection_anchor_status = "resolved"
         self.selection_anchor_changed.emit("resolved", self._selection_anchor, row)
+        return True
 
     def discard_window_requests(self, generations: Iterable[int]) -> None:
         """Forget queued requests canceled before their worker started."""

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -85,6 +85,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._edit_service_getter = edit_service_getter
         self._thumb_size = QSize(512, 512)
         self._current_row = -1
+        self._current_path: Path | None = None
         self._last_snapshot: Optional[tuple[int, Optional[tuple[int, int]], int]] = None
         self._last_selection_signature: tuple[str, str, str] | None = None
         self._last_window_identity_signature: tuple[str, ...] | None = None
@@ -412,6 +413,11 @@ class GalleryListModelAdapter(QAbstractListModel):
     def row_for_path(self, path: Path) -> int | None:
         return self._store.row_for_path(path)
 
+    def cached_row_for_path(self, path: Path) -> int | None:
+        """Return a cached row without performing database or filesystem I/O."""
+
+        return self._store.cached_row_for_path(path)
+
     def begin_startup_gallery_warmup(self) -> None:
         """Prioritize startup Gallery demand without starving guard thumbnails."""
 
@@ -705,7 +711,19 @@ class GalleryListModelAdapter(QAbstractListModel):
         return True
 
     def set_current_row(self, row: int) -> None:
-        if self._current_row == row:
+        """Set the positional current row for legacy callers."""
+
+        self._set_current_asset(row, path=self._current_path)
+
+    def set_current_asset(self, row: int, path: Path) -> None:
+        """Set the current asset while retaining its path-stable visual identity."""
+
+        self._set_current_asset(row, path=Path(path))
+
+    def _set_current_asset(self, row: int, *, path: Path | None) -> None:
+        path_changed = path != self._current_path
+        self._current_path = path
+        if self._current_row == row and not path_changed:
             return
         old_row = self._current_row
         self._current_row = row
@@ -770,6 +788,11 @@ class GalleryListModelAdapter(QAbstractListModel):
         return None, None
 
     def _on_source_changed(self) -> None:
+        # The store cache already contains the new revision when this callback
+        # runs.  Re-anchor the visual current item by its stable path before
+        # views receive modelAboutToBeReset; carrying the old numeric row into
+        # the reset would briefly expand/highlight a different asset.
+        self._reanchor_current_asset_from_cache()
         count = self._store.count()
         current_snapshot = self._store.snapshot_signature()
         current_selection_signature = self._selection_signature()
@@ -824,6 +847,13 @@ class GalleryListModelAdapter(QAbstractListModel):
             self._current_row = -1
         if collection_revision_changed:
             self._republish_thumbnail_demand_for_collection_revision()
+
+    def _reanchor_current_asset_from_cache(self) -> None:
+        path = self._current_path
+        if path is None:
+            return
+        cached_row = self._store.cached_row_for_path(path)
+        self._current_row = -1 if cached_row is None else cached_row
 
     def _republish_thumbnail_demand_for_collection_revision(self) -> None:
         """Rebuild guard demand even when the viewport itself did not move."""

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -60,6 +60,10 @@ def _startup_hang_diag_enabled() -> bool:
     return os.environ.get("IPHOTO_STARTUP_HANG_DIAG", "").strip().lower() in _TRUE_ENV_VALUES
 
 
+def _runtime_diag_enabled() -> bool:
+    return os.environ.get("IPHOTO_RUNTIME_DIAG", "").strip().lower() in _TRUE_ENV_VALUES
+
+
 class GalleryListModelAdapter(QAbstractListModel):
     """Expose a pure Python collection store to Qt item views."""
 
@@ -112,6 +116,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._startup_gallery_viewport_seen = False
         self._startup_gallery_thumbnail_seen = False
         self._startup_gallery_heartbeat_count = 0
+        self._runtime_diag_heartbeat_count = 0
         self._prioritize_timer = QTimer(self)
         self._prioritize_timer.setSingleShot(True)
         self._prioritize_timer.setInterval(16)
@@ -133,6 +138,12 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._startup_gallery_heartbeat_timer.setInterval(250)
         self._startup_gallery_heartbeat_timer.timeout.connect(
             self._log_startup_gallery_heartbeat
+        )
+        self._runtime_diag_heartbeat_timer = QTimer(self)
+        self._runtime_diag_heartbeat_timer.setSingleShot(False)
+        self._runtime_diag_heartbeat_timer.setInterval(1000)
+        self._runtime_diag_heartbeat_timer.timeout.connect(
+            self._log_runtime_diag_heartbeat
         )
         self._startup_gallery_timeout_timer = QTimer(self)
         self._startup_gallery_timeout_timer.setSingleShot(True)
@@ -159,6 +170,8 @@ class GalleryListModelAdapter(QAbstractListModel):
         if callable(thumbnail_status_connect):
             thumbnail_status_connect(self._on_thumbnail_status_changed)
         self._bind_backfill_completion_signal(self._current_asset_query_service())
+        if _runtime_diag_enabled():
+            self._runtime_diag_heartbeat_timer.start()
 
     @classmethod
     def create(
@@ -477,7 +490,25 @@ class GalleryListModelAdapter(QAbstractListModel):
 
     @Slot(object)
     def _on_window_result(self, result: GalleryWindowResult) -> None:
-        if self._store.apply_window_result(result):
+        anchor_result = result.selection_anchor_result
+        emit_perf_event(
+            "gallery_window_result_received",
+            generation=result.generation,
+            requested_revision=result.requested_revision,
+            collection_revision=result.collection_revision,
+            rows=len(result.rows),
+            total_count=result.total_count,
+            error=result.error,
+            anchor_status=(anchor_result.status if anchor_result is not None else None),
+        )
+        applied = self._store.apply_window_result(result)
+        emit_perf_event(
+            "gallery_window_result_applied",
+            generation=result.generation,
+            collection_revision=result.collection_revision,
+            applied=applied,
+        )
+        if applied:
             if self._startup_gallery_warmup_active:
                 self._startup_gallery_window_seen = True
                 mark("gallery_startup_warmup.first_window_applied")
@@ -514,6 +545,14 @@ class GalleryListModelAdapter(QAbstractListModel):
 
     @Slot(object)
     def _enqueue_scan_batch_on_ui_thread(self, batch: object) -> None:
+        rows = getattr(batch, "rows", None)
+        emit_perf_event(
+            "gallery_scan_batch_received",
+            collection_revision=getattr(batch, "collection_revision", None),
+            ready_count=getattr(batch, "ready_count", None),
+            row_count=len(rows) if isinstance(rows, (list, tuple)) else None,
+            pending_batches=self._pending_scan_batch_count,
+        )
         record_batch = getattr(self._store, "record_scan_batch", None)
         if callable(record_batch):
             if record_batch(batch):
@@ -530,7 +569,12 @@ class GalleryListModelAdapter(QAbstractListModel):
     def _flush_pending_scan_batches(self) -> None:
         if self._pending_scan_batch_count <= 0:
             return
+        coalesced_count = self._pending_scan_batch_count
         self._pending_scan_batch_count = 0
+        emit_perf_event(
+            "gallery_scan_batches_flushed",
+            coalesced_count=coalesced_count,
+        )
         flush = getattr(self._store, "flush_pending_scan_refresh", None)
         if callable(flush):
             flush()
@@ -1093,6 +1137,25 @@ class GalleryListModelAdapter(QAbstractListModel):
         )
         if self._startup_gallery_heartbeat_count >= 12:
             self._startup_gallery_heartbeat_timer.stop()
+
+    @Slot()
+    def _log_runtime_diag_heartbeat(self) -> None:
+        if not _runtime_diag_enabled():
+            self._runtime_diag_heartbeat_timer.stop()
+            return
+        self._runtime_diag_heartbeat_count += 1
+        snapshot_getter = getattr(self._store, "diagnostic_snapshot", None)
+        snapshot = snapshot_getter() if callable(snapshot_getter) else {}
+        if not isinstance(snapshot, dict):
+            snapshot = {}
+        emit_perf_event(
+            "runtime_gui_heartbeat",
+            heartbeat=self._runtime_diag_heartbeat_count,
+            model_current_row=self._current_row,
+            viewport_generation=self._viewport_generation,
+            pending_scan_batches=self._pending_scan_batch_count,
+            **snapshot,
+        )
 
     def _reconcile_full_thumbnail_demand(self) -> None:
         demand = self._viewport_demand

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -621,8 +621,6 @@ class GalleryListModelAdapter(QAbstractListModel):
         asset_query_service,
         library_root: Optional[Path],
     ) -> None:
-        self._selection_anchor_retry_timer.stop()
-        self._pending_selection_anchor_retry = None
         self._last_snapshot = None
         self._last_selection_signature = None
         self._last_window_identity_signature = None
@@ -753,20 +751,35 @@ class GalleryListModelAdapter(QAbstractListModel):
 
         self._set_current_asset(row, path=self._current_path)
 
-    def set_current_asset(self, row: int, path: Path) -> None:
-        """Set the current asset while retaining its path-stable visual identity."""
+    def set_current_asset(
+        self,
+        authoritative_row: int | None,
+        path: Path,
+    ) -> int | None:
+        """Project semantic selection onto a cached Filmstrip visual row."""
 
-        self._set_current_asset(row, path=Path(path))
+        return self._set_current_asset(authoritative_row, path=Path(path))
 
-    def _set_current_asset(self, row: int, *, path: Path | None) -> None:
+    def _set_current_asset(
+        self,
+        authoritative_row: int | None,
+        *,
+        path: Path | None,
+    ) -> int | None:
+        visual_row = (
+            int(authoritative_row)
+            if authoritative_row is not None and int(authoritative_row) >= 0
+            else None
+        )
+        if visual_row is None and path is not None:
+            visual_row = self._store.cached_row_for_path(path)
+        row = visual_row if visual_row is not None and visual_row >= 0 else -1
         path_changed = path != self._current_path
         self._current_path = path
         if self._current_row == row and not path_changed:
-            return
+            return visual_row
         old_row = self._current_row
         self._current_row = row
-        if row >= 0:
-            self.pin_row(row)
         if old_row >= 0:
             idx = self.index(old_row, 0)
             if idx.isValid():
@@ -783,6 +796,7 @@ class GalleryListModelAdapter(QAbstractListModel):
                     idx,
                     [Roles.IS_CURRENT, Roles.TILE_SNAPSHOT, Qt.ItemDataRole.SizeHintRole],
                 )
+        return visual_row
 
     def metadata_for_path(self, path: Path) -> Optional[Dict[str, Any]]:
         dto = self._store.find_dto_by_path(path)

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -48,7 +48,11 @@ from .gallery_thumbnail_hint_loader import (
     GalleryThumbnailHintResult,
 )
 from .gallery_tile import GalleryTileRecord, GalleryTileSnapshot
-from .gallery_window_loader import GalleryWindowLoader, GalleryWindowResult
+from .gallery_window_loader import (
+    GallerySelectionAnchorRetryTicket,
+    GalleryWindowLoader,
+    GalleryWindowResult,
+)
 
 _LOGGER = logging.getLogger(__name__)
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
@@ -104,6 +108,9 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._thumbnail_hint_loader.resultReady.connect(self._on_thumbnail_hint_result)
         self._thumbnail_hint_request_id = 0
         self._pending_scan_batch_count = 0
+        self._pending_selection_anchor_retry: (
+            GallerySelectionAnchorRetryTicket | None
+        ) = None
         self._backfill_completion_source: Any | None = None
         self._startup_diag_logged_source = False
         self._startup_diag_logged_viewport = False
@@ -134,6 +141,11 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._scan_batch_timer.setSingleShot(True)
         self._scan_batch_timer.setInterval(150)
         self._scan_batch_timer.timeout.connect(self._flush_pending_scan_batches)
+        self._selection_anchor_retry_timer = QTimer(self)
+        self._selection_anchor_retry_timer.setSingleShot(True)
+        self._selection_anchor_retry_timer.timeout.connect(
+            self._retry_selection_anchor
+        )
         self._startup_gallery_heartbeat_timer = QTimer(self)
         self._startup_gallery_heartbeat_timer.setSingleShot(False)
         self._startup_gallery_heartbeat_timer.setInterval(250)
@@ -165,6 +177,14 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._store.window_changed.connect(self._on_window_changed)
         self._store.data_changed.connect(self._on_source_changed)
         self._store.row_changed.connect(self._on_row_changed)
+        anchor_retry_signal = getattr(
+            self._store,
+            "selection_anchor_retry_requested",
+            None,
+        )
+        anchor_retry_connect = getattr(anchor_retry_signal, "connect", None)
+        if callable(anchor_retry_connect):
+            anchor_retry_connect(self._schedule_selection_anchor_retry)
         self._thumbnails.thumbnailReady.connect(self._on_thumbnail_ready)
         thumbnail_status_signal = getattr(self._thumbnails, "thumbnailStatusChanged", None)
         thumbnail_status_connect = getattr(thumbnail_status_signal, "connect", None)
@@ -601,6 +621,8 @@ class GalleryListModelAdapter(QAbstractListModel):
         asset_query_service,
         library_root: Optional[Path],
     ) -> None:
+        self._selection_anchor_retry_timer.stop()
+        self._pending_selection_anchor_retry = None
         self._last_snapshot = None
         self._last_selection_signature = None
         self._last_window_identity_signature = None
@@ -612,6 +634,22 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._thumbnail_hint_loader.cancel_pending()
         self._store.rebind_asset_query_service(asset_query_service, library_root)
         self._bind_backfill_completion_signal(asset_query_service)
+
+    @Slot(object)
+    def _schedule_selection_anchor_retry(self, ticket: object) -> None:
+        self._selection_anchor_retry_timer.stop()
+        if not isinstance(ticket, GallerySelectionAnchorRetryTicket):
+            self._pending_selection_anchor_retry = None
+            return
+        self._pending_selection_anchor_retry = ticket
+        self._selection_anchor_retry_timer.start(max(0, int(ticket.delay_ms)))
+
+    @Slot()
+    def _retry_selection_anchor(self) -> None:
+        ticket = self._pending_selection_anchor_retry
+        self._pending_selection_anchor_retry = None
+        if ticket is not None:
+            self._store.retry_selection_anchor(ticket)
 
     def invalidate_thumbnail(
         self,

--- a/src/iPhoto/gui/viewmodels/gallery_window_loader.py
+++ b/src/iPhoto/gui/viewmodels/gallery_window_loader.py
@@ -23,6 +23,17 @@ class GallerySelectionAnchor:
     path: Path
     asset_id: str
     previous_row: int
+    selection_version: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class GallerySelectionAnchorRetryTicket:
+    """One bounded, cancelable retry of a path-stable selection anchor."""
+
+    anchor: GallerySelectionAnchor
+    collection_revision: int
+    attempt: int
+    delay_ms: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +65,8 @@ class GalleryWindowRequest:
     collection_revision: int = 0
     demand_generation: int = 0
     priority: int = 1
+    purpose: Literal["viewport", "selection_anchor_retry"] = "viewport"
+    selection_anchor_retry_attempt: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,6 +83,8 @@ class GalleryWindowResult:
     demand_generation: int = 0
     priority: int = 1
     selection_anchor_result: GallerySelectionAnchorResult | None = None
+    purpose: Literal["viewport", "selection_anchor_retry"] = "viewport"
+    selection_anchor_retry_attempt: int = 0
 
 
 class _GalleryWindowSignals(QObject):
@@ -259,6 +274,10 @@ class _GalleryWindowWorker(QRunnable):
                     demand_generation=request.demand_generation,
                     priority=request.priority,
                     selection_anchor_result=selection_anchor_result,
+                    purpose=request.purpose,
+                    selection_anchor_retry_attempt=(
+                        request.selection_anchor_retry_attempt
+                    ),
                 )
             )
             request_backfill = getattr(request.query_service, "request_thumbnail_backfill", None)
@@ -289,6 +308,10 @@ class _GalleryWindowWorker(QRunnable):
                     requested_revision=request.collection_revision,
                     demand_generation=request.demand_generation,
                     priority=request.priority,
+                    purpose=request.purpose,
+                    selection_anchor_retry_attempt=(
+                        request.selection_anchor_retry_attempt
+                    ),
                 )
             )
 
@@ -405,12 +428,15 @@ class GalleryWindowLoader(QObject):
             request.selection_anchor,
             request.request_backfill,
             request.collection_revision,
+            request.purpose,
+            request.selection_anchor_retry_attempt,
         )
 
 
 __all__ = [
     "GallerySelectionAnchor",
     "GallerySelectionAnchorResult",
+    "GallerySelectionAnchorRetryTicket",
     "GalleryWindowLoader",
     "GalleryWindowRequest",
     "GalleryWindowResult",

--- a/src/iPhoto/gui/viewmodels/gallery_window_loader.py
+++ b/src/iPhoto/gui/viewmodels/gallery_window_loader.py
@@ -3,15 +3,36 @@
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
 
 from iPhoto.application.dtos import AssetDTO
 from iPhoto.domain.models.query import AssetQuery
 from iPhoto.gui.viewmodels.asset_dto_converter import scan_row_to_dto
+
+
+@dataclass(frozen=True, slots=True)
+class GallerySelectionAnchor:
+    """Path-stable selection identity carried across collection revisions."""
+
+    path: Path
+    asset_id: str
+    previous_row: int
+
+
+@dataclass(frozen=True, slots=True)
+class GallerySelectionAnchorResult:
+    """Authoritative result of resolving an anchor on the Gallery worker."""
+
+    anchor: GallerySelectionAnchor
+    status: Literal["resolved", "missing", "retry"]
+    row: int | None = None
+    dto: AssetDTO | None = None
+    elapsed_ms: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,7 +46,9 @@ class GalleryWindowRequest:
     limit: int
     pending_source_ids: frozenset[str] = frozenset()
     pending_source_count: int = 0
+    pending_source_rows: tuple[int, ...] = ()
     pending_insertions: tuple[AssetDTO, ...] = ()
+    selection_anchor: GallerySelectionAnchor | None = None
     request_backfill: bool = True
     collection_revision: int = 0
     demand_generation: int = 0
@@ -45,6 +68,7 @@ class GalleryWindowResult:
     requested_revision: int = 0
     demand_generation: int = 0
     priority: int = 1
+    selection_anchor_result: GallerySelectionAnchorResult | None = None
 
 
 class _GalleryWindowSignals(QObject):
@@ -59,6 +83,88 @@ def _dto_identity_keys(dto: AssetDTO) -> set[str]:
     if dto.id:
         keys.add(f"id:{dto.id}")
     return keys
+
+
+def _normalized_path(path: Path) -> str:
+    return os.path.normcase(os.path.abspath(os.fspath(path)))
+
+
+def _resolve_selection_anchor(
+    request: GalleryWindowRequest,
+    reader: Any,
+    rows: dict[int, AssetDTO],
+    collection_revision: int,
+) -> GallerySelectionAnchorResult | None:
+    anchor = request.selection_anchor
+    if anchor is None:
+        return None
+
+    started = time.perf_counter()
+    target = _normalized_path(anchor.path)
+    for view_row, dto in rows.items():
+        if _normalized_path(dto.abs_path) == target:
+            return GallerySelectionAnchorResult(
+                anchor=anchor,
+                status="resolved",
+                row=view_row,
+                dto=dto,
+                elapsed_ms=(time.perf_counter() - started) * 1000.0,
+            )
+
+    try:
+        find_row_by_path = getattr(request.query_service, "find_row_by_path", None)
+        if not callable(find_row_by_path):
+            raise RuntimeError("query service does not support anchor resolution")
+        raw_row = find_row_by_path(request.query, anchor.path)
+        if raw_row is None:
+            return GallerySelectionAnchorResult(
+                anchor=anchor,
+                status="missing",
+                elapsed_ms=(time.perf_counter() - started) * 1000.0,
+            )
+
+        raw_row = int(raw_row)
+        exact_window = reader(request.root, request.query, raw_row, 1)
+        if int(exact_window.collection_revision) != int(collection_revision):
+            raise RuntimeError("collection changed during anchor resolution")
+        dto: AssetDTO | None = None
+        for raw_asset in exact_window.rows:
+            rel = raw_asset.get("rel") if isinstance(raw_asset, dict) else None
+            if not isinstance(rel, str) or not rel:
+                continue
+            candidate = scan_row_to_dto(request.root, rel, raw_asset)
+            if candidate is None:
+                continue
+            if str(candidate.id) in request.pending_source_ids:
+                return GallerySelectionAnchorResult(
+                    anchor=anchor,
+                    status="missing",
+                    elapsed_ms=(time.perf_counter() - started) * 1000.0,
+                )
+            if _normalized_path(candidate.abs_path) == target:
+                dto = candidate
+                break
+        if dto is None:
+            # The index changed between the row lookup and exact read. Let the
+            # next revision retry instead of falsely declaring the asset gone.
+            raise RuntimeError("anchor row changed during resolution")
+
+        hidden_before = sum(
+            1 for source_row in request.pending_source_rows if source_row < raw_row
+        )
+        return GallerySelectionAnchorResult(
+            anchor=anchor,
+            status="resolved",
+            row=max(0, raw_row - hidden_before),
+            dto=dto,
+            elapsed_ms=(time.perf_counter() - started) * 1000.0,
+        )
+    except Exception:  # noqa: BLE001 - anchor failure must not fail the window
+        return GallerySelectionAnchorResult(
+            anchor=anchor,
+            status="retry",
+            elapsed_ms=(time.perf_counter() - started) * 1000.0,
+        )
 
 
 class _GalleryWindowWorker(QRunnable):
@@ -113,6 +219,12 @@ class _GalleryWindowWorker(QRunnable):
             for offset, dto in enumerate(pending_insertions):
                 rows[insertion_start + offset] = dto
 
+            selection_anchor_result = _resolve_selection_anchor(
+                request,
+                reader,
+                rows,
+                int(window.collection_revision),
+            )
             last = request.view_first + loaded_count - 1
             self._signals.completed.emit(
                 GalleryWindowResult(
@@ -125,6 +237,7 @@ class _GalleryWindowWorker(QRunnable):
                     requested_revision=request.collection_revision,
                     demand_generation=request.demand_generation,
                     priority=request.priority,
+                    selection_anchor_result=selection_anchor_result,
                 )
             )
             request_backfill = getattr(request.query_service, "request_thumbnail_backfill", None)
@@ -259,13 +372,17 @@ class GalleryWindowLoader(QObject):
             request.limit,
             request.pending_source_ids,
             request.pending_source_count,
+            request.pending_source_rows,
             request.pending_insertions,
+            request.selection_anchor,
             request.request_backfill,
             request.collection_revision,
         )
 
 
 __all__ = [
+    "GallerySelectionAnchor",
+    "GallerySelectionAnchorResult",
     "GalleryWindowLoader",
     "GalleryWindowRequest",
     "GalleryWindowResult",

--- a/src/iPhoto/gui/viewmodels/gallery_window_loader.py
+++ b/src/iPhoto/gui/viewmodels/gallery_window_loader.py
@@ -13,6 +13,7 @@ from PySide6.QtCore import QObject, QRunnable, QThreadPool, Signal
 from iPhoto.application.dtos import AssetDTO
 from iPhoto.domain.models.query import AssetQuery
 from iPhoto.gui.viewmodels.asset_dto_converter import scan_row_to_dto
+from iPhoto.infrastructure.services.performance_events import emit_perf_event
 
 
 @dataclass(frozen=True, slots=True)
@@ -176,6 +177,7 @@ class _GalleryWindowWorker(QRunnable):
 
     def run(self) -> None:  # pragma: no cover - background Qt task
         request = self._request
+        started = time.perf_counter()
         try:
             reader = getattr(request.query_service, "read_gallery_asset_window", None)
             if not callable(reader):
@@ -226,6 +228,25 @@ class _GalleryWindowWorker(QRunnable):
                 int(window.collection_revision),
             )
             last = request.view_first + loaded_count - 1
+            emit_perf_event(
+                "gallery_window_worker_finished",
+                generation=request.generation,
+                requested_revision=request.collection_revision,
+                collection_revision=int(window.collection_revision),
+                elapsed_ms=round((time.perf_counter() - started) * 1000.0, 3),
+                rows=len(rows),
+                total_count=total_count,
+                anchor_status=(
+                    selection_anchor_result.status
+                    if selection_anchor_result is not None
+                    else None
+                ),
+                anchor_elapsed_ms=(
+                    round(selection_anchor_result.elapsed_ms, 3)
+                    if selection_anchor_result is not None
+                    else None
+                ),
+            )
             self._signals.completed.emit(
                 GalleryWindowResult(
                     generation=request.generation,
@@ -249,6 +270,13 @@ class _GalleryWindowWorker(QRunnable):
                     request.limit,
                 )
         except Exception as exc:  # noqa: BLE001 - worker boundary
+            emit_perf_event(
+                "gallery_window_worker_failed",
+                generation=request.generation,
+                requested_revision=request.collection_revision,
+                elapsed_ms=round((time.perf_counter() - started) * 1000.0, 3),
+                error=type(exc).__name__,
+            )
             self._signals.completed.emit(
                 GalleryWindowResult(
                     generation=request.generation,

--- a/src/iPhoto/infrastructure/services/performance_events.py
+++ b/src/iPhoto/infrastructure/services/performance_events.py
@@ -2,17 +2,35 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import os
 import sys
 import time
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_SENSITIVE_FIELDS = {
+    "absolute_path",
+    "caller",
+    "key",
+    "old_key",
+    "path",
+    "paths",
+    "source",
+    "source_path",
+}
 
 
 def perf_logging_enabled() -> bool:
-    return os.environ.get("IPHOTO_PERF_LOG", "").strip().lower() in {"1", "true", "yes", "on"}
+    return os.environ.get("IPHOTO_PERF_LOG", "").strip().lower() in _TRUE_VALUES
+
+
+def privacy_safe_perf_logging_enabled() -> bool:
+    return os.environ.get("IPHOTO_PERF_PRIVACY_SAFE", "").strip().lower() in _TRUE_VALUES
 
 
 def explain_enabled() -> bool:
@@ -87,23 +105,52 @@ def _caller_is_gallery_collection(caller: str | None) -> bool:
 
 
 def _json_safe_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    safe: dict[str, Any] = {}
-    for key, value in payload.items():
-        if isinstance(value, (str, int, float, bool)) or value is None:
-            safe[key] = value
-        elif isinstance(value, (list, tuple)):
-            safe[key] = [
-                item if isinstance(item, (str, int, float, bool)) or item is None else str(item)
-                for item in value
-            ]
-        elif isinstance(value, dict):
-            safe[key] = {
-                str(k): v if isinstance(v, (str, int, float, bool)) or v is None else str(v)
-                for k, v in value.items()
-            }
-        else:
-            safe[key] = str(value)
-    return safe
+    privacy_safe = privacy_safe_perf_logging_enabled()
+    return {
+        str(key): _json_safe_value(
+            value,
+            privacy_safe=privacy_safe,
+            sensitive=str(key).lower() in _SENSITIVE_FIELDS,
+        )
+        for key, value in payload.items()
+    }
+
+
+def _json_safe_value(
+    value: Any,
+    *,
+    privacy_safe: bool,
+    sensitive: bool,
+) -> Any:
+    if isinstance(value, (list, tuple)):
+        return [
+            _json_safe_value(
+                item,
+                privacy_safe=privacy_safe,
+                sensitive=sensitive,
+            )
+            for item in value
+        ]
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe_value(
+                item,
+                privacy_safe=privacy_safe,
+                sensitive=sensitive or str(key).lower() in _SENSITIVE_FIELDS,
+            )
+            for key, item in value.items()
+        }
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    text = os.fspath(value) if isinstance(value, Path) else str(value)
+    if privacy_safe and (sensitive or isinstance(value, Path) or os.path.isabs(text)):
+        salt = os.environ.get("IPHOTO_PERF_PRIVACY_SALT", "iPhoto-perf")
+        digest = hashlib.sha256(
+            f"{salt}|{text}".encode("utf-8", errors="replace")
+        ).hexdigest()
+        return f"redacted:{digest[:16]}"
+    return text
 
 
 __all__ = [
@@ -112,5 +159,6 @@ __all__ = [
     "explain_enabled",
     "fail_on_full_scan_query_enabled",
     "monotonic_ms",
+    "privacy_safe_perf_logging_enabled",
     "perf_logging_enabled",
 ]

--- a/src/iPhoto/runtime_diagnostics.py
+++ b/src/iPhoto/runtime_diagnostics.py
@@ -1,0 +1,154 @@
+"""Opt-in runtime hang diagnostics for packaged and source GUI processes."""
+
+from __future__ import annotations
+
+import atexit
+import faulthandler
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import TextIO
+
+_LOGGER = logging.getLogger(__name__)
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_LOCK = threading.Lock()
+_STREAM: TextIO | None = None
+_ACTIVE = False
+_ATEXIT_REGISTERED = False
+
+
+def runtime_diagnostics_enabled() -> bool:
+    """Return whether persistent all-thread stack dumps were requested."""
+
+    return os.environ.get("IPHOTO_RUNTIME_DIAG", "").strip().lower() in _TRUE_VALUES
+
+
+def runtime_diagnostics_active() -> bool:
+    """Return whether the runtime stack watchdog was successfully enabled."""
+
+    with _LOCK:
+        return _ACTIVE
+
+
+def _interval_seconds() -> int:
+    raw_value = os.environ.get("IPHOTO_RUNTIME_DIAG_INTERVAL_SEC", "10").strip()
+    try:
+        return max(5, min(60, int(raw_value)))
+    except ValueError:
+        return 10
+
+
+def enable_runtime_diagnostics() -> bool:
+    """Start persistent traceback dumps to the configured diagnostic file."""
+
+    global _ACTIVE, _ATEXIT_REGISTERED, _STREAM
+
+    if not runtime_diagnostics_enabled():
+        return False
+    with _LOCK:
+        if _ACTIVE:
+            return True
+
+        target_value = os.environ.get("IPHOTO_RUNTIME_DIAG_STACK_PATH", "").strip()
+        stream: TextIO | None = None
+        owns_stream = False
+        try:
+            if target_value:
+                target = Path(target_value).expanduser()
+                target.parent.mkdir(parents=True, exist_ok=True)
+                stream = target.open("a", encoding="utf-8", buffering=1)
+                owns_stream = True
+            elif sys.stderr is not None:
+                stream = sys.stderr
+            if stream is None:
+                return False
+
+            interval = _interval_seconds()
+            stream.write(
+                json.dumps(
+                    {
+                        "event": "runtime_diagnostics_started",
+                        "wall_time": time.time(),
+                        "pid": os.getpid(),
+                        "platform": sys.platform,
+                        "interval_seconds": interval,
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+            stream.flush()
+            faulthandler.enable(file=stream, all_threads=True)
+            faulthandler.dump_traceback_later(
+                interval,
+                repeat=True,
+                file=stream,
+                exit=False,
+            )
+            _STREAM = stream if owns_stream else None
+            _ACTIVE = True
+            if not _ATEXIT_REGISTERED:
+                atexit.register(shutdown_runtime_diagnostics)
+                _ATEXIT_REGISTERED = True
+            _LOGGER.info(
+                "Runtime hang diagnostics enabled; dumping all thread stacks every %ss",
+                interval,
+            )
+            return True
+        except Exception:  # noqa: BLE001 - diagnostics cannot break startup
+            if owns_stream and stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+            _LOGGER.warning("Failed to enable runtime hang diagnostics", exc_info=True)
+            return False
+
+
+def shutdown_runtime_diagnostics() -> None:
+    """Stop the watchdog and flush its owned stack stream."""
+
+    global _ACTIVE, _STREAM
+
+    with _LOCK:
+        if not _ACTIVE:
+            return
+        try:
+            faulthandler.cancel_dump_traceback_later()
+        except Exception:  # noqa: BLE001 - shutdown remains best-effort
+            pass
+        stream = _STREAM
+        _STREAM = None
+        _ACTIVE = False
+        if stream is not None:
+            try:
+                stream.write(
+                    json.dumps(
+                        {
+                            "event": "runtime_diagnostics_stopped",
+                            "wall_time": time.time(),
+                            "pid": os.getpid(),
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+                stream.flush()
+            except OSError:
+                pass
+            try:
+                stream.close()
+            except OSError:
+                pass
+
+
+__all__ = [
+    "enable_runtime_diagnostics",
+    "runtime_diagnostics_active",
+    "runtime_diagnostics_enabled",
+    "shutdown_runtime_diagnostics",
+]

--- a/src/iPhoto/sqlite_utils.py
+++ b/src/iPhoto/sqlite_utils.py
@@ -28,10 +28,12 @@ def configure_sqlite_connection(
     *,
     foreign_keys: bool = False,
     wal: bool = False,
+    busy_timeout_ms: int = SQLITE_BUSY_TIMEOUT_MS,
 ) -> None:
     """Apply common per-connection pragmas, and initialize WAL once per DB path."""
 
-    conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}")
+    timeout_ms = max(0, int(busy_timeout_ms))
+    conn.execute(f"PRAGMA busy_timeout={timeout_ms}")
     if foreign_keys:
         conn.execute("PRAGMA foreign_keys=ON")
     if not wal:

--- a/tests/application/test_library_probe.py
+++ b/tests/application/test_library_probe.py
@@ -1029,7 +1029,7 @@ def test_controller_real_helper_round_trip(qapp, tmp_path: Path) -> None:
     assert controller._process is None
 
 
-def test_probe_process_command_uses_python_module_for_source(
+def test_probe_process_command_uses_checkout_entrypoint_for_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delitem(probe_module.__dict__, "__compiled__", raising=False)
@@ -1038,7 +1038,54 @@ def test_probe_process_command_uses_python_module_for_source(
     program, arguments = _probe_process_command()
 
     assert program == sys.executable
+    assert arguments == [
+        str(Path(probe_module.__file__).resolve().parents[2] / "entrypoint.py"),
+        "--startup-library-probe",
+        "--stdin",
+    ]
+
+
+def test_probe_process_command_falls_back_to_module_without_checkout_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(probe_module.__dict__, "__compiled__", raising=False)
+    monkeypatch.delattr(probe_module.sys, "frozen", raising=False)
+    monkeypatch.setattr(probe_module, "_source_probe_entrypoint", lambda: None)
+
+    program, arguments = _probe_process_command()
+
+    assert program == sys.executable
     assert arguments == ["-m", "iPhoto.bootstrap.library_probe", "--stdin"]
+
+
+def test_checkout_helper_ignores_stale_pythonpath_install(tmp_path: Path) -> None:
+    stale_package = tmp_path / "stale-install" / "iPhoto"
+    stale_package.mkdir(parents=True)
+    (stale_package / "__init__.py").write_text(
+        'raise RuntimeError("stale iPhoto install was imported")\n',
+        encoding="utf-8",
+    )
+    library = tmp_path / "library"
+    library.mkdir()
+    request = LibraryProbeRequest.create(library)
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(stale_package.parent)
+    program, arguments = _probe_process_command()
+
+    completed = subprocess.run(
+        [program, *arguments],
+        input=json.dumps(asdict(request)),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+        cwd=tmp_path,
+    )
+
+    envelope = json.loads(completed.stdout)
+    assert completed.returncode == 0
+    assert envelope["protocol_version"] == PROBE_PROTOCOL_VERSION
+    assert envelope["prepared"]["request_id"] == request.request_id
 
 
 def test_probe_process_command_uses_qt_application_path_when_packaged(

--- a/tests/cache/test_move_delete_optimizations.py
+++ b/tests/cache/test_move_delete_optimizations.py
@@ -62,6 +62,18 @@ class TestWALMode:
         finally:
             conn.close()
 
+    def test_create_connection_preserves_ten_second_busy_timeout(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        db = DatabaseManager(tmp_path / "test.db")
+        conn = db._create_connection()
+        try:
+            timeout_ms = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+            assert timeout_ms == 10_000
+        finally:
+            conn.close()
+
     def test_transaction_uses_wal(self, tmp_path: Path) -> None:
         db = DatabaseManager(tmp_path / "test.db")
         with db.transaction() as conn:
@@ -104,6 +116,8 @@ class TestWALMode:
         assert connections[0].statements.count("PRAGMA journal_mode=WAL") == 1
         assert "PRAGMA journal_mode=WAL" not in connections[1].statements
         assert "PRAGMA synchronous=NORMAL" in connections[1].statements
+        assert "PRAGMA busy_timeout=10000" in connections[0].statements
+        assert "PRAGMA busy_timeout=10000" in connections[1].statements
         assert "PRAGMA cache_size=-8000" in connections[1].statements
 
 

--- a/tests/cache/test_move_delete_optimizations.py
+++ b/tests/cache/test_move_delete_optimizations.py
@@ -13,6 +13,8 @@ from typing import Dict
 
 import pytest
 
+from iPhoto import sqlite_utils
+from iPhoto.cache.index_store import engine as engine_module
 from iPhoto.cache.index_store import get_global_repository, reset_global_repository
 from iPhoto.cache.index_store.engine import DatabaseManager
 from iPhoto.cache.index_store.repository import AssetRepository
@@ -70,6 +72,39 @@ class TestWALMode:
         db = DatabaseManager(tmp_path / "test.db")
         with db.transaction(begin_mode="IMMEDIATE") as conn:
             assert conn.in_transaction is True
+
+    def test_short_connections_initialize_wal_only_once(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _FakeConnection:
+            def __init__(self) -> None:
+                self.statements: list[str] = []
+
+            def execute(self, statement: str):
+                self.statements.append(statement)
+                return self
+
+        connections: list[_FakeConnection] = []
+
+        def _connect(*args, **kwargs):
+            del args, kwargs
+            connection = _FakeConnection()
+            connections.append(connection)
+            return connection
+
+        sqlite_utils._WAL_INITIALIZED_PATHS.clear()
+        monkeypatch.setattr(engine_module.sqlite3, "connect", _connect)
+        manager = DatabaseManager(tmp_path / "test.db")
+
+        manager._create_connection()
+        manager._create_connection()
+
+        assert connections[0].statements.count("PRAGMA journal_mode=WAL") == 1
+        assert "PRAGMA journal_mode=WAL" not in connections[1].statements
+        assert "PRAGMA synchronous=NORMAL" in connections[1].statements
+        assert "PRAGMA cache_size=-8000" in connections[1].statements
 
 
 # ------------------------------------------------------------------
@@ -179,6 +214,7 @@ class TestIncrementalCacheUpdate:
     def cache_manager(self):
         from PySide6.QtCore import QSize
         from PySide6.QtGui import QPixmap
+
         from iPhoto.gui.ui.models.asset_cache_manager import AssetCacheManager
 
         mgr = AssetCacheManager(QSize(120, 120))

--- a/tests/contracts/test_windows_scan_playback_diagnostics.py
+++ b/tests/contracts/test_windows_scan_playback_diagnostics.py
@@ -21,8 +21,10 @@ def test_windows_collector_enables_required_runtime_probes() -> None:
     ):
         assert variable in script
     assert 'Marker "problem_reproduced"' in script
+    assert "Resolve-SourceApplicationProcess" in script
     assert "process_metrics.csv" in script
     assert "Compress-Archive" in script
+    assert "$replacementValues.ToArray()" in script
 
 
 def test_windows_collector_does_not_copy_user_media_or_index() -> None:

--- a/tests/contracts/test_windows_scan_playback_diagnostics.py
+++ b/tests/contracts/test_windows_scan_playback_diagnostics.py
@@ -16,6 +16,7 @@ def test_windows_collector_enables_required_runtime_probes() -> None:
         "IPHOTO_PERF_PRIVACY_SAFE",
         "IPHOTO_RUNTIME_DIAG",
         "IPHOTO_RUNTIME_DIAG_STACK_PATH",
+        "PYTHONPATH",
         "QT_LOGGING_RULES",
     ):
         assert variable in script

--- a/tests/contracts/test_windows_scan_playback_diagnostics.py
+++ b/tests/contracts/test_windows_scan_playback_diagnostics.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+COLLECTOR = REPOSITORY_ROOT / "tools" / "collect_windows_scan_playback_diagnostics.ps1"
+DOCUMENTATION = REPOSITORY_ROOT / "docs" / "WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md"
+
+
+def test_windows_collector_enables_required_runtime_probes() -> None:
+    script = COLLECTOR.read_text(encoding="utf-8")
+
+    for variable in (
+        "IPHOTO_DETAIL_PROFILE",
+        "IPHOTO_PERF_LOG",
+        "IPHOTO_PERF_PRIVACY_SAFE",
+        "IPHOTO_RUNTIME_DIAG",
+        "IPHOTO_RUNTIME_DIAG_STACK_PATH",
+        "QT_LOGGING_RULES",
+    ):
+        assert variable in script
+    assert 'Marker "problem_reproduced"' in script
+    assert "process_metrics.csv" in script
+    assert "Compress-Archive" in script
+
+
+def test_windows_collector_does_not_copy_user_media_or_index() -> None:
+    script = COLLECTOR.read_text(encoding="utf-8").lower()
+
+    assert "copy-item" not in script
+    assert "global_index.db" not in script
+    assert "thumbnail" not in script
+
+
+def test_windows_collector_documentation_describes_reproduction_marker() -> None:
+    documentation = DOCUMENTATION.read_text(encoding="utf-8")
+
+    assert "press `R` once" in documentation
+    assert "single ZIP" in documentation
+    assert "does not copy photos" in documentation

--- a/tests/core/test_runtime_diagnostics.py
+++ b/tests/core/test_runtime_diagnostics.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from iPhoto import runtime_diagnostics
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_diagnostics(monkeypatch):
+    stream = runtime_diagnostics._STREAM
+    if stream is not None and not stream.closed:
+        stream.close()
+    monkeypatch.setattr(runtime_diagnostics, "_ACTIVE", False)
+    monkeypatch.setattr(runtime_diagnostics, "_STREAM", None)
+    monkeypatch.setattr(runtime_diagnostics, "_ATEXIT_REGISTERED", False)
+    yield
+    stream = runtime_diagnostics._STREAM
+    if stream is not None and not stream.closed:
+        stream.close()
+
+
+def test_runtime_diagnostics_stays_disabled_without_opt_in(monkeypatch) -> None:
+    monkeypatch.delenv("IPHOTO_RUNTIME_DIAG", raising=False)
+    enable = MagicMock()
+    monkeypatch.setattr(runtime_diagnostics.faulthandler, "enable", enable)
+
+    assert runtime_diagnostics.enable_runtime_diagnostics() is False
+    enable.assert_not_called()
+
+
+def test_runtime_diagnostics_persistently_dumps_and_shuts_down(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    stack_path = tmp_path / "runtime-stacks.log"
+    monkeypatch.setenv("IPHOTO_RUNTIME_DIAG", "1")
+    monkeypatch.setenv("IPHOTO_RUNTIME_DIAG_STACK_PATH", str(stack_path))
+    monkeypatch.setenv("IPHOTO_RUNTIME_DIAG_INTERVAL_SEC", "2")
+    enable = MagicMock()
+    dump = MagicMock()
+    cancel = MagicMock()
+    monkeypatch.setattr(runtime_diagnostics.faulthandler, "enable", enable)
+    monkeypatch.setattr(
+        runtime_diagnostics.faulthandler,
+        "dump_traceback_later",
+        dump,
+    )
+    monkeypatch.setattr(
+        runtime_diagnostics.faulthandler,
+        "cancel_dump_traceback_later",
+        cancel,
+    )
+
+    assert runtime_diagnostics.enable_runtime_diagnostics() is True
+    assert runtime_diagnostics.runtime_diagnostics_active() is True
+    enable.assert_called_once()
+    assert enable.call_args.kwargs["all_threads"] is True
+    dump.assert_called_once()
+    assert dump.call_args.args[0] == 5
+    assert dump.call_args.kwargs["repeat"] is True
+
+    runtime_diagnostics.shutdown_runtime_diagnostics()
+
+    assert runtime_diagnostics.runtime_diagnostics_active() is False
+    cancel.assert_called_once_with()
+    records = [json.loads(line) for line in stack_path.read_text().splitlines()]
+    assert records[0]["event"] == "runtime_diagnostics_started"
+    assert records[0]["interval_seconds"] == 5
+    assert records[-1]["event"] == "runtime_diagnostics_stopped"

--- a/tests/gui/coordinators/test_edit_coordinator.py
+++ b/tests/gui/coordinators/test_edit_coordinator.py
@@ -10,13 +10,14 @@ import pytest
 pytest.importorskip("PySide6", reason="PySide6 is required for edit coordinator tests", exc_type=ImportError)
 pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets not available", exc_type=ImportError)
 
+from PySide6.QtCore import QObject
 from PySide6.QtGui import QImage
 from PySide6.QtWidgets import QApplication, QSlider
 
 from iPhoto.core.adjustment_mapping import VIDEO_TRIM_IN_KEY, VIDEO_TRIM_OUT_KEY
 from iPhoto.gui.coordinators.edit_coordinator import EditCoordinator
-from iPhoto.gui.ui.tasks.video_sidebar_preview_worker import VideoSidebarPreviewResult
 from iPhoto.gui.ui.media import MediaRestoreRequest
+from iPhoto.gui.ui.tasks.video_sidebar_preview_worker import VideoSidebarPreviewResult
 
 
 @pytest.fixture(scope="module")
@@ -235,6 +236,27 @@ def test_unexpected_library_rebind_safely_leaves_active_edit() -> None:
         restore_reason="library_invalidated",
         restore_detail=False,
     )
+
+
+def test_still_edit_without_presented_render_session_is_not_silent(qapp) -> None:
+    coordinator = EditCoordinator.__new__(EditCoordinator)
+    QObject.__init__(coordinator)
+    coordinator._session = None
+    coordinator._current_source = None
+    coordinator._render_session_controller = Mock(
+        acquire_render_session=Mock(return_value=None),
+        _request_generation=7,
+    )
+    coordinator._emit_video_trim_diag = Mock()
+    messages: list[str] = []
+    coordinator.editUnavailable.connect(messages.append)
+
+    EditCoordinator.enter_edit_mode(coordinator, Path("/fake/photo.jpg"))
+
+    assert coordinator._current_source is None
+    assert messages == [
+        "The photo is still loading. Try Edit again when it appears."
+    ]
 
 
 def test_leave_edit_mode_can_emit_edit_done_restore_reason() -> None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -276,6 +276,35 @@ def test_fullscreen_keeps_stable_pending_anchor_instead_of_opening_row_zero() ->
     coordinator.play_asset.assert_not_called()
 
 
+def test_fullscreen_restarts_terminal_pending_still_from_stable_identity() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    presentation = replace(
+        _make_presentation(path="/fake/photo.jpg", is_video=False),
+        row=-1,
+    )
+    transaction = PlaybackCoordinator._transaction_for_presentation(presentation)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_failed(transaction.generation, "abandoned")
+    coordinator._asset_model = Mock(rowCount=Mock(return_value=5))
+    coordinator.current_row = Mock(return_value=-1)
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._current_presentation = presentation
+    coordinator._active_live_motion = None
+    coordinator._player_view = Mock(has_current_render_session=Mock(return_value=False))
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._detail_vm = Mock()
+    coordinator._detail_vm.selection_state.value = MediaSelectionState.ANCHOR_RESOLVING
+    coordinator._detail_vm.recover_current_presentation.return_value = True
+    coordinator.play_asset = Mock()
+
+    assert PlaybackCoordinator.prepare_fullscreen_asset(coordinator) is True
+
+    coordinator._detail_vm.recover_current_presentation.assert_called_once_with()
+    coordinator._detail_vm.show_current.assert_not_called()
+    coordinator.play_asset.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("delta", "method_name"),
     [(1, "next"), (-1, "previous")],

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -408,6 +408,26 @@ def test_same_render_pending_keeps_visual_row_and_reconciles_all_capabilities() 
     coordinator._share_button.setEnabled.assert_called_with(True)
 
 
+def test_filmstrip_selection_cancels_old_restore_before_deferred_center() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    source_index = Mock()
+    visual_index = Mock(isValid=Mock(return_value=True))
+    proxy_model = Mock(mapFromSource=Mock(return_value=visual_index))
+    coordinator._asset_model = Mock(index=Mock(return_value=source_index))
+    coordinator._filmstrip_view = Mock(
+        model=Mock(return_value=proxy_model),
+        select_index_for_centering=Mock(return_value=True),
+    )
+
+    result = PlaybackCoordinator._select_filmstrip_row(coordinator, 24)
+
+    assert result is visual_index
+    proxy_model.mapFromSource.assert_called_once_with(source_index)
+    coordinator._filmstrip_view.select_index_for_centering.assert_called_once_with(
+        visual_index
+    )
+
+
 def test_scan_row_relocation_reuses_preparing_still_without_covering_it() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
     previous = replace(

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -214,6 +214,48 @@ def test_relative_navigation_preserves_single_step_behavior() -> None:
     coordinator.play_asset.assert_called_once_with(2)
 
 
+def test_fullscreen_keeps_active_still_transaction() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    presentation = _make_presentation(path="/fake/photo.jpg", is_video=False)
+    transaction = PlaybackCoordinator._transaction_for_presentation(presentation)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(transaction.generation)
+    coordinator._asset_model = Mock(rowCount=Mock(return_value=1))
+    coordinator.current_row = Mock(return_value=0)
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._current_presentation = presentation
+    coordinator._active_live_motion = None
+    coordinator._player_view = Mock(has_current_render_session=Mock(return_value=False))
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._detail_vm = Mock(show_current=Mock())
+
+    assert PlaybackCoordinator.prepare_fullscreen_asset(coordinator) is True
+
+    coordinator._detail_vm.show_current.assert_not_called()
+
+
+def test_fullscreen_restarts_still_after_terminal_without_render_session() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    presentation = _make_presentation(path="/fake/photo.jpg", is_video=False)
+    transaction = PlaybackCoordinator._transaction_for_presentation(presentation)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_failed(transaction.generation, "abandoned")
+    coordinator._asset_model = Mock(rowCount=Mock(return_value=1))
+    coordinator.current_row = Mock(return_value=0)
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._current_presentation = presentation
+    coordinator._active_live_motion = None
+    coordinator._player_view = Mock(has_current_render_session=Mock(return_value=False))
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._detail_vm = Mock(show_current=Mock())
+
+    assert PlaybackCoordinator.prepare_fullscreen_asset(coordinator) is True
+
+    coordinator._detail_vm.show_current.assert_called_once_with()
+
+
 def test_handle_presentation_changed_renders_video_and_updates_header() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
     coordinator._current_presentation = None
@@ -265,6 +307,76 @@ def test_handle_presentation_changed_skips_full_rerender_for_same_asset() -> Non
 
     coordinator._render_presentation.assert_not_called()
     coordinator._update_favorite_icon.assert_called_once_with(True)
+
+
+def test_scan_row_relocation_reuses_preparing_still_without_covering_it() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    previous = replace(
+        _make_presentation(path="/fake/photo.jpg", is_video=False),
+        row=0,
+        source_identity=AssetSourceIdentity.create(
+            Path("/fake/photo.jpg"),
+            source_mtime_ns=10,
+        ),
+    )
+    relocated = replace(previous, row=7, is_favorite=True)
+    transaction = PlaybackCoordinator._transaction_for_presentation(previous)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(transaction.generation)
+    active_token = object()
+    coordinator._current_presentation = previous
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._detail_render_transaction = transaction
+    coordinator._active_async_token = active_token
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._asset_model = Mock(set_current_row=Mock())
+    coordinator.assetChanged = Mock(emit=Mock())
+    coordinator._update_header = Mock()
+    coordinator._select_filmstrip_row = Mock()
+    coordinator._player_view = Mock(show_placeholder=Mock())
+    coordinator._render_presentation = Mock()
+    coordinator._update_favorite_icon = Mock()
+    coordinator._clear_play_profile = Mock()
+    coordinator._info_panel = None
+
+    PlaybackCoordinator._handle_presentation_changed(coordinator, relocated)
+
+    assert coordinator._current_presentation == relocated
+    assert coordinator._active_async_token is active_token
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.state is DetailRenderState.PREPARING
+    coordinator._select_filmstrip_row.assert_called_once_with(7)
+    coordinator._player_view.show_placeholder.assert_not_called()
+    coordinator._render_presentation.assert_not_called()
+
+
+def test_duplicate_lifecycle_transaction_never_covers_existing_surface() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    presentation = _make_presentation(path="/fake/photo.jpg", is_video=False)
+    transaction = PlaybackCoordinator._transaction_for_presentation(presentation)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(transaction.generation)
+    active_token = object()
+    coordinator._current_presentation = None
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._detail_render_transaction = transaction
+    coordinator._active_async_token = active_token
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._asset_model = Mock(set_current_row=Mock())
+    coordinator.assetChanged = Mock(emit=Mock())
+    coordinator._update_header = Mock()
+    coordinator._select_filmstrip_row = Mock()
+    coordinator._player_view = Mock(show_placeholder=Mock())
+    coordinator._render_presentation = Mock()
+    coordinator._clear_play_profile = Mock()
+
+    PlaybackCoordinator._handle_presentation_changed(coordinator, presentation)
+
+    assert coordinator._active_async_token is active_token
+    coordinator._player_view.show_placeholder.assert_not_called()
+    coordinator._render_presentation.assert_not_called()
 
 
 def test_handle_presentation_changed_rerenders_same_asset_for_new_generation() -> None:
@@ -732,7 +844,59 @@ def test_render_presentation_stops_video_area_before_showing_still() -> None:
         transaction=None,
     )
     coordinator._player_bar.setEnabled.assert_called_once_with(False)
+    coordinator._edit_button.setEnabled.assert_called_once_with(False)
     coordinator._refresh_face_name_overlay_for_presentation.assert_not_called()
+
+
+def test_still_edit_enables_only_after_surface_is_presented() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.jpg")
+    presentation = _make_presentation(path=str(still), is_video=False)
+    transaction = PlaybackCoordinator._transaction_for_presentation(presentation)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(transaction.generation)
+    coordinator._current_presentation = presentation
+    coordinator._detail_render_transaction = transaction
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._active_live_motion = None
+    coordinator._edit_button = Mock(setEnabled=Mock())
+    coordinator._schedule_recognition_overlay = Mock()
+    coordinator._prefetch_neighbor_stills = Mock()
+
+    PlaybackCoordinator._on_still_frame_presented(
+        coordinator,
+        still,
+        transaction.generation,
+    )
+
+    coordinator._edit_button.setEnabled.assert_called_once_with(True)
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.state is DetailRenderState.PRESENTED
+
+
+def test_still_loading_failure_marks_transaction_terminal_and_disables_edit() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    still = Path("/fake/photo.jpg")
+    presentation = _make_presentation(path=str(still), is_video=False)
+    transaction = PlaybackCoordinator._transaction_for_presentation(presentation)
+    lifecycle = DetailRenderCoordinator()
+    lifecycle.begin(transaction)
+    lifecycle.mark_preparing(transaction.generation)
+    coordinator._current_presentation = presentation
+    coordinator._detail_render_transaction = transaction
+    coordinator._detail_render_coordinator = lifecycle
+    coordinator._edit_button = Mock(setEnabled=Mock())
+
+    PlaybackCoordinator._on_still_loading_failed(
+        coordinator,
+        still,
+        "decoder failed",
+    )
+
+    assert lifecycle.snapshot is not None
+    assert lifecycle.snapshot.state is DetailRenderState.FAILED
+    coordinator._edit_button.setEnabled.assert_called_once_with(False)
 
 
 def test_live_photo_fallback_reuses_the_asset_identity() -> None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -25,8 +25,8 @@ from iPhoto.gui.detail_render_coordinator import (
     DetailSurfacePresentationResult,
 )
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
-from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
 from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
+from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
 from iPhoto.gui.ui.widgets.recognition_annotations import RecognitionAnnotation
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailPresentation
 from iPhoto.people.repository import AssetFaceAnnotation
@@ -350,6 +350,62 @@ def test_handle_presentation_changed_skips_full_rerender_for_same_asset() -> Non
 
     coordinator._render_presentation.assert_not_called()
     coordinator._update_favorite_icon.assert_called_once_with(True)
+
+
+def test_same_render_pending_keeps_visual_row_and_reconciles_all_capabilities() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    resolved = _make_presentation(path="/fake/photo.jpg", is_video=False)
+    pending = replace(
+        resolved,
+        row=-1,
+        can_edit=False,
+        can_rotate=False,
+        can_share=False,
+        can_toggle_favorite=False,
+    )
+    coordinator._current_presentation = resolved
+    coordinator._presented_still_source = resolved.path
+    coordinator._presented_still_generation = resolved.request_generation
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._asset_model = Mock(
+        set_current_asset=Mock(side_effect=[4, 0]),
+    )
+    coordinator.assetChanged = Mock(emit=Mock())
+    coordinator._update_header = Mock()
+    coordinator._select_filmstrip_row = Mock()
+    coordinator._player_view = Mock(show_placeholder=Mock())
+    coordinator._render_presentation = Mock()
+    coordinator._update_favorite_icon = Mock()
+    coordinator._clear_play_profile = Mock()
+    coordinator._info_panel = None
+    coordinator._favorite_button = Mock(setEnabled=Mock())
+    coordinator._edit_button = Mock(setEnabled=Mock())
+    coordinator._rotate_button = Mock(setEnabled=Mock())
+    coordinator._share_button = Mock(setEnabled=Mock())
+
+    PlaybackCoordinator._handle_presentation_changed(coordinator, pending)
+
+    coordinator._asset_model.set_current_asset.assert_called_once_with(
+        None,
+        resolved.path,
+    )
+    coordinator.assetChanged.emit.assert_not_called()
+    coordinator._select_filmstrip_row.assert_called_once_with(4)
+    coordinator._favorite_button.setEnabled.assert_called_once_with(False)
+    coordinator._edit_button.setEnabled.assert_called_once_with(False)
+    coordinator._rotate_button.setEnabled.assert_called_once_with(False)
+    coordinator._share_button.setEnabled.assert_called_once_with(False)
+    coordinator._render_presentation.assert_not_called()
+    coordinator._player_view.show_placeholder.assert_not_called()
+
+    PlaybackCoordinator._handle_presentation_changed(coordinator, resolved)
+
+    coordinator.assetChanged.emit.assert_called_once_with(0)
+    assert coordinator._select_filmstrip_row.call_args_list == [call(4), call(0)]
+    coordinator._favorite_button.setEnabled.assert_called_with(True)
+    coordinator._edit_button.setEnabled.assert_called_with(True)
+    coordinator._rotate_button.setEnabled.assert_called_with(True)
+    coordinator._share_button.setEnabled.assert_called_with(True)
 
 
 def test_scan_row_relocation_reuses_preparing_still_without_covering_it() -> None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -318,7 +318,10 @@ def test_handle_presentation_changed_renders_video_and_updates_header() -> None:
     ):
         PlaybackCoordinator._handle_presentation_changed(coordinator, presentation)
 
-    coordinator._asset_model.set_current_row.assert_called_once_with(0)
+    coordinator._asset_model.set_current_asset.assert_called_once_with(
+        0,
+        presentation.path,
+    )
     coordinator.assetChanged.emit.assert_called_once_with(0)
     coordinator._update_header.assert_called_once_with(presentation)
     coordinator._select_filmstrip_row.assert_called_once_with(0)

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -26,6 +26,7 @@ from iPhoto.gui.detail_render_coordinator import (
 )
 from iPhoto.gui.services.location_file_write_queue import LocationFileWriteResult
 from iPhoto.gui.ui.tasks.info_panel_metadata_worker import InfoPanelMetadataResult
+from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
 from iPhoto.gui.ui.widgets.recognition_annotations import RecognitionAnnotation
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailPresentation
 from iPhoto.people.repository import AssetFaceAnnotation
@@ -254,6 +255,45 @@ def test_fullscreen_restarts_still_after_terminal_without_render_session() -> No
     assert PlaybackCoordinator.prepare_fullscreen_asset(coordinator) is True
 
     coordinator._detail_vm.show_current.assert_called_once_with()
+
+
+def test_fullscreen_keeps_stable_pending_anchor_instead_of_opening_row_zero() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    presentation = replace(
+        _make_presentation(path="/fake/photo.jpg", is_video=False),
+        row=-1,
+    )
+    coordinator._asset_model = Mock(rowCount=Mock(return_value=5))
+    coordinator.current_row = Mock(return_value=-1)
+    coordinator._router = Mock(is_detail_view_active=Mock(return_value=True))
+    coordinator._current_presentation = presentation
+    coordinator._active_live_motion = None
+    coordinator._player_view = Mock(has_current_render_session=Mock(return_value=True))
+    coordinator.play_asset = Mock()
+
+    assert PlaybackCoordinator.prepare_fullscreen_asset(coordinator) is True
+
+    coordinator.play_asset.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("delta", "method_name"),
+    [(1, "next"), (-1, "previous")],
+)
+def test_relative_navigation_defers_while_selection_anchor_is_resolving(
+    delta: int,
+    method_name: str,
+) -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    coordinator._asset_model = Mock(rowCount=Mock(return_value=5))
+    coordinator._detail_vm = Mock()
+    coordinator._detail_vm.selection_state.value = MediaSelectionState.ANCHOR_RESOLVING
+    coordinator.play_asset = Mock()
+
+    PlaybackCoordinator._request_relative_asset(coordinator, delta)
+
+    getattr(coordinator._detail_vm, method_name).assert_called_once_with()
+    coordinator.play_asset.assert_not_called()
 
 
 def test_handle_presentation_changed_renders_video_and_updates_header() -> None:

--- a/tests/gui/test_detail_decode_backend.py
+++ b/tests/gui/test_detail_decode_backend.py
@@ -153,7 +153,61 @@ def test_platform_registry_keeps_cancellation_terminal() -> None:
 
     with pytest.raises(DecodeCancelledError):
         DefaultStillDecodeBackend(registry).decode(
-            _request(Path("photo.jpg")),
+            _request(Path("photo.heic")),
+            _Token(),
+        )
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [".jpg", ".jpeg", ".jpe", ".jfif", ".JPG"],
+)
+def test_windows_jpegs_bypass_wic(
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    source = tmp_path / f"photo{suffix}"
+    image = QImage(64, 32, QImage.Format.Format_RGBA8888)
+    image.fill(0xFF123456)
+    format_name = "JPEG"
+    if not image.save(str(source), format_name):
+        pytest.skip(f"Qt test runtime does not provide the {format_name} writer")
+
+    crashing_wic = MagicMock()
+    crashing_wic.decode.side_effect = AssertionError(
+        "common still format entered WIC"
+    )
+
+    registry = StillDecodeBackendRegistry(
+        platform="win32",
+        windows_backend=crashing_wic,
+    )
+
+    surface = DefaultStillDecodeBackend(registry).decode(_request(source), _Token())
+
+    crashing_wic.decode.assert_not_called()
+    assert surface.backend == "qt"
+    assert surface.fallback is None
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [".png", ".webp", ".tif", ".heic", ".heif", ".jxr"],
+)
+def test_windows_non_jpeg_formats_keep_wic_fallback(suffix: str) -> None:
+    class _MarkerWic:
+        def decode(self, request, cancellation):
+            del request, cancellation
+            raise DecodeCancelledError("wic selected")
+
+    registry = StillDecodeBackendRegistry(
+        platform="win32",
+        windows_backend=_MarkerWic(),
+    )
+
+    with pytest.raises(DecodeCancelledError, match="wic selected"):
+        DefaultStillDecodeBackend(registry).decode(
+            _request(Path(f"photo{suffix}")),
             _Token(),
         )
 

--- a/tests/gui/test_startup_orchestrator.py
+++ b/tests/gui/test_startup_orchestrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -257,3 +258,24 @@ def test_canonical_milestone_is_emitted_once_per_generation(qapp, monkeypatch) -
     orchestrator.transition(StartupPhase.INTERACTIVE)
 
     assert events.count("startup.interactive") == 1
+
+
+def test_terminal_keeps_persistent_runtime_diagnostics_active(
+    qapp,
+    monkeypatch,
+) -> None:
+    cancel_dump = MagicMock()
+    monkeypatch.setattr(
+        "iPhoto.runtime_diagnostics.runtime_diagnostics_active",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "faulthandler.cancel_dump_traceback_later",
+        cancel_dump,
+    )
+    orchestrator = StartupOrchestrator()
+    orchestrator.begin()
+
+    orchestrator.complete()
+
+    cancel_dump.assert_not_called()

--- a/tests/gui/viewmodels/test_detail_viewmodel.py
+++ b/tests/gui/viewmodels/test_detail_viewmodel.py
@@ -6,8 +6,12 @@ from unittest.mock import Mock
 from iPhoto.application.dtos import AssetDTO
 from iPhoto.application.ports import EditRenderingState
 from iPhoto.gui.ui.media.media_restore_request import MediaRestoreRequest
-from iPhoto.gui.ui.media.media_selection_session import MediaSelectionSession
-from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
+from iPhoto.gui.ui.media.media_selection_session import (
+    MediaSelectionChangeReason,
+    MediaSelectionSession,
+    MediaSelectionSnapshot,
+    MediaSelectionState,
+)
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailViewModel
 from iPhoto.gui.viewmodels.signal import Signal
 
@@ -152,8 +156,11 @@ class _AsyncLazyCollection(_LazyCollection):
 class _AnchoredLazyCollection(_LazyCollection):
     def __init__(self) -> None:
         super().__init__()
+        self.row_loaded = Signal()
         self.anchor_path: Path | None = None
         self.anchor_status: str | None = None
+        self.pin_calls: list[tuple[Path, str, int | None]] = []
+        self.favorite_updates: list[tuple[int, bool]] = []
 
     def cached_row_for_path(self, path: Path) -> int | None:
         for row in self._loaded_rows:
@@ -171,9 +178,14 @@ class _AnchoredLazyCollection(_LazyCollection):
         asset_id: str = "",
         previous_row: int | None = None,
     ) -> None:
-        del asset_id, previous_row
+        self.pin_calls.append((path, asset_id, previous_row))
         self.anchor_path = path
         self.anchor_status = "resolved"
+
+    def update_favorite_status(self, row: int, value: bool) -> None:
+        self._dtos[row].is_favorite = value
+        self.favorite_updates.append((row, value))
+        self.row_changed.emit(row)
 
 
 def test_next_can_open_row_outside_current_store_window() -> None:
@@ -194,6 +206,28 @@ def test_next_can_open_row_outside_current_store_window() -> None:
     assert vm.current_row.value == 1
     assert vm.current_path.value == Path("/tmp/deep.jpg")
     assert vm.presentation.value.path == Path("/tmp/deep.jpg")
+
+
+def test_show_row_hot_path_pins_once_and_never_looks_up_path() -> None:
+    store = _AnchoredLazyCollection()
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    store.pin_calls.clear()
+    store.row_for_path = Mock(side_effect=AssertionError("hot path path lookup"))
+    vm = DetailViewModel(
+        collection_store=store,
+        media_session=session,
+        asset_state_service=Mock(),
+        adjustment_commit_port=None,
+        edit_service_getter=None,
+    )
+
+    vm.show_row(0)
+
+    dto = store.asset_at(0)
+    assert dto is not None
+    assert store.pin_calls == [(dto.abs_path, str(dto.id), 0)]
+    store.row_for_path.assert_not_called()
 
 
 def test_show_row_retries_after_async_placeholder_load() -> None:
@@ -220,6 +254,73 @@ def test_show_row_retries_after_async_placeholder_load() -> None:
     assert vm.current_row.value == 1
     assert vm.current_path.value == Path("/tmp/deep.jpg")
     assert requested == ["detail"]
+    assert vm.presentation.value.request_generation == 1
+
+
+def test_async_fallback_resolution_atomically_converges_detail_and_actions() -> None:
+    store = _AnchoredLazyCollection()
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    asset_state_service = Mock()
+    asset_state_service.toggle_favorite.return_value = True
+    vm = DetailViewModel(
+        collection_store=store,
+        media_session=session,
+        asset_state_service=asset_state_service,
+        adjustment_commit_port=None,
+        edit_service_getter=None,
+    )
+    edits: list[Path] = []
+    rotations: list[tuple[Path, bool]] = []
+    vm.edit_requested.connect(edits.append)
+    vm.rotate_requested.connect(lambda path, is_video: rotations.append((path, is_video)))
+
+    vm.show_row(1)
+    original = vm.presentation.value
+    assert original.path == Path("/tmp/deep.jpg")
+
+    replacement = _make_dto("/tmp/replacement.jpg")
+    store._dtos = [_make_dto("/tmp/visible.jpg"), replacement]
+    store._loaded_rows = {0}
+    store.anchor_status = "missing"
+    store.data_changed.emit()
+
+    assert session.selection_state() is MediaSelectionState.FALLBACK_PENDING
+    assert vm.selection_state.value is MediaSelectionState.FALLBACK_PENDING
+    assert vm.current_row.value == -1
+    assert vm.current_path.value == original.path
+    assert vm.presentation.value.path == original.path
+    assert vm.presentation.value.request_generation == original.request_generation
+
+    vm.toggle_favorite()
+    vm.request_edit()
+    vm.rotate_current()
+    assert vm.current_asset_path() is None
+    asset_state_service.toggle_favorite.assert_not_called()
+    assert edits == []
+    assert rotations == []
+
+    store._loaded_rows.add(1)
+    store.row_loaded.emit(1)
+
+    snapshot = session.selection_snapshot()
+    assert snapshot.state is MediaSelectionState.RESOLVED
+    assert snapshot.row == 1
+    assert snapshot.path == replacement.abs_path
+    assert snapshot.asset_id == str(replacement.id)
+    assert vm.current_row.value == 1
+    assert vm.current_path.value == replacement.abs_path
+    assert vm.presentation.value.path == replacement.abs_path
+    assert vm.presentation.value.request_generation == original.request_generation + 1
+
+    vm.toggle_favorite()
+    vm.request_edit()
+    vm.rotate_current()
+    assert vm.current_asset_path() == replacement.abs_path
+    asset_state_service.toggle_favorite.assert_called_once_with(replacement.abs_path)
+    assert store.favorite_updates == [(1, True)]
+    assert edits == [replacement.abs_path]
+    assert rotations == [(replacement.abs_path, False)]
 
 
 def test_pending_selection_anchor_keeps_existing_detail_presentation() -> None:
@@ -536,12 +637,19 @@ def test_scan_row_relocation_keeps_render_generation() -> None:
     relocated.metadata["source_mtime_ns"] = 100
     store.asset_at.side_effect = [first, relocated]
     session.set_current_row.return_value = first.abs_path
-    session.current_row.return_value = 7
-    session.current_source.return_value = first.abs_path
 
     vm.show_row(0)
     initial = vm.presentation.value
-    vm._handle_store_changed()
+    vm._handle_selection_changed(
+        MediaSelectionSnapshot(
+            version=2,
+            state=MediaSelectionState.RESOLVED,
+            row=7,
+            path=relocated.abs_path,
+            asset_id=str(relocated.id),
+        ),
+        MediaSelectionChangeReason.ANCHOR_RESOLVED,
+    )
     refreshed = vm.presentation.value
 
     assert initial.render_key == refreshed.render_key

--- a/tests/gui/viewmodels/test_detail_viewmodel.py
+++ b/tests/gui/viewmodels/test_detail_viewmodel.py
@@ -12,7 +12,7 @@ from iPhoto.gui.ui.media.media_selection_session import (
     MediaSelectionSnapshot,
     MediaSelectionState,
 )
-from iPhoto.gui.viewmodels.detail_viewmodel import DetailViewModel
+from iPhoto.gui.viewmodels.detail_viewmodel import DetailPresentation, DetailViewModel
 from iPhoto.gui.viewmodels.signal import Signal
 
 _UNSET = object()
@@ -363,6 +363,40 @@ def test_pending_selection_anchor_keeps_existing_detail_presentation() -> None:
     assert vm.selection_state.value is MediaSelectionState.RESOLVED
     assert vm.presentation.value.request_generation == original.request_generation
     assert vm.presentation.value.render_key == original.render_key
+
+
+def test_pending_still_can_restart_render_from_stable_identity() -> None:
+    store = _AnchoredLazyCollection()
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    vm = DetailViewModel(
+        collection_store=store,
+        media_session=session,
+        asset_state_service=Mock(),
+        adjustment_commit_port=None,
+        edit_service_getter=None,
+    )
+    changes: list[DetailPresentation] = []
+    vm.presentation_changed.connect(changes.append)
+    vm.show_row(0)
+    original = vm.presentation.value
+    assert original is not None
+
+    store.anchor_status = "retry"
+    store.data_changed.emit()
+    pending = vm.presentation.value
+    assert pending is not None
+    assert pending.row == -1
+
+    assert vm.recover_current_presentation() is True
+
+    recovered = vm.presentation.value
+    assert recovered.path == original.path
+    assert recovered.asset_id == original.asset_id
+    assert recovered.row == -1
+    assert recovered.render_key == original.render_key
+    assert recovered.request_generation == original.request_generation + 1
+    assert changes[-1] == recovered
 
 
 def test_retry_favorite_never_targets_the_asset_at_the_stale_row() -> None:

--- a/tests/gui/viewmodels/test_detail_viewmodel.py
+++ b/tests/gui/viewmodels/test_detail_viewmodel.py
@@ -148,6 +148,33 @@ class _AsyncLazyCollection(_LazyCollection):
         self.row_loaded.emit(row)
 
 
+class _AnchoredLazyCollection(_LazyCollection):
+    def __init__(self) -> None:
+        super().__init__()
+        self.anchor_path: Path | None = None
+        self.anchor_status: str | None = None
+
+    def cached_row_for_path(self, path: Path) -> int | None:
+        for row in self._loaded_rows:
+            if self._dtos[row].abs_path == path:
+                return row
+        return None
+
+    def selection_anchor_status(self, path: Path) -> str | None:
+        return self.anchor_status if path == self.anchor_path else None
+
+    def pin_path(
+        self,
+        path: Path,
+        *,
+        asset_id: str = "",
+        previous_row: int | None = None,
+    ) -> None:
+        del asset_id, previous_row
+        self.anchor_path = path
+        self.anchor_status = "resolved"
+
+
 def test_next_can_open_row_outside_current_store_window() -> None:
     store = _LazyCollection()
     session = MediaSelectionSession()
@@ -192,6 +219,39 @@ def test_show_row_retries_after_async_placeholder_load() -> None:
     assert vm.current_row.value == 1
     assert vm.current_path.value == Path("/tmp/deep.jpg")
     assert requested == ["detail"]
+
+
+def test_pending_selection_anchor_keeps_existing_detail_presentation() -> None:
+    store = _AnchoredLazyCollection()
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    vm = DetailViewModel(
+        collection_store=store,
+        media_session=session,
+        asset_state_service=Mock(),
+        adjustment_commit_port=None,
+        edit_service_getter=None,
+    )
+    changes = []
+    vm.presentation_changed.connect(changes.append)
+    vm.show_row(0)
+    original = vm.presentation.value
+    assert original is not None
+
+    store.anchor_status = "retry"
+    store.data_changed.emit()
+
+    assert session.current_row() == -1
+    assert session.current_source() == Path("/tmp/visible.jpg")
+    assert vm.presentation.value is original
+    assert changes == [original]
+
+    store.anchor_status = "resolved"
+    store.data_changed.emit()
+
+    assert session.current_row() == 0
+    assert vm.presentation.value.request_generation == original.request_generation
+    assert vm.presentation.value.render_key == original.render_key
 
 
 def test_toggle_favorite_updates_store_and_presentation():

--- a/tests/gui/viewmodels/test_detail_viewmodel.py
+++ b/tests/gui/viewmodels/test_detail_viewmodel.py
@@ -7,6 +7,7 @@ from iPhoto.application.dtos import AssetDTO
 from iPhoto.application.ports import EditRenderingState
 from iPhoto.gui.ui.media.media_restore_request import MediaRestoreRequest
 from iPhoto.gui.ui.media.media_selection_session import MediaSelectionSession
+from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailViewModel
 from iPhoto.gui.viewmodels.signal import Signal
 
@@ -243,15 +244,61 @@ def test_pending_selection_anchor_keeps_existing_detail_presentation() -> None:
 
     assert session.current_row() == -1
     assert session.current_source() == Path("/tmp/visible.jpg")
-    assert vm.presentation.value is original
-    assert changes == [original]
+    assert vm.current_row.value == -1
+    assert vm.selection_state.value is MediaSelectionState.ANCHOR_RESOLVING
+    pending = vm.presentation.value
+    assert pending is not original
+    assert pending.path == original.path
+    assert pending.row == -1
+    assert pending.can_toggle_favorite is False
+    assert pending.render_key == original.render_key
+    assert changes == [original, pending]
 
     store.anchor_status = "resolved"
     store.data_changed.emit()
 
     assert session.current_row() == 0
+    assert vm.current_row.value == 0
+    assert vm.selection_state.value is MediaSelectionState.RESOLVED
     assert vm.presentation.value.request_generation == original.request_generation
     assert vm.presentation.value.render_key == original.render_key
+
+
+def test_retry_favorite_never_targets_the_asset_at_the_stale_row() -> None:
+    store = _AnchoredLazyCollection()
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    asset_state_service = Mock()
+    vm = DetailViewModel(
+        collection_store=store,
+        media_session=session,
+        asset_state_service=asset_state_service,
+        adjustment_commit_port=None,
+        edit_service_getter=None,
+    )
+    vm.show_row(0)
+    visible = vm.presentation.value
+    assert visible is not None
+
+    wrong = _make_dto("/tmp/wrong.jpg")
+    store._dtos = [wrong, store._dtos[0]]
+    store._loaded_rows = {0, 1}
+    store.anchor_status = "retry"
+    store.data_changed.emit()
+
+    assert store.asset_at(0).abs_path == wrong.abs_path
+    assert vm.presentation.value.path == visible.path
+    assert vm.current_row.value == -1
+    vm.toggle_favorite()
+
+    asset_state_service.toggle_favorite.assert_not_called()
+
+    store.anchor_status = "resolved"
+    store.data_changed.emit()
+
+    assert vm.current_row.value == 1
+    assert vm.presentation.value.path == visible.path
+    assert vm.presentation.value.can_toggle_favorite is True
 
 
 def test_toggle_favorite_updates_store_and_presentation():

--- a/tests/gui/viewmodels/test_detail_viewmodel.py
+++ b/tests/gui/viewmodels/test_detail_viewmodel.py
@@ -419,3 +419,45 @@ def test_store_row_change_refreshes_current_presentation():
     vm._handle_row_changed(0)
 
     assert vm.presentation.value.is_favorite is True
+
+
+def test_scan_row_relocation_keeps_render_generation() -> None:
+    vm, store, session, _ = _make_vm()
+    first = _make_dto("/tmp/photo.jpg", is_favorite=False)
+    relocated = _make_dto("/tmp/photo.jpg", is_favorite=True)
+    first.metadata["source_mtime_ns"] = 100
+    relocated.metadata["source_mtime_ns"] = 100
+    store.asset_at.side_effect = [first, relocated]
+    session.set_current_row.return_value = first.abs_path
+    session.current_row.return_value = 7
+    session.current_source.return_value = first.abs_path
+
+    vm.show_row(0)
+    initial = vm.presentation.value
+    vm._handle_store_changed()
+    refreshed = vm.presentation.value
+
+    assert initial.render_key == refreshed.render_key
+    assert refreshed.row == 7
+    assert refreshed.is_favorite is True
+    assert refreshed.request_generation == initial.request_generation
+
+
+def test_source_revision_refresh_allocates_new_render_generation() -> None:
+    vm, store, session, _ = _make_vm()
+    first = _make_dto("/tmp/photo.jpg")
+    revised = _make_dto("/tmp/photo.jpg")
+    first.metadata["source_mtime_ns"] = 100
+    revised.metadata["source_mtime_ns"] = 200
+    store.asset_at.side_effect = [first, revised]
+    session.set_current_row.return_value = first.abs_path
+    session.current_row.return_value = 0
+    session.current_source.return_value = first.abs_path
+
+    vm.show_row(0)
+    initial = vm.presentation.value
+    vm._handle_store_changed()
+    refreshed = vm.presentation.value
+
+    assert initial.render_key != refreshed.render_key
+    assert refreshed.request_generation == initial.request_generation + 1

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -15,7 +15,7 @@ from iPhoto.config import RECENTLY_DELETED_DIR_NAME
 from iPhoto.domain.models import Asset, MediaType
 from iPhoto.domain.models.query import AssetQuery, WindowResult
 from iPhoto.gui.gallery_demand import MICRO_QUERY_CHUNK, MICRO_WARM_LIMIT, build_viewport_demand
-from iPhoto.gui.ui.media import MediaSelectionSession
+from iPhoto.gui.ui.media import MediaSelectionSession, MediaSelectionState
 from iPhoto.gui.viewmodels.asset_dto_converter import scan_row_to_dto
 from iPhoto.gui.viewmodels.gallery_collection_store import GalleryCollectionStore
 from iPhoto.gui.viewmodels.gallery_window_loader import (
@@ -1234,6 +1234,123 @@ def test_scan_revisions_atomically_relocate_anchor_across_1000_assets() -> None:
         assert store.selection_anchor_status(current.abs_path) == "resolved"
 
     assert service.row_lookup_calls == []
+
+
+def test_same_query_reload_preserves_deep_anchor_when_db_revision_is_unchanged() -> None:
+    root = Path("/library")
+    service = _FakeQueryService([], library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store = GalleryCollectionStore(service, library_root=root)
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    initial_request = requests[-1]
+    first = scan_row_to_dto(
+        root,
+        "first.jpg",
+        {"id": "first", "rel": "first.jpg", "media_type": 0},
+    )
+    current = scan_row_to_dto(
+        root,
+        "current.jpg",
+        {"id": "current", "rel": "current.jpg", "media_type": 0},
+    )
+    assert first is not None and current is not None
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=initial_request.generation,
+            first=0,
+            last=79,
+            rows={0: first, 700: current},
+            total_count=1_000,
+            collection_revision=42,
+            requested_revision=initial_request.collection_revision,
+        )
+    )
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    assert session.set_current_row(700) == current.abs_path
+    selected_anchor = store._selection_anchor
+    assert selected_anchor is not None
+    requests.clear()
+
+    store.reload_current_selection()
+
+    assert len(requests) == 1
+    reload_request = requests[0]
+    assert reload_request.selection_anchor is not None
+    assert reload_request.selection_anchor.path == current.abs_path
+    assert reload_request.selection_anchor.previous_row == 700
+    assert (
+        reload_request.selection_anchor.selection_version
+        > selected_anchor.selection_version
+    )
+    assert session.selection_state() is MediaSelectionState.ANCHOR_RESOLVING
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=reload_request.generation,
+            first=0,
+            last=79,
+            rows={0: first},
+            total_count=1_000,
+            # The database did not change; only the Store reset generation did.
+            collection_revision=42,
+            requested_revision=reload_request.collection_revision,
+            selection_anchor_result=GallerySelectionAnchorResult(
+                anchor=reload_request.selection_anchor,
+                status="resolved",
+                row=700,
+                dto=current,
+            ),
+        )
+    )
+    assert session.current_row() == 700
+    assert session.current_source() == current.abs_path
+    assert store.selection_anchor_status(current.abs_path) == "resolved"
+
+
+def test_query_service_rebind_preserves_anchor_only_within_same_library() -> None:
+    root = Path("/library")
+    first_service = _FakeQueryService([], library_root=root)
+    second_service = _FakeQueryService([], library_root=root)
+    store = GalleryCollectionStore(first_service, library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    current = scan_row_to_dto(
+        root,
+        "current.jpg",
+        {"id": "current", "rel": "current.jpg", "media_type": 0},
+    )
+    assert current is not None
+    store._total_count = 1_000
+    store._row_cache[700] = current
+    store.pin_path(current.abs_path, asset_id=str(current.id), previous_row=700)
+    previous_anchor = store._selection_anchor
+    assert previous_anchor is not None
+
+    store.rebind_asset_query_service(second_service, Path("/library/../library"))
+
+    preserved_anchor = store._selection_anchor
+    assert preserved_anchor is not None
+    assert preserved_anchor.path == current.abs_path
+    assert preserved_anchor.selection_version > previous_anchor.selection_version
+    assert store.selection_anchor_status(current.abs_path) == "pending"
+    requests.clear()
+    store.reload_current_selection()
+    assert requests[-1].selection_anchor == store._selection_anchor
+
+    store.load_selection(root, query=AssetQuery(is_favorite=True))
+
+    assert store._selection_anchor is None
+    assert store.selection_anchor_status(current.abs_path) is None
+
+    store._total_count = 1_000
+    store._row_cache[700] = current
+    store.pin_path(current.abs_path, asset_id=str(current.id), previous_row=700)
+    store.rebind_asset_query_service(second_service, Path("/other-library"))
+
+    assert store._selection_anchor is None
+    assert store.selection_anchor_status(current.abs_path) is None
 
 
 def test_anchor_retry_preserves_source_until_resolved_then_missing_falls_back() -> None:

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -1481,6 +1481,9 @@ def test_anchor_retry_is_bounded_and_needs_no_new_scan_revision(
     store._collection_revision = 20
     store._row_cache[10] = current
     store.pin_path(current.abs_path, asset_id=str(current.id), previous_row=10)
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    assert session.set_current_row(10) == current.abs_path
     requests.clear()
 
     tickets: list[GallerySelectionAnchorRetryTicket | None] = []
@@ -1542,10 +1545,84 @@ def test_anchor_retry_is_bounded_and_needs_no_new_scan_revision(
     assert [ticket.attempt for ticket in tickets if ticket is not None] == [1, 2, 3]
     assert store._selection_anchor_retry_ticket is None
     assert store._selection_anchor_retry_inflight is None
+    assert store.selection_anchor_status(current.abs_path) == "resolved"
+    assert session.selection_state() is MediaSelectionState.RESOLVED
+    assert session.current_source() == current.abs_path
     exhausted = [item for item in events if item[0] == "selection_anchor_retry_exhausted"]
     assert len(exhausted) == 1
     assert exhausted[0][1]["collection_revision"] == 20
+    assert exhausted[0][1]["resolved_from_cache"] is True
     assert "path" not in exhausted[0][1]
+
+
+def test_anchor_retry_exhaustion_publishes_terminal_unresolved_state(
+    monkeypatch,
+) -> None:
+    root = Path("/library")
+    service = _FakeQueryService([], library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store = GalleryCollectionStore(service, library_root=root)
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    current = scan_row_to_dto(
+        root,
+        "current.jpg",
+        {"id": "current", "rel": "current.jpg", "media_type": 0},
+    )
+    assert current is not None
+    store._total_count = 30
+    store._collection_revision = 20
+    store._row_cache[10] = current
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    assert session.set_current_row(10) == current.abs_path
+    store._row_cache.clear()
+    requests.clear()
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "iPhoto.gui.viewmodels.gallery_collection_store.emit_detail_event",
+        lambda name, **payload: events.append((name, payload)),
+    )
+
+    store._request_async_chunk(0, 0, demand_generation=0, priority=0)
+    request = requests[-1]
+    for attempt in range(4):
+        assert request.selection_anchor is not None
+        assert store.apply_window_result(
+            GalleryWindowResult(
+                generation=request.generation,
+                first=request.view_first,
+                last=request.view_first,
+                rows={},
+                total_count=30,
+                collection_revision=20,
+                requested_revision=request.collection_revision,
+                selection_anchor_result=GallerySelectionAnchorResult(
+                    anchor=request.selection_anchor,
+                    status="retry",
+                ),
+                purpose=request.purpose,
+                selection_anchor_retry_attempt=(
+                    request.selection_anchor_retry_attempt
+                ),
+            )
+        )
+        if attempt == 3:
+            break
+        ticket = store._selection_anchor_retry_ticket
+        assert isinstance(ticket, GallerySelectionAnchorRetryTicket)
+        assert store.retry_selection_anchor(ticket)
+        request = requests[-1]
+
+    assert store.selection_anchor_status(current.abs_path) == "unresolved"
+    assert store._selection_anchor_retry_ticket is None
+    assert store._selection_anchor_retry_inflight is None
+    assert session.selection_state() is MediaSelectionState.ANCHOR_UNRESOLVED
+    assert session.current_source() == current.abs_path
+    assert session.next_row() == 11
+    exhausted = [item for item in events if item[0] == "selection_anchor_retry_exhausted"]
+    assert len(exhausted) == 1
+    assert exhausted[0][1]["resolved_from_cache"] is False
 
 
 def test_new_selection_cancels_stale_anchor_retry_ticket() -> None:

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -21,6 +21,7 @@ from iPhoto.gui.viewmodels.gallery_collection_store import GalleryCollectionStor
 from iPhoto.gui.viewmodels.gallery_window_loader import (
     GallerySelectionAnchor,
     GallerySelectionAnchorResult,
+    GallerySelectionAnchorRetryTicket,
     GalleryWindowLoader,
     GalleryWindowRequest,
     GalleryWindowResult,
@@ -1260,6 +1261,8 @@ def test_anchor_retry_preserves_source_until_resolved_then_missing_falls_back() 
     session.bind_collection(store)
     session.set_current_row(10)
     requests.clear()
+    retry_tickets: list[GallerySelectionAnchorRetryTicket | None] = []
+    store.selection_anchor_retry_requested.connect(retry_tickets.append)
 
     store._request_async_chunk(0, 19, demand_generation=0, priority=0)
     retry_request = requests[-1]
@@ -1282,10 +1285,20 @@ def test_anchor_retry_preserves_source_until_resolved_then_missing_falls_back() 
     )
     assert session.current_row() == -1
     assert session.current_source() == current.abs_path
+    assert retry_tickets[-1] is not None
+    retry_ticket = retry_tickets[-1]
+    assert retry_ticket.attempt == 1
+    assert retry_ticket.delay_ms == 100
 
-    store._request_async_chunk(0, 19, demand_generation=0, priority=0)
+    assert store.retry_selection_anchor(retry_ticket)
     resolved_request = requests[-1]
     assert resolved_request.selection_anchor is not None
+    assert resolved_request.view_first == 10
+    assert resolved_request.limit == 1
+    assert resolved_request.request_backfill is False
+    assert resolved_request.demand_generation == 0
+    assert resolved_request.purpose == "selection_anchor_retry"
+    assert resolved_request.selection_anchor_retry_attempt == 1
     assert store.apply_window_result(
         GalleryWindowResult(
             generation=resolved_request.generation,
@@ -1293,13 +1306,17 @@ def test_anchor_retry_preserves_source_until_resolved_then_missing_falls_back() 
             last=0,
             rows={0: fallback},
             total_count=30,
-            collection_revision=22,
+            collection_revision=21,
             requested_revision=resolved_request.collection_revision,
             selection_anchor_result=GallerySelectionAnchorResult(
                 anchor=resolved_request.selection_anchor,
                 status="resolved",
                 row=11,
                 dto=current,
+            ),
+            purpose=resolved_request.purpose,
+            selection_anchor_retry_attempt=(
+                resolved_request.selection_anchor_retry_attempt
             ),
         )
     )
@@ -1326,6 +1343,146 @@ def test_anchor_retry_preserves_source_until_resolved_then_missing_falls_back() 
     )
     assert session.current_row() == 11
     assert session.current_source() == fallback.abs_path
+
+
+def test_anchor_retry_is_bounded_and_needs_no_new_scan_revision(
+    monkeypatch,
+) -> None:
+    root = Path("/library")
+    service = _FakeQueryService([], library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store = GalleryCollectionStore(service, library_root=root)
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    current = scan_row_to_dto(
+        root,
+        "current.jpg",
+        {"id": "current", "rel": "current.jpg", "media_type": 0},
+    )
+    assert current is not None
+    store._total_count = 30
+    store._collection_revision = 20
+    store._row_cache[10] = current
+    store.pin_path(current.abs_path, asset_id=str(current.id), previous_row=10)
+    requests.clear()
+
+    tickets: list[GallerySelectionAnchorRetryTicket | None] = []
+    events: list[tuple[str, dict]] = []
+    store.selection_anchor_retry_requested.connect(tickets.append)
+    monkeypatch.setattr(
+        "iPhoto.gui.viewmodels.gallery_collection_store.emit_detail_event",
+        lambda name, **payload: events.append((name, payload)),
+    )
+
+    store._request_async_chunk(0, 0, demand_generation=0, priority=0)
+    initial = requests[-1]
+    assert initial.selection_anchor is not None
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=initial.generation,
+            first=0,
+            last=0,
+            rows={},
+            total_count=30,
+            collection_revision=20,
+            requested_revision=initial.collection_revision,
+            selection_anchor_result=GallerySelectionAnchorResult(
+                anchor=initial.selection_anchor,
+                status="retry",
+            ),
+        )
+    )
+
+    for attempt, delay_ms in enumerate((100, 250, 500), start=1):
+        ticket = tickets[-1]
+        assert isinstance(ticket, GallerySelectionAnchorRetryTicket)
+        assert (ticket.attempt, ticket.delay_ms) == (attempt, delay_ms)
+        assert store.retry_selection_anchor(ticket)
+        request = requests[-1]
+        assert request.purpose == "selection_anchor_retry"
+        assert request.selection_anchor_retry_attempt == attempt
+        assert request.selection_anchor is not None
+        assert store.apply_window_result(
+            GalleryWindowResult(
+                generation=request.generation,
+                first=request.view_first,
+                last=request.view_first,
+                rows={},
+                total_count=30,
+                collection_revision=20,
+                requested_revision=request.collection_revision,
+                selection_anchor_result=GallerySelectionAnchorResult(
+                    anchor=request.selection_anchor,
+                    status="retry",
+                ),
+                purpose=request.purpose,
+                selection_anchor_retry_attempt=(
+                    request.selection_anchor_retry_attempt
+                ),
+            )
+        )
+
+    assert [ticket.attempt for ticket in tickets if ticket is not None] == [1, 2, 3]
+    assert store._selection_anchor_retry_ticket is None
+    assert store._selection_anchor_retry_inflight is None
+    exhausted = [item for item in events if item[0] == "selection_anchor_retry_exhausted"]
+    assert len(exhausted) == 1
+    assert exhausted[0][1]["collection_revision"] == 20
+    assert "path" not in exhausted[0][1]
+
+
+def test_new_selection_cancels_stale_anchor_retry_ticket() -> None:
+    root = Path("/library")
+    service = _FakeQueryService([], library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store = GalleryCollectionStore(service, library_root=root)
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    first = scan_row_to_dto(
+        root,
+        "first.jpg",
+        {"id": "first", "rel": "first.jpg", "media_type": 0},
+    )
+    second = scan_row_to_dto(
+        root,
+        "second.jpg",
+        {"id": "second", "rel": "second.jpg", "media_type": 0},
+    )
+    assert first is not None and second is not None
+    store._total_count = 2
+    store._collection_revision = 7
+    store._row_cache.update({0: first, 1: second})
+    store.pin_path(first.abs_path, asset_id=str(first.id), previous_row=0)
+    requests.clear()
+    emitted: list[GallerySelectionAnchorRetryTicket | None] = []
+    store.selection_anchor_retry_requested.connect(emitted.append)
+
+    store._request_async_chunk(0, 0, demand_generation=0, priority=0)
+    request = requests[-1]
+    assert request.selection_anchor is not None
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=request.generation,
+            first=0,
+            last=0,
+            rows={0: first},
+            total_count=2,
+            collection_revision=7,
+            requested_revision=request.collection_revision,
+            selection_anchor_result=GallerySelectionAnchorResult(
+                anchor=request.selection_anchor,
+                status="retry",
+            ),
+        )
+    )
+    stale_ticket = emitted[-1]
+    assert isinstance(stale_ticket, GallerySelectionAnchorRetryTicket)
+
+    store.pin_path(second.abs_path, asset_id=str(second.id), previous_row=1)
+
+    assert emitted[-1] is None
+    assert store.retry_selection_anchor(stale_ticket) is False
+    assert store.selection_anchor_status(second.abs_path) == "resolved"
 
 
 def test_row_for_path_uses_query_lookup_without_scanning_batches() -> None:

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -1,20 +1,26 @@
 from __future__ import annotations
 
+import threading
+import time
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
 
-from PySide6.QtGui import QImage
 from PIL import Image
+from PySide6.QtCore import QTimer
+from PySide6.QtGui import QImage
 
 from iPhoto.config import RECENTLY_DELETED_DIR_NAME
 from iPhoto.domain.models import Asset, MediaType
 from iPhoto.domain.models.query import AssetQuery, WindowResult
 from iPhoto.gui.gallery_demand import MICRO_QUERY_CHUNK, MICRO_WARM_LIMIT, build_viewport_demand
+from iPhoto.gui.ui.media import MediaSelectionSession
 from iPhoto.gui.viewmodels.asset_dto_converter import scan_row_to_dto
 from iPhoto.gui.viewmodels.gallery_collection_store import GalleryCollectionStore
 from iPhoto.gui.viewmodels.gallery_window_loader import (
+    GallerySelectionAnchor,
+    GallerySelectionAnchorResult,
     GalleryWindowLoader,
     GalleryWindowRequest,
     GalleryWindowResult,
@@ -1074,6 +1080,234 @@ def test_async_window_fetches_replacement_rows_for_pending_sources(qapp) -> None
     assert results[0].last == 2
     assert results[0].total_count == 3
     assert [dto.id for dto in results[0].rows.values()] == ["0", "2", "3"]
+
+
+def test_window_loader_resolves_blocked_anchor_off_gui_thread(tmp_path: Path, qapp) -> None:
+    current = tmp_path / "current.jpg"
+    entered = threading.Event()
+    release = threading.Event()
+    worker_threads: list[int] = []
+
+    class _BlockingAnchorService:
+        def read_gallery_asset_window(
+            self,
+            root: Path,
+            query: AssetQuery,
+            first: int,
+            limit: int,
+        ) -> WindowResult:
+            del root, query, limit
+            rel = "current.jpg" if first == 700 else "visible.jpg"
+            asset_id = "current" if first == 700 else "visible"
+            return WindowResult(
+                first=first,
+                rows=[{"id": asset_id, "rel": rel, "media_type": 0}],
+                total_count=1_000,
+                collection_revision=9,
+            )
+
+        def find_row_by_path(self, query: AssetQuery, path: Path) -> int:
+            del query
+            assert path == current
+            worker_threads.append(threading.get_ident())
+            entered.set()
+            assert release.wait(2.0)
+            return 700
+
+    loader = GalleryWindowLoader()
+    results: list[GalleryWindowResult] = []
+    loader.resultReady.connect(results.append)
+    loader.request(
+        GalleryWindowRequest(
+            generation=1,
+            root=tmp_path,
+            query=AssetQuery(),
+            query_service=_BlockingAnchorService(),
+            view_first=0,
+            raw_first=0,
+            limit=1,
+            request_backfill=False,
+            selection_anchor=GallerySelectionAnchor(current, "current", 700),
+        )
+    )
+
+    deadline = time.monotonic() + 2.0
+    while not entered.is_set() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    assert entered.is_set()
+    assert worker_threads == [worker_threads[0]]
+    assert worker_threads[0] != threading.get_ident()
+
+    heartbeat: list[bool] = []
+    QTimer.singleShot(0, lambda: heartbeat.append(True))
+    qapp.processEvents()
+    assert heartbeat == [True]
+
+    release.set()
+    deadline = time.monotonic() + 2.0
+    while not results and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.005)
+    loader.shutdown()
+
+    assert results
+    anchor_result = results[0].selection_anchor_result
+    assert anchor_result is not None
+    assert anchor_result.status == "resolved"
+    assert anchor_result.row == 700
+    assert anchor_result.dto is not None
+    assert anchor_result.dto.abs_path == current
+
+
+def test_scan_revisions_atomically_relocate_anchor_across_1000_assets() -> None:
+    root = Path("/library")
+    service = _FakeQueryService([], library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store = GalleryCollectionStore(service, library_root=root)
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    current = scan_row_to_dto(
+        root,
+        "current.jpg",
+        {"id": "current", "rel": "current.jpg", "media_type": 0},
+    )
+    first = scan_row_to_dto(
+        root,
+        "first.jpg",
+        {"id": "first", "rel": "first.jpg", "media_type": 0},
+    )
+    assert current is not None and first is not None
+    store._total_count = 500
+    store._collection_revision = 10
+    store._row_cache[0] = first
+    store._row_cache[300] = current
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    session.set_current_row(300)
+    requests.clear()
+
+    for revision, total_count, resolved_row in ((11, 500, 301), (12, 1_000, 302)):
+        store._request_async_chunk(0, 79, demand_generation=0, priority=0)
+        request = requests[-1]
+        assert request.selection_anchor is not None
+        assert store.apply_window_result(
+            GalleryWindowResult(
+                generation=request.generation,
+                first=0,
+                last=0,
+                rows={0: first},
+                total_count=total_count,
+                collection_revision=revision,
+                requested_revision=request.collection_revision,
+                selection_anchor_result=GallerySelectionAnchorResult(
+                    anchor=request.selection_anchor,
+                    status="resolved",
+                    row=resolved_row,
+                    dto=current,
+                    elapsed_ms=1.25,
+                ),
+            )
+        )
+        assert session.current_row() == resolved_row
+        assert session.current_source() == current.abs_path
+        assert store.cached_row_for_path(current.abs_path) == resolved_row
+        assert store.selection_anchor_status(current.abs_path) == "resolved"
+
+    assert service.row_lookup_calls == []
+
+
+def test_anchor_retry_preserves_source_until_resolved_then_missing_falls_back() -> None:
+    root = Path("/library")
+    service = _FakeQueryService([], library_root=root)
+    requests: list[GalleryWindowRequest] = []
+    store = GalleryCollectionStore(service, library_root=root)
+    store.set_window_request_handler(requests.append)
+    store.load_selection(root, query=AssetQuery())
+    current = scan_row_to_dto(
+        root,
+        "current.jpg",
+        {"id": "current", "rel": "current.jpg", "media_type": 0},
+    )
+    fallback = scan_row_to_dto(
+        root,
+        "fallback.jpg",
+        {"id": "fallback", "rel": "fallback.jpg", "media_type": 0},
+    )
+    assert current is not None and fallback is not None
+    store._total_count = 30
+    store._collection_revision = 20
+    store._row_cache[10] = current
+    session = MediaSelectionSession()
+    session.bind_collection(store)
+    session.set_current_row(10)
+    requests.clear()
+
+    store._request_async_chunk(0, 19, demand_generation=0, priority=0)
+    retry_request = requests[-1]
+    assert retry_request.selection_anchor is not None
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=retry_request.generation,
+            first=0,
+            last=0,
+            rows={0: fallback},
+            total_count=30,
+            collection_revision=21,
+            requested_revision=retry_request.collection_revision,
+            selection_anchor_result=GallerySelectionAnchorResult(
+                anchor=retry_request.selection_anchor,
+                status="retry",
+                elapsed_ms=10_000.0,
+            ),
+        )
+    )
+    assert session.current_row() == -1
+    assert session.current_source() == current.abs_path
+
+    store._request_async_chunk(0, 19, demand_generation=0, priority=0)
+    resolved_request = requests[-1]
+    assert resolved_request.selection_anchor is not None
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=resolved_request.generation,
+            first=0,
+            last=0,
+            rows={0: fallback},
+            total_count=30,
+            collection_revision=22,
+            requested_revision=resolved_request.collection_revision,
+            selection_anchor_result=GallerySelectionAnchorResult(
+                anchor=resolved_request.selection_anchor,
+                status="resolved",
+                row=11,
+                dto=current,
+            ),
+        )
+    )
+    assert session.current_row() == 11
+    assert session.current_source() == current.abs_path
+
+    store._request_async_chunk(0, 19, demand_generation=0, priority=0)
+    missing_request = requests[-1]
+    assert missing_request.selection_anchor is not None
+    assert store.apply_window_result(
+        GalleryWindowResult(
+            generation=missing_request.generation,
+            first=11,
+            last=11,
+            rows={11: fallback},
+            total_count=30,
+            collection_revision=23,
+            requested_revision=missing_request.collection_revision,
+            selection_anchor_result=GallerySelectionAnchorResult(
+                anchor=missing_request.selection_anchor,
+                status="missing",
+            ),
+        )
+    )
+    assert session.current_row() == 11
+    assert session.current_source() == fallback.abs_path
 
 
 def test_row_for_path_uses_query_lookup_without_scanning_batches() -> None:

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -217,6 +217,24 @@ def test_scan_row_to_dto_ignores_invalid_micro_thumbnail_bytes() -> None:
     assert dto.micro_thumbnail is None
 
 
+def test_diagnostic_snapshot_contains_only_in_memory_collection_state() -> None:
+    store = GalleryCollectionStore(
+        _FakeQueryService([]),
+        library_root=Path("/private/photos"),
+    )
+    store._total_count = 25
+    store._collection_revision = 9
+    store._pending_scan_rels.update({"secret/a.jpg", "secret/b.jpg"})
+
+    snapshot = store.diagnostic_snapshot()
+
+    assert snapshot["row_count"] == 25
+    assert snapshot["collection_revision"] == 9
+    assert snapshot["pending_scan_rows"] == 2
+    assert "private" not in str(snapshot)
+    assert "secret" not in str(snapshot)
+
+
 def test_load_initial_window_uses_sparse_cache() -> None:
     assets = [
         Asset(

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -22,6 +22,10 @@ from iPhoto.gui.viewmodels.gallery_thumbnail_hint_loader import (
     GalleryThumbnailHintResult,
 )
 from iPhoto.gui.viewmodels.gallery_tile import GalleryTileSnapshot
+from iPhoto.gui.viewmodels.gallery_window_loader import (
+    GallerySelectionAnchor,
+    GallerySelectionAnchorRetryTicket,
+)
 from iPhoto.infrastructure.services.thumbnail_cache_service import (
     ThumbnailCacheService,
     ThumbnailLoadResult,
@@ -154,6 +158,50 @@ def test_detail_prefetch_descriptor_carries_indexed_source_identity(
 
 def test_adapter_init(adapter):
     assert adapter.rowCount() == 0
+
+
+def test_adapter_schedules_and_cancels_anchor_retry_on_gui_timer(
+    mock_thumb_service,
+    qapp,
+) -> None:
+    store = MagicMock(spec=GalleryCollectionStore)
+    store.data_changed = _Signal()
+    store.window_changed = _Signal()
+    store.row_changed = _Signal()
+    store.selection_anchor_retry_requested = _Signal()
+    store.count.return_value = 0
+    adapter = GalleryListModelAdapter(store, mock_thumb_service)
+    anchor = GallerySelectionAnchor(
+        path=Path("/library/current.jpg"),
+        asset_id="current",
+        previous_row=12,
+        selection_version=3,
+    )
+    immediate = GallerySelectionAnchorRetryTicket(
+        anchor=anchor,
+        collection_revision=8,
+        attempt=1,
+        delay_ms=0,
+    )
+
+    store.selection_anchor_retry_requested.emit(immediate)
+    qapp.processEvents()
+
+    store.retry_selection_anchor.assert_called_once_with(immediate)
+    delayed = GallerySelectionAnchorRetryTicket(
+        anchor=anchor,
+        collection_revision=8,
+        attempt=2,
+        delay_ms=500,
+    )
+    store.selection_anchor_retry_requested.emit(delayed)
+    assert adapter._selection_anchor_retry_timer.isActive()
+
+    store.selection_anchor_retry_requested.emit(None)
+
+    assert not adapter._selection_anchor_retry_timer.isActive()
+    assert adapter._pending_selection_anchor_retry is None
+    store.retry_selection_anchor.assert_called_once()
 
 
 def test_runtime_diagnostic_heartbeat_reports_privacy_safe_store_state(

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -204,6 +204,37 @@ def test_adapter_schedules_and_cancels_anchor_retry_on_gui_timer(
     store.retry_selection_anchor.assert_called_once()
 
 
+def test_rebind_leaves_anchor_retry_cancellation_to_store(
+    mock_thumb_service,
+) -> None:
+    store = MagicMock(spec=GalleryCollectionStore)
+    store.data_changed = _Signal()
+    store.window_changed = _Signal()
+    store.row_changed = _Signal()
+    store.selection_anchor_retry_requested = _Signal()
+    store.count.return_value = 0
+    adapter = GalleryListModelAdapter(store, mock_thumb_service)
+    ticket = GallerySelectionAnchorRetryTicket(
+        anchor=GallerySelectionAnchor(
+            path=Path("/library/current.jpg"),
+            asset_id="current",
+            previous_row=12,
+            selection_version=3,
+        ),
+        collection_revision=8,
+        attempt=2,
+        delay_ms=500,
+    )
+    store.selection_anchor_retry_requested.emit(ticket)
+    assert adapter._selection_anchor_retry_timer.isActive()
+
+    adapter.rebind_asset_query_service(_BackfillService(), Path("/library"))
+
+    assert adapter._selection_anchor_retry_timer.isActive()
+    assert adapter._pending_selection_anchor_retry == ticket
+    adapter._selection_anchor_retry_timer.stop()
+
+
 def test_runtime_diagnostic_heartbeat_reports_privacy_safe_store_state(
     adapter,
     mock_store,
@@ -288,12 +319,35 @@ def test_cached_row_for_path_never_uses_synchronous_lookup(adapter, mock_store):
 def test_setting_current_asset_does_not_resolve_its_path(adapter, mock_store):
     path = Path("/library/photo.jpg")
 
-    adapter.set_current_asset(3, path)
+    visual_row = adapter.set_current_asset(3, path)
 
+    assert visual_row == 3
     assert adapter._current_row == 3
     assert adapter._current_path == path
     mock_store.cached_row_for_path.assert_not_called()
     mock_store.row_for_path.assert_not_called()
+    mock_store.pin_row.assert_not_called()
+
+
+def test_pending_selection_keeps_cached_visual_row_without_geometry_change(
+    adapter,
+    mock_store,
+) -> None:
+    path = Path("/library/current.jpg")
+    mock_store.count.return_value = 10
+    assert adapter.set_current_asset(4, path) == 4
+    changed: list[tuple] = []
+    adapter.dataChanged.connect(lambda *args: changed.append(args))
+    mock_store.cached_row_for_path.return_value = 4
+
+    visual_row = adapter.set_current_asset(None, path)
+
+    assert visual_row == 4
+    assert adapter._current_row == 4
+    assert adapter.data(adapter.index(4, 0), Roles.IS_CURRENT) is True
+    assert changed == []
+    mock_store.row_for_path.assert_not_called()
+    mock_store.pin_row.assert_not_called()
 
 
 def test_scan_reset_reanchors_visual_current_asset_by_cached_path(

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -228,6 +228,68 @@ def test_row_for_path_delegates_to_store(adapter, mock_store):
     mock_store.row_for_path.assert_called_once_with(path)
 
 
+def test_cached_row_for_path_never_uses_synchronous_lookup(adapter, mock_store):
+    path = Path("/library/photo.jpg")
+    mock_store.cached_row_for_path.return_value = 9
+
+    assert adapter.cached_row_for_path(path) == 9
+    mock_store.cached_row_for_path.assert_called_once_with(path)
+    mock_store.row_for_path.assert_not_called()
+
+
+def test_setting_current_asset_does_not_resolve_its_path(adapter, mock_store):
+    path = Path("/library/photo.jpg")
+
+    adapter.set_current_asset(3, path)
+
+    assert adapter._current_row == 3
+    assert adapter._current_path == path
+    mock_store.cached_row_for_path.assert_not_called()
+    mock_store.row_for_path.assert_not_called()
+
+
+def test_scan_reset_reanchors_visual_current_asset_by_cached_path(
+    adapter,
+    mock_store,
+) -> None:
+    path = Path("/library/current.jpg")
+    adapter.set_current_asset(4, path)
+    adapter._last_snapshot = (10, (0, 9), 1)
+    adapter._last_selection_signature = ("", "", "")
+    adapter._last_window_identity_signature = ()
+    mock_store.count.return_value = 11
+    mock_store.snapshot_signature.return_value = (11, (0, 10), 2)
+    mock_store.cached_row_for_path.return_value = 7
+    mock_store.cached_rows.return_value = []
+
+    adapter._on_source_changed()
+
+    assert adapter._current_row == 7
+    assert adapter._current_path == path
+    mock_store.row_for_path.assert_not_called()
+
+
+def test_scan_retry_clears_only_visual_row_and_retains_stable_path(
+    adapter,
+    mock_store,
+) -> None:
+    path = Path("/library/current.jpg")
+    adapter.set_current_asset(4, path)
+    adapter._last_snapshot = (10, (0, 9), 1)
+    adapter._last_selection_signature = ("", "", "")
+    adapter._last_window_identity_signature = ()
+    mock_store.count.return_value = 10
+    mock_store.snapshot_signature.return_value = (10, (0, 9), 2)
+    mock_store.cached_row_for_path.return_value = None
+    mock_store.cached_rows.return_value = []
+
+    adapter._on_source_changed()
+
+    assert adapter._current_row == -1
+    assert adapter._current_path == path
+    mock_store.row_for_path.assert_not_called()
+
+
 def test_prioritize_rows_delegates_to_store(adapter, mock_store):
     adapter.prioritize_rows(10, 25)
     adapter._flush_pending_prioritize_rows()

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -156,6 +156,43 @@ def test_adapter_init(adapter):
     assert adapter.rowCount() == 0
 
 
+def test_runtime_diagnostic_heartbeat_reports_privacy_safe_store_state(
+    adapter,
+    mock_store,
+    monkeypatch,
+) -> None:
+    emitted: list[tuple[str, dict]] = []
+    monkeypatch.setenv("IPHOTO_RUNTIME_DIAG", "1")
+    monkeypatch.setattr(
+        adapter_module,
+        "emit_perf_event",
+        lambda name, **payload: emitted.append((name, payload)),
+    )
+    mock_store.diagnostic_snapshot.return_value = {
+        "row_count": 501,
+        "collection_revision": 12,
+        "anchor_status": "retry",
+    }
+    adapter._current_row = 7
+
+    adapter._log_runtime_diag_heartbeat()
+
+    assert emitted == [
+        (
+            "runtime_gui_heartbeat",
+            {
+                "heartbeat": 1,
+                "model_current_row": 7,
+                "viewport_generation": 0,
+                "pending_scan_batches": 0,
+                "row_count": 501,
+                "collection_revision": 12,
+                "anchor_status": "retry",
+            },
+        )
+    ]
+
+
 def test_info_role_contains_required_keys(adapter, mock_store):
     mock_store.count.return_value = 1
     mock_store.asset_at.return_value = _make_dto(

--- a/tests/infrastructure/test_performance_events.py
+++ b/tests/infrastructure/test_performance_events.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from iPhoto.infrastructure.services.performance_events import emit_perf_event
+
+
+def test_privacy_safe_performance_events_hash_paths(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("IPHOTO_PERF_LOG", "1")
+    monkeypatch.setenv("IPHOTO_PERF_PRIVACY_SAFE", "1")
+    monkeypatch.setenv("IPHOTO_PERF_PRIVACY_SALT", "test-session")
+    source = Path("C:/Users/Alice/Pictures/private-name.jpg")
+
+    emit_perf_event(
+        "privacy_test",
+        path=source,
+        caller="C:/checkout/iPhoto/example.py:10:test",
+        nested={"source": str(source), "count": 3},
+        outcome="resolved",
+    )
+
+    event = json.loads(capsys.readouterr().err)
+    assert event["path"].startswith("redacted:")
+    assert event["caller"].startswith("redacted:")
+    assert event["nested"]["source"] == event["path"]
+    assert event["nested"]["count"] == 3
+    assert event["outcome"] == "resolved"
+    assert "private-name.jpg" not in json.dumps(event)
+
+
+def test_performance_event_privacy_mode_is_opt_in(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("IPHOTO_PERF_LOG", "1")
+    monkeypatch.delenv("IPHOTO_PERF_PRIVACY_SAFE", raising=False)
+
+    emit_perf_event("plain_test", key="cache-key")
+
+    event = json.loads(capsys.readouterr().err)
+    assert event["key"] == "cache-key"

--- a/tests/test_detail_benchmark.py
+++ b/tests/test_detail_benchmark.py
@@ -77,7 +77,7 @@ def test_detail_benchmark_accepts_production_presented_and_reports_cache_tiers(t
             "stage": "backend_selected",
             "generation": 4,
             "monotonic_ms": 16.0,
-            "details": {"backend": "wic"},
+            "details": {"backend": "wic", "duration_ms": 12.5},
         },
         {
             "stage": "decode_fallback",
@@ -96,6 +96,14 @@ def test_detail_benchmark_accepts_production_presented_and_reports_cache_tiers(t
     assert result["diagnostics"]["surface_cache_hits"] == {"disk": 1}
     assert result["diagnostics"]["gpu_upload_count"] == 1
     assert result["diagnostics"]["backend_distribution"] == {"wic": 1}
+    assert result["diagnostics"]["backend_decode_ms"] == {
+        "wic": {
+            "count": 1,
+            "p50_ms": 12.5,
+            "p95_ms": 12.5,
+            "max_ms": 12.5,
+        }
+    }
     assert result["diagnostics"]["fallback_distribution"] == {"wic_to_qt": 1}
 
 

--- a/tests/test_sqlite_utils.py
+++ b/tests/test_sqlite_utils.py
@@ -30,3 +30,15 @@ def test_configure_sqlite_connection_initializes_wal_once_per_path(tmp_path: Pat
     assert "PRAGMA foreign_keys=ON" in second.statements
     assert "PRAGMA journal_mode=WAL" not in second.statements
     assert "PRAGMA synchronous=NORMAL" in second.statements
+
+
+def test_configure_sqlite_connection_accepts_explicit_busy_timeout(tmp_path: Path) -> None:
+    connection = _FakeConnection()
+
+    sqlite_utils.configure_sqlite_connection(
+        connection,
+        tmp_path / "index.db",
+        busy_timeout_ms=10_000,
+    )
+
+    assert connection.statements == ["PRAGMA busy_timeout=10000"]

--- a/tests/ui/controllers/test_player_view_controller_adjustments.py
+++ b/tests/ui/controllers/test_player_view_controller_adjustments.py
@@ -196,6 +196,28 @@ def test_adjusted_image_worker_uses_viewport_backend_once() -> None:
     signals.completed.emit.assert_called_once_with(surface)
 
 
+def test_still_worker_reports_decode_duration_for_playback_regression() -> None:
+    source = Path("/tmp/photo.jpg")
+    signals = Mock()
+    request = _request(source)
+    surface = _surface(request)
+    backend = Mock(decode=Mock(return_value=surface))
+    worker = _StillSurfaceDecodeWorker(request, signals, backend)
+
+    with patch(
+        "iPhoto.gui.ui.controllers.player_view_controller.emit_detail_event"
+    ) as emit_event:
+        worker.run()
+
+    backend_event = next(
+        call
+        for call in emit_event.call_args_list
+        if call.args == ("backend_selected",)
+    )
+    assert backend_event.kwargs["backend"] == "fake"
+    assert backend_event.kwargs["duration_ms"] >= 0.0
+
+
 def test_lod_upgrade_failure_preserves_the_presented_surface() -> None:
     source = Path("/tmp/photo.jpg")
     fail_current = Mock()

--- a/tests/ui/controllers/test_player_view_controller_adjustments.py
+++ b/tests/ui/controllers/test_player_view_controller_adjustments.py
@@ -99,6 +99,38 @@ def test_path_only_prefetch_uses_the_display_image_fallback_identity() -> None:
     assert intent.reason == "prefetch"
 
 
+def test_zero_sized_viewport_waits_for_metrics_signal_without_timer_loop() -> None:
+    intent = _PreparedRequestIntent(
+        asset_id="asset-1",
+        source_identity=AssetSourceIdentity.create(Path("/tmp/photo.jpg")),
+        generation=7,
+        reason="initial",
+    )
+    dispatch = Mock(return_value=True)
+    metrics = Mock(side_effect=[None, ((1200, 900), 1.0)])
+    controller = SimpleNamespace(
+        _pending_layout_intent=(intent, {"Exposure": 0.2}),
+        _request_generation=7,
+        _viewport_metrics=metrics,
+        _dispatch_prepared_intent=dispatch,
+        _active_source_identity=None,
+    )
+    controller._retry_pending_layout_intent = lambda: (
+        PlayerViewController._retry_pending_layout_intent(controller)
+    )
+
+    with patch(
+        "iPhoto.gui.ui.controllers.player_view_controller.QTimer.singleShot"
+    ) as single_shot:
+        PlayerViewController._retry_pending_layout_intent(controller)
+        assert controller._pending_layout_intent is not None
+        PlayerViewController._on_viewport_metrics_changed(controller)
+
+    single_shot.assert_not_called()
+    assert controller._pending_layout_intent is None
+    dispatch.assert_called_once_with(intent, {"Exposure": 0.2})
+
+
 def test_clear_frame_cache_invalidates_old_library_requests_before_rebind() -> None:
     calls: list[object] = []
     controller = SimpleNamespace(

--- a/tests/ui/test_media_selection_session.py
+++ b/tests/ui/test_media_selection_session.py
@@ -58,6 +58,60 @@ class _Collection:
         self.data_changed.emit()
 
 
+class _AnchoredCollection(_Collection):
+    def __init__(self, paths: list[Path]) -> None:
+        super().__init__(paths)
+        self.row_loaded = Signal()
+        self.anchor_status: str | None = None
+        self.anchor_path: Path | None = None
+        self.cached_rows = set(range(len(paths)))
+        self.sync_lookup_calls = 0
+
+    def row_for_path(self, path: Path) -> int | None:
+        del path
+        self.sync_lookup_calls += 1
+        raise AssertionError("refresh must not call the synchronous path lookup")
+
+    def asset_at(self, row: int):
+        if row not in self.cached_rows:
+            return None
+        return super().asset_at(row)
+
+    def cached_row_for_path(self, path: Path) -> int | None:
+        for index, candidate in enumerate(self._paths):
+            if index in self.cached_rows and candidate == path:
+                return index
+        return None
+
+    def selection_anchor_status(self, path: Path) -> str | None:
+        if path == self.anchor_path:
+            return self.anchor_status
+        return None
+
+    def pin_path(
+        self,
+        path: Path,
+        *,
+        asset_id: str = "",
+        previous_row: int | None = None,
+    ) -> None:
+        del asset_id, previous_row
+        self.anchor_path = path
+        self.anchor_status = "resolved"
+
+    def publish(
+        self,
+        paths: list[Path],
+        *,
+        status: str,
+        cached_rows: set[int],
+    ) -> None:
+        self._paths = list(paths)
+        self.cached_rows = set(cached_rows)
+        self.anchor_status = status
+        self.data_changed.emit()
+
+
 def test_session_tracks_current_row_and_source() -> None:
     session = MediaSelectionSession()
     collection = _Collection([Path("/fake/a.jpg"), Path("/fake/b.jpg")])
@@ -119,3 +173,75 @@ def test_session_emits_restore_request_payload() -> None:
     session.request_restore(request)
 
     assert emitted == [request]
+
+
+def test_scan_refresh_uses_only_anchor_cache_and_preserves_pending_source() -> None:
+    current = Path("/fake/current.jpg")
+    collection = _AnchoredCollection([Path("/fake/a.jpg"), current])
+    session = MediaSelectionSession()
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    collection.publish(
+        [Path("/fake/new.jpg"), Path("/fake/a.jpg"), current],
+        status="retry",
+        cached_rows={0, 1, 2},
+    )
+
+    assert session.current_row() == -1
+    assert session.current_source() == current
+    assert collection.sync_lookup_calls == 0
+
+    collection.publish(
+        [Path("/fake/new.jpg"), Path("/fake/a.jpg"), current],
+        status="resolved",
+        cached_rows={0, 1, 2},
+    )
+
+    assert session.current_row() == 2
+    assert session.current_source() == current
+    assert collection.sync_lookup_calls == 0
+
+
+def test_confirmed_missing_anchor_falls_back_near_previous_row() -> None:
+    current = Path("/fake/current.jpg")
+    replacement = Path("/fake/replacement.jpg")
+    collection = _AnchoredCollection([Path("/fake/a.jpg"), current])
+    session = MediaSelectionSession()
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    collection.publish(
+        [Path("/fake/a.jpg"), replacement],
+        status="missing",
+        cached_rows={0, 1},
+    )
+
+    assert session.current_row() == 1
+    assert session.current_source() == replacement
+    assert collection.sync_lookup_calls == 0
+
+
+def test_confirmed_missing_anchor_waits_for_async_fallback_row() -> None:
+    current = Path("/fake/current.jpg")
+    replacement = Path("/fake/replacement.jpg")
+    collection = _AnchoredCollection([Path("/fake/a.jpg"), current])
+    session = MediaSelectionSession()
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    collection.publish(
+        [Path("/fake/a.jpg"), replacement],
+        status="missing",
+        cached_rows={0},
+    )
+
+    assert session.current_row() == -1
+    assert session.current_source() == current
+    assert collection.ensure_calls[-1] == 1
+
+    collection.cached_rows.add(1)
+    collection.row_loaded.emit(1)
+
+    assert session.current_row() == 1
+    assert session.current_source() == replacement

--- a/tests/ui/test_media_selection_session.py
+++ b/tests/ui/test_media_selection_session.py
@@ -109,7 +109,7 @@ class _AnchoredCollection(_Collection):
         self,
         paths: list[Path],
         *,
-        status: str,
+        status: str | None,
         cached_rows: set[int],
     ) -> None:
         self._paths = list(paths)
@@ -301,6 +301,26 @@ def test_confirmed_missing_anchor_falls_back_near_previous_row() -> None:
         cached_rows={0, 1},
     )
 
+    assert session.current_row() == 1
+    assert session.current_source() == replacement
+    assert collection.sync_lookup_calls == 0
+
+
+def test_anchor_without_resolution_owner_falls_back_instead_of_stalling() -> None:
+    current = Path("/fake/current.jpg")
+    replacement = Path("/fake/replacement.jpg")
+    collection = _AnchoredCollection([Path("/fake/a.jpg"), current])
+    session = MediaSelectionSession()
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    collection.publish(
+        [Path("/fake/a.jpg"), replacement],
+        status=None,
+        cached_rows={0, 1},
+    )
+
+    assert session.selection_state() is MediaSelectionState.RESOLVED
     assert session.current_row() == 1
     assert session.current_source() == replacement
     assert collection.sync_lookup_calls == 0

--- a/tests/ui/test_media_selection_session.py
+++ b/tests/ui/test_media_selection_session.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from iPhoto.application.dtos import AssetDTO
 from iPhoto.gui.ui.media import (
     MediaRestoreRequest,
+    MediaSelectionChangeReason,
     MediaSelectionSession,
+    MediaSelectionSnapshot,
     MediaSelectionState,
 )
 from iPhoto.gui.viewmodels.signal import Signal
@@ -126,6 +128,38 @@ def test_session_tracks_current_row_and_source() -> None:
     assert source == Path("/fake/b.jpg")
     assert session.current_row() == 1
     assert session.current_source() == Path("/fake/b.jpg")
+
+
+def test_session_publishes_one_coherent_snapshot_per_transition() -> None:
+    current = Path("/fake/current.jpg")
+    collection = _AnchoredCollection([Path("/fake/a.jpg"), current])
+    session = MediaSelectionSession()
+    changes: list[tuple[MediaSelectionSnapshot, MediaSelectionChangeReason]] = []
+    session.selectionChanged.connect(lambda snapshot, reason: changes.append((snapshot, reason)))
+    session.bind_collection(collection)
+    changes.clear()
+
+    session.set_current_row(1)
+    selected, selected_reason = changes[-1]
+    assert selected_reason is MediaSelectionChangeReason.USER_SELECTED
+    assert selected == session.selection_snapshot()
+    assert selected.state is MediaSelectionState.RESOLVED
+    assert selected.row == 1
+    assert selected.path == current
+    assert selected.asset_id == "1"
+
+    collection.publish(
+        [Path("/fake/new.jpg"), Path("/fake/a.jpg"), current],
+        status="retry",
+        cached_rows={0, 1, 2},
+    )
+    pending, pending_reason = changes[-1]
+    assert pending_reason is MediaSelectionChangeReason.ANCHOR_PENDING
+    assert pending.version == selected.version + 1
+    assert pending.state is MediaSelectionState.ANCHOR_RESOLVING
+    assert pending.row is None
+    assert pending.path == current
+    assert pending.asset_id == selected.asset_id
 
 
 def test_session_ensures_missing_row_before_setting_current() -> None:

--- a/tests/ui/test_media_selection_session.py
+++ b/tests/ui/test_media_selection_session.py
@@ -135,7 +135,9 @@ def test_session_publishes_one_coherent_snapshot_per_transition() -> None:
     collection = _AnchoredCollection([Path("/fake/a.jpg"), current])
     session = MediaSelectionSession()
     changes: list[tuple[MediaSelectionSnapshot, MediaSelectionChangeReason]] = []
-    session.selectionChanged.connect(lambda snapshot, reason: changes.append((snapshot, reason)))
+    session.selectionChanged.connect(
+        lambda snapshot, reason: changes.append((snapshot, reason))
+    )
     session.bind_collection(collection)
     changes.clear()
 
@@ -285,6 +287,60 @@ def test_retry_previous_preserves_direction_until_anchor_resolves() -> None:
 
     assert session.current_row() == 2
     assert requested == [1]
+
+
+def test_pending_navigation_clamps_to_last_row_after_anchor_resolves() -> None:
+    paths = [Path(f"/fake/{row}.jpg") for row in range(1000)]
+    current = paths[998]
+    collection = _AnchoredCollection(paths)
+    session = MediaSelectionSession()
+    requested: list[int] = []
+    session.navigationRequested.connect(requested.append)
+    session.bind_collection(collection)
+    session.set_current_row(998)
+
+    collection.publish(paths, status="retry", cached_rows=set(range(1000)))
+    assert session.next_row() is None
+    assert session.next_row() is None
+
+    collection.publish(paths, status="resolved", cached_rows=set(range(1000)))
+
+    assert session.current_source() == current
+    assert requested == [999]
+
+
+def test_retry_exhaustion_is_terminal_and_navigation_remains_available() -> None:
+    current = Path("/fake/current.jpg")
+    collection = _AnchoredCollection(
+        [Path("/fake/before.jpg"), current, Path("/fake/after.jpg")]
+    )
+    session = MediaSelectionSession()
+    changes: list[tuple[MediaSelectionSnapshot, MediaSelectionChangeReason]] = []
+    requested: list[int] = []
+    session.selectionChanged.connect(lambda snapshot, reason: changes.append((snapshot, reason)))
+    session.navigationRequested.connect(requested.append)
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    collection.publish(
+        collection._paths,
+        status="retry",
+        cached_rows=set(),
+    )
+    assert session.next_row() is None
+    collection.publish(
+        collection._paths,
+        status="unresolved",
+        cached_rows=set(),
+    )
+
+    snapshot, reason = changes[-1]
+    assert reason is MediaSelectionChangeReason.ANCHOR_UNRESOLVED
+    assert snapshot.state is MediaSelectionState.ANCHOR_UNRESOLVED
+    assert snapshot.row is None
+    assert snapshot.path == current
+    assert requested == [2]
+    assert session.previous_row() == 0
 
 
 def test_confirmed_missing_anchor_falls_back_near_previous_row() -> None:

--- a/tests/ui/test_media_selection_session.py
+++ b/tests/ui/test_media_selection_session.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from iPhoto.application.dtos import AssetDTO
-from iPhoto.gui.ui.media import MediaRestoreRequest, MediaSelectionSession
+from iPhoto.gui.ui.media import (
+    MediaRestoreRequest,
+    MediaSelectionSession,
+    MediaSelectionState,
+)
 from iPhoto.gui.viewmodels.signal import Signal
 
 
@@ -190,6 +194,7 @@ def test_scan_refresh_uses_only_anchor_cache_and_preserves_pending_source() -> N
 
     assert session.current_row() == -1
     assert session.current_source() == current
+    assert session.selection_state() is MediaSelectionState.ANCHOR_RESOLVING
     assert collection.sync_lookup_calls == 0
 
     collection.publish(
@@ -200,7 +205,52 @@ def test_scan_refresh_uses_only_anchor_cache_and_preserves_pending_source() -> N
 
     assert session.current_row() == 2
     assert session.current_source() == current
+    assert session.selection_state() is MediaSelectionState.RESOLVED
     assert collection.sync_lookup_calls == 0
+
+
+def test_retry_next_waits_for_resolved_anchor_instead_of_jumping_to_zero() -> None:
+    current = Path("/fake/current.jpg")
+    after = Path("/fake/after.jpg")
+    collection = _AnchoredCollection([Path("/fake/a.jpg"), current, after])
+    session = MediaSelectionSession()
+    requested: list[int] = []
+    session.navigationRequested.connect(requested.append)
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    reordered = [Path("/fake/new.jpg"), Path("/fake/a.jpg"), current, after]
+    collection.publish(reordered, status="retry", cached_rows={0, 1, 2, 3})
+
+    assert session.next_row() is None
+    assert requested == []
+
+    collection.publish(reordered, status="resolved", cached_rows={0, 1, 2, 3})
+
+    assert session.current_row() == 2
+    assert requested == [3]
+
+
+def test_retry_previous_preserves_direction_until_anchor_resolves() -> None:
+    before = Path("/fake/before.jpg")
+    current = Path("/fake/current.jpg")
+    collection = _AnchoredCollection([before, current, Path("/fake/after.jpg")])
+    session = MediaSelectionSession()
+    requested: list[int] = []
+    session.navigationRequested.connect(requested.append)
+    session.bind_collection(collection)
+    session.set_current_row(1)
+
+    reordered = [Path("/fake/new.jpg"), before, current, Path("/fake/after.jpg")]
+    collection.publish(reordered, status="retry", cached_rows={0, 1, 2, 3})
+
+    assert session.previous_row() is None
+    assert requested == []
+
+    collection.publish(reordered, status="resolved", cached_rows={0, 1, 2, 3})
+
+    assert session.current_row() == 2
+    assert requested == [1]
 
 
 def test_confirmed_missing_anchor_falls_back_near_previous_row() -> None:
@@ -238,6 +288,7 @@ def test_confirmed_missing_anchor_waits_for_async_fallback_row() -> None:
 
     assert session.current_row() == -1
     assert session.current_source() == current
+    assert session.selection_state() is MediaSelectionState.FALLBACK_PENDING
     assert collection.ensure_calls[-1] == 1
 
     collection.cached_rows.add(1)

--- a/tests/ui/widgets/test_filmstrip_view.py
+++ b/tests/ui/widgets/test_filmstrip_view.py
@@ -58,6 +58,15 @@ class _AssetListModel(QAbstractListModel):
         self.beginResetModel()
         self.endResetModel()
 
+    def set_current_path(self, path: Path) -> None:
+        old_row = self._paths.index(self._current_path)
+        new_row = self._paths.index(path)
+        self._current_path = path
+        roles = [Roles.IS_CURRENT, Qt.ItemDataRole.SizeHintRole]
+        self.dataChanged.emit(self.index(old_row, 0), self.index(old_row, 0), roles)
+        self.dataChanged.emit(self.index(new_row, 0), self.index(new_row, 0), roles)
+
+
 @pytest.fixture(scope="session")
 def qapp():
     app = QApplication.instance()
@@ -150,6 +159,101 @@ def test_playback_selection_cancels_queued_show_restore_before_centering(qapp):
     assert view.selectionModel().currentIndex() == target
     assert view.horizontalScrollBar().value() == target_scroll_value
     assert target_scroll_value != stale_scroll_value
+
+
+def test_centering_settles_current_tile_geometry_before_scroll(qapp):
+    """Model Windows processing a delayed item layout after the center request."""
+
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
+    model = _AssetListModel(paths, paths[5])
+    proxy = SpacerProxyModel()
+    proxy.setSourceModel(model)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(proxy)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    initial = proxy.mapFromSource(model.index(5, 0))
+    target = proxy.mapFromSource(model.index(24, 0))
+    view.select_index_for_centering(initial)
+    view.center_on_index(initial)
+    qapp.processEvents()
+
+    model.set_current_path(paths[24])
+    view.select_index_for_centering(target)
+    view.center_on_index(target)
+    centered_x = int(view.visualRect(target).center().x())
+
+    view.executeDelayedItemsLayout()
+    qapp.processEvents()
+
+    assert abs(int(view.visualRect(target).center().x()) - centered_x) <= 1
+
+
+def test_current_change_does_not_publish_transient_spacer_width(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
+    model = _AssetListModel(paths, paths[5])
+    proxy = SpacerProxyModel()
+    proxy.setSourceModel(model)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(proxy)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    widths: list[int] = []
+    original_set_spacer_width = proxy.set_spacer_width
+
+    def record_spacer_width(width: int) -> None:
+        widths.append(width)
+        original_set_spacer_width(width)
+
+    proxy.set_spacer_width = record_spacer_width  # type: ignore[method-assign]
+    model.set_current_path(paths[24])
+    target = proxy.mapFromSource(model.index(24, 0))
+    view.select_index_for_centering(target)
+
+    expected = max(0, (view.viewport().width() - 120) // 2)
+    assert widths
+    assert set(widths) == {expected}
+
+
+def test_centering_executes_delayed_layout_before_reading_item_geometry(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(20)]
+    model = _AssetListModel(paths, paths[5])
+    proxy = SpacerProxyModel()
+    proxy.setSourceModel(model)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(proxy)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+    target = proxy.mapFromSource(model.index(5, 0))
+
+    calls: list[str] = []
+    execute_layout = view.executeDelayedItemsLayout
+    visual_rect = view.visualRect
+
+    def record_layout() -> None:
+        calls.append("layout")
+        execute_layout()
+
+    def record_rect(index: QModelIndex):
+        calls.append("rect")
+        return visual_rect(index)
+
+    view.executeDelayedItemsLayout = record_layout  # type: ignore[method-assign]
+    view.visualRect = record_rect  # type: ignore[method-assign]
+    view.center_on_index(target)
+
+    assert "layout" in calls
+    assert "rect" in calls
+    layout_position = calls.index("layout")
+    assert "rect" in calls[layout_position + 1 :]
 
 
 def test_scan_reset_restores_same_asset_at_same_viewport_position(qapp):

--- a/tests/ui/widgets/test_filmstrip_view.py
+++ b/tests/ui/widgets/test_filmstrip_view.py
@@ -1,8 +1,62 @@
-from PySide6.QtCore import QItemSelectionModel, QStringListModel
-from PySide6.QtGui import QPalette, QColor
-from PySide6.QtWidgets import QApplication
-from iPhoto.gui.ui.widgets.filmstrip_view import FilmstripView
+from pathlib import Path
+
 import pytest
+from PySide6.QtCore import (
+    QAbstractListModel,
+    QItemSelectionModel,
+    QModelIndex,
+    QStringListModel,
+    Qt,
+)
+from PySide6.QtGui import QColor, QPalette
+from PySide6.QtWidgets import QApplication
+
+from iPhoto.gui.ui.models.roles import Roles
+from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
+from iPhoto.gui.ui.widgets.asset_delegate import AssetGridDelegate
+from iPhoto.gui.ui.widgets.filmstrip_view import FilmstripView
+
+
+class _AssetListModel(QAbstractListModel):
+    def __init__(self, paths: list[Path], current_path: Path) -> None:
+        super().__init__()
+        self._paths = paths
+        self._current_path = current_path
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N802
+        return 0 if parent.isValid() else len(self._paths)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N802
+        return 0 if parent.isValid() else 1
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):
+        if not index.isValid() or not (0 <= index.row() < len(self._paths)):
+            return None
+        path = self._paths[index.row()]
+        if role == Qt.DisplayRole:
+            return path.name
+        if role == Roles.ABS:
+            return str(path)
+        if role == Roles.ASSET_ID:
+            return path.stem
+        if role == Roles.IS_CURRENT:
+            return path == self._current_path
+        if role == Roles.IS_SPACER:
+            return False
+        return None
+
+    def cached_row_for_path(self, path: Path) -> int | None:
+        try:
+            return self._paths.index(path)
+        except ValueError:
+            return None
+
+    def publish_scan_revision(self, paths: list[Path]) -> None:
+        # GalleryCollectionStore has already replaced its cache by the time
+        # GalleryListModelAdapter begins the Qt reset; mirror that ordering.
+        self._paths = paths
+        self.beginResetModel()
+        self.endResetModel()
 
 @pytest.fixture(scope="session")
 def qapp():
@@ -59,3 +113,63 @@ def test_center_on_index_overrides_pending_restore(qapp):
     qapp.processEvents()
 
     assert view.selectionModel().currentIndex().row() == selected.row()
+
+
+def test_scan_reset_restores_same_asset_at_same_viewport_position(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
+    current_path = paths[12]
+    model = _AssetListModel(paths, current_path)
+    proxy = SpacerProxyModel()
+    proxy.setSourceModel(model)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(proxy)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    selected = proxy.mapFromSource(model.index(12, 0))
+    view.selectionModel().setCurrentIndex(selected, QItemSelectionModel.ClearAndSelect)
+    view.center_on_index(selected)
+    qapp.processEvents()
+    anchor_x = int(view.visualRect(selected).center().x())
+
+    reordered = paths[:]
+    reordered.remove(current_path)
+    reordered.insert(21, current_path)
+    model.publish_scan_revision(reordered)
+    qapp.processEvents()
+
+    restored = view.selectionModel().currentIndex()
+    assert restored.data(Roles.ABS) == str(current_path)
+    assert restored.row() == 22
+    assert abs(int(view.visualRect(restored).center().x()) - anchor_x) <= 1
+
+
+def test_unresolved_scan_anchor_preserves_scroll_without_selecting_stale_row(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
+    current_path = paths[12]
+    model = _AssetListModel(paths, current_path)
+    proxy = SpacerProxyModel()
+    proxy.setSourceModel(model)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(proxy)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    selected = proxy.mapFromSource(model.index(12, 0))
+    view.selectionModel().setCurrentIndex(selected, QItemSelectionModel.ClearAndSelect)
+    view.center_on_index(selected)
+    qapp.processEvents()
+    scroll_value = view.horizontalScrollBar().value()
+    without_current = [path for path in paths if path != current_path]
+    without_current.insert(0, Path("/library/new-photo.jpg"))
+    model.publish_scan_revision(without_current)
+    qapp.processEvents()
+
+    restored = view.selectionModel().currentIndex()
+    assert not restored.isValid()
+    assert view.horizontalScrollBar().value() == scroll_value
+    assert model.index(12, 0).data(Roles.ABS) != str(current_path)

--- a/tests/ui/widgets/test_filmstrip_view.py
+++ b/tests/ui/widgets/test_filmstrip_view.py
@@ -115,6 +115,43 @@ def test_center_on_index_overrides_pending_restore(qapp):
     assert view.selectionModel().currentIndex().row() == selected.row()
 
 
+def test_playback_selection_cancels_queued_show_restore_before_centering(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
+    model = _AssetListModel(paths, paths[5])
+    proxy = SpacerProxyModel()
+    proxy.setSourceModel(model)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(proxy)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    stale = proxy.mapFromSource(model.index(5, 0))
+    target = proxy.mapFromSource(model.index(24, 0))
+    view.selectionModel().setCurrentIndex(
+        stale,
+        QItemSelectionModel.ClearAndSelect,
+    )
+    view.center_on_index(stale)
+    view._capture_scroll_state()
+    stale_scroll_value = view.horizontalScrollBar().value()
+    view._schedule_restore_scroll("show")
+    assert view._restore_timer.isActive()
+
+    assert view.select_index_for_centering(target) is True
+
+    assert not view._restore_timer.isActive()
+    assert view._pending_scroll_value is None
+    view.center_on_index(target)
+    target_scroll_value = view.horizontalScrollBar().value()
+    qapp.processEvents()
+
+    assert view.selectionModel().currentIndex() == target
+    assert view.horizontalScrollBar().value() == target_scroll_value
+    assert target_scroll_value != stale_scroll_value
+
+
 def test_scan_reset_restores_same_asset_at_same_viewport_position(qapp):
     paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
     current_path = paths[12]

--- a/tools/collect_windows_scan_playback_diagnostics.ps1
+++ b/tools/collect_windows_scan_playback_diagnostics.ps1
@@ -350,6 +350,19 @@ $diagnosticEnvironment = [ordered]@{
     PYTHONFAULTHANDLER = "1"
     QT_LOGGING_RULES = "qt.qpa.gl=true;qt.rhi.*=true;qt.multimedia.*=true"
 }
+if ($launch.Mode -eq "source") {
+    $sourceRoot = Join-Path $repositoryRoot "src"
+    $inheritedPythonPath = [Environment]::GetEnvironmentVariable(
+        "PYTHONPATH",
+        "Process"
+    )
+    $diagnosticEnvironment["PYTHONPATH"] = if ($inheritedPythonPath) {
+        "$sourceRoot$([IO.Path]::PathSeparator)$inheritedPythonPath"
+    }
+    else {
+        $sourceRoot
+    }
+}
 $previousEnvironment = @{}
 foreach ($key in $diagnosticEnvironment.Keys) {
     $previousEnvironment[$key] = [Environment]::GetEnvironmentVariable($key, "Process")

--- a/tools/collect_windows_scan_playback_diagnostics.ps1
+++ b/tools/collect_windows_scan_playback_diagnostics.ps1
@@ -106,6 +106,44 @@ function Add-ReproductionMarker {
     ($payload | ConvertTo-Json -Compress) | Add-Content -LiteralPath $MarkerPath -Encoding UTF8
 }
 
+function Resolve-SourceApplicationProcess {
+    param(
+        [Parameter(Mandatory = $true)]$LauncherProcess,
+        [int]$TimeoutMilliseconds = 5000
+    )
+
+    $deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMilliseconds)
+    do {
+        try {
+            $children = @(Get-CimInstance Win32_Process -Filter (
+                "ParentProcessId = {0}" -f $LauncherProcess.Id
+            ) -ErrorAction Stop | Sort-Object CreationDate -Descending)
+            foreach ($child in $children) {
+                $candidate = Get-Process -Id ([int]$child.ProcessId) `
+                    -ErrorAction SilentlyContinue
+                if ($candidate -and -not $candidate.HasExited) {
+                    return $candidate
+                }
+            }
+        }
+        catch {}
+        try {
+            $LauncherProcess.Refresh()
+            if ($LauncherProcess.HasExited) {
+                break
+            }
+            if ($LauncherProcess.MainWindowHandle -ne [IntPtr]::Zero) {
+                return $LauncherProcess
+            }
+        }
+        catch {
+            break
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    return $LauncherProcess
+}
+
 function Write-SystemSnapshot {
     param(
         [Parameter(Mandatory = $true)][string]$Target,
@@ -154,7 +192,7 @@ function Write-SystemSnapshot {
     $snapshot = [ordered]@{
         session_id = $SessionId
         collected_utc = [DateTime]::UtcNow.ToString("o")
-        collector_version = 1
+        collector_version = 2
         launch_mode = $Launch.Mode
         application_name = $appFile.Name
         application_size_bytes = $appFile.Length
@@ -387,6 +425,9 @@ try {
         $startParameters["ArgumentList"] = $launch.Arguments
     }
     $process = Start-Process @startParameters
+    if ($launch.Mode -eq "source") {
+        $process = Resolve-SourceApplicationProcess -LauncherProcess $process
+    }
     Add-ReproductionMarker -MarkerPath $markerPath -Marker "application_started" `
         -ProcessId $process.Id
 
@@ -480,7 +521,8 @@ foreach ($replacement in @(
         }
     }
 }
-Protect-TextArtifacts -Root $sessionDir -Replacements @($replacementValues)
+[object[]]$replacementArray = $replacementValues.ToArray()
+Protect-TextArtifacts -Root $sessionDir -Replacements $replacementArray
 
 $manifest = Get-ChildItem -LiteralPath $sessionDir -Recurse -File | ForEach-Object {
     [pscustomobject]@{

--- a/tools/collect_windows_scan_playback_diagnostics.ps1
+++ b/tools/collect_windows_scan_playback_diagnostics.ps1
@@ -1,0 +1,490 @@
+[CmdletBinding()]
+param(
+    [string]$AppPath = "",
+    [string]$PythonExe = "",
+    [string]$OutputRoot = "",
+    [string]$LibraryRootToRedact = "",
+    [ValidateRange(1, 120)]
+    [int]$MaxMinutes = 30,
+    [string[]]$AppArguments = @()
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+function Resolve-Executable {
+    param([Parameter(Mandatory = $true)][string]$Candidate)
+
+    if (Test-Path -LiteralPath $Candidate -PathType Leaf) {
+        return (Get-Item -LiteralPath $Candidate).FullName
+    }
+    $command = Get-Command $Candidate -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($command) {
+        return $command.Source
+    }
+    return $null
+}
+
+function Resolve-DiagnosticLaunch {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot,
+        [string]$RequestedApp,
+        [string]$RequestedPython,
+        [string[]]$ExtraArguments
+    )
+
+    if ($RequestedApp) {
+        $resolvedApp = Resolve-Executable -Candidate $RequestedApp
+        if (-not $resolvedApp) {
+            throw "Application executable was not found: $RequestedApp"
+        }
+        return [pscustomobject]@{
+            FilePath = $resolvedApp
+            Arguments = @($ExtraArguments)
+            Mode = "packaged"
+            WorkingDirectory = (Split-Path -Parent $resolvedApp)
+        }
+    }
+
+    $entrypoint = Join-Path $RepositoryRoot "src\entrypoint.py"
+    if (-not (Test-Path -LiteralPath $entrypoint -PathType Leaf)) {
+        throw "Source entrypoint was not found: $entrypoint"
+    }
+
+    $pythonCandidates = New-Object System.Collections.Generic.List[string]
+    if ($RequestedPython) {
+        $pythonCandidates.Add($RequestedPython) | Out-Null
+    }
+    else {
+        $pythonCandidates.Add((Join-Path $RepositoryRoot ".venv\Scripts\python.exe")) |
+            Out-Null
+        $pythonCandidates.Add("python.exe") | Out-Null
+    }
+    foreach ($candidate in $pythonCandidates) {
+        $resolvedPython = Resolve-Executable -Candidate $candidate
+        if (-not $resolvedPython) {
+            continue
+        }
+        $arguments = New-Object System.Collections.Generic.List[string]
+        $arguments.Add(('"{0}"' -f $entrypoint)) | Out-Null
+        foreach ($argument in $ExtraArguments) {
+            $arguments.Add($argument) | Out-Null
+        }
+        return [pscustomobject]@{
+            FilePath = $resolvedPython
+            Arguments = @($arguments)
+            Mode = "source"
+            WorkingDirectory = $RepositoryRoot
+        }
+    }
+
+    $builtApp = Join-Path $RepositoryRoot "build\entrypoint.dist\entrypoint.exe"
+    if (Test-Path -LiteralPath $builtApp -PathType Leaf) {
+        return [pscustomobject]@{
+            FilePath = (Get-Item -LiteralPath $builtApp).FullName
+            Arguments = @($ExtraArguments)
+            Mode = "packaged"
+            WorkingDirectory = (Split-Path -Parent $builtApp)
+        }
+    }
+    throw "No source Python or packaged entrypoint.exe was found. Pass -AppPath explicitly."
+}
+
+function Add-ReproductionMarker {
+    param(
+        [Parameter(Mandatory = $true)][string]$MarkerPath,
+        [Parameter(Mandatory = $true)][string]$Marker,
+        [int]$ProcessId = 0
+    )
+
+    $payload = [ordered]@{
+        marker = $Marker
+        utc_time = [DateTime]::UtcNow.ToString("o")
+        process_id = $ProcessId
+    }
+    ($payload | ConvertTo-Json -Compress) | Add-Content -LiteralPath $MarkerPath -Encoding UTF8
+}
+
+function Write-SystemSnapshot {
+    param(
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(Mandatory = $true)]$Launch,
+        [Parameter(Mandatory = $true)][string]$SessionId,
+        [Parameter(Mandatory = $true)][string]$RepositoryRoot
+    )
+
+    $operatingSystem = $null
+    $computerSystem = $null
+    $videoControllers = @()
+    try {
+        $operatingSystem = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop |
+            Select-Object Caption, Version, BuildNumber, OSArchitecture,
+                TotalVisibleMemorySize, FreePhysicalMemory
+    }
+    catch {}
+    try {
+        $computerSystem = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop |
+            Select-Object Manufacturer, Model, TotalPhysicalMemory
+    }
+    catch {}
+    try {
+        $videoControllers = @(Get-CimInstance Win32_VideoController -ErrorAction Stop |
+            Select-Object Name, DriverVersion, AdapterRAM, VideoModeDescription)
+    }
+    catch {}
+
+    $appFile = Get-Item -LiteralPath $Launch.FilePath
+    $appHash = $null
+    try {
+        $appHash = (Get-FileHash -LiteralPath $Launch.FilePath -Algorithm SHA256).Hash
+    }
+    catch {}
+    $gitCommit = $null
+    $gitDirty = $null
+    try {
+        $git = Get-Command git.exe -CommandType Application -ErrorAction Stop |
+            Select-Object -First 1
+        $gitCommit = (& $git.Source -C $RepositoryRoot rev-parse HEAD 2>$null |
+            Select-Object -First 1)
+        $gitStatus = @(& $git.Source -C $RepositoryRoot status --porcelain 2>$null)
+        $gitDirty = $gitStatus.Count -gt 0
+    }
+    catch {}
+    $snapshot = [ordered]@{
+        session_id = $SessionId
+        collected_utc = [DateTime]::UtcNow.ToString("o")
+        collector_version = 1
+        launch_mode = $Launch.Mode
+        application_name = $appFile.Name
+        application_size_bytes = $appFile.Length
+        application_sha256 = $appHash
+        application_file_version = $appFile.VersionInfo.FileVersion
+        source_git_commit = $gitCommit
+        source_git_dirty = $gitDirty
+        powershell_version = $PSVersionTable.PSVersion.ToString()
+        operating_system = $operatingSystem
+        computer = $computerSystem
+        video_controllers = $videoControllers
+    }
+    $snapshot | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $Target -Encoding UTF8
+}
+
+function Write-ProcessMetric {
+    param(
+        [Parameter(Mandatory = $true)]$Process,
+        [Parameter(Mandatory = $true)][string]$Target
+    )
+
+    try {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            return
+        }
+        $hung = $false
+        $gdiObjects = 0
+        $userObjects = 0
+        $windowHandle = [IntPtr]::Zero
+        try {
+            $windowHandle = $Process.MainWindowHandle
+            if ($windowHandle -ne [IntPtr]::Zero) {
+                $hung = [IPhotoDiag.NativeMethods]::IsHungAppWindow($windowHandle)
+            }
+            $gdiObjects = [IPhotoDiag.NativeMethods]::GetGuiResources($Process.Handle, 0)
+            $userObjects = [IPhotoDiag.NativeMethods]::GetGuiResources($Process.Handle, 1)
+        }
+        catch {}
+        $culture = [Globalization.CultureInfo]::InvariantCulture
+        $values = @(
+            [DateTime]::UtcNow.ToString("o"),
+            $Process.Id,
+            $Process.TotalProcessorTime.TotalSeconds.ToString("F3", $culture),
+            ([Math]::Round($Process.WorkingSet64 / 1MB, 3)).ToString($culture),
+            ([Math]::Round($Process.PrivateMemorySize64 / 1MB, 3)).ToString($culture),
+            $Process.HandleCount,
+            $Process.Threads.Count,
+            $gdiObjects,
+            $userObjects,
+            [int]($windowHandle -ne [IntPtr]::Zero),
+            [int]$hung
+        )
+        ($values -join ",") | Add-Content -LiteralPath $Target -Encoding UTF8
+    }
+    catch {}
+}
+
+function Collect-ApplicationEvents {
+    param(
+        [Parameter(Mandatory = $true)][DateTime]$StartTime,
+        [Parameter(Mandatory = $true)][string]$Target
+    )
+
+    try {
+        $events = Get-WinEvent -FilterHashtable @{
+            LogName = "Application"
+            StartTime = $StartTime.AddMinutes(-5)
+        } -ErrorAction Stop | Where-Object {
+            $_.LevelDisplayName -in @("Critical", "Error", "Warning") -or
+            $_.ProviderName -match "Application Error|Windows Error Reporting|Display|Qt"
+        } | Select-Object -First 200 | ForEach-Object {
+            [pscustomobject]@{
+                TimeCreated = $_.TimeCreated.ToUniversalTime().ToString("o")
+                Id = $_.Id
+                Level = $_.LevelDisplayName
+                Provider = $_.ProviderName
+                Message = (([string]$_.Message -replace "[\r\n]+", " ").Trim())
+            }
+        }
+        $events | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $Target -Encoding UTF8
+    }
+    catch {
+        @{ error = $_.Exception.GetType().Name } | ConvertTo-Json |
+            Set-Content -LiteralPath $Target -Encoding UTF8
+    }
+}
+
+function Protect-TextArtifacts {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][object[]]$Replacements
+    )
+
+    $extensions = @(".log", ".json", ".jsonl", ".csv", ".txt")
+    Get-ChildItem -LiteralPath $Root -Recurse -File | Where-Object {
+        $extensions -contains $_.Extension.ToLowerInvariant()
+    } | ForEach-Object {
+        $source = $_.FullName
+        $temporary = "$source.redacting"
+        $reader = [IO.File]::OpenText($source)
+        $writer = New-Object IO.StreamWriter($temporary, $false, (New-Object Text.UTF8Encoding($false)))
+        try {
+            while (($line = $reader.ReadLine()) -ne $null) {
+                foreach ($replacement in $Replacements) {
+                    if (-not $replacement.Original) {
+                        continue
+                    }
+                    $line = [regex]::Replace(
+                        $line,
+                        [regex]::Escape($replacement.Original),
+                        $replacement.Token,
+                        [Text.RegularExpressions.RegexOptions]::IgnoreCase
+                    )
+                }
+                $writer.WriteLine($line)
+            }
+        }
+        finally {
+            $reader.Dispose()
+            $writer.Dispose()
+        }
+        Move-Item -LiteralPath $temporary -Destination $source -Force
+    }
+}
+
+if ($env:OS -ne "Windows_NT") {
+    throw "This collector must be run on Windows."
+}
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$launch = Resolve-DiagnosticLaunch -RepositoryRoot $repositoryRoot `
+    -RequestedApp $AppPath -RequestedPython $PythonExe -ExtraArguments $AppArguments
+
+if (-not $OutputRoot) {
+    $OutputRoot = [Environment]::GetFolderPath("Desktop")
+    if (-not $OutputRoot) {
+        $OutputRoot = (Get-Location).Path
+    }
+}
+New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+$OutputRoot = (Get-Item -LiteralPath $OutputRoot).FullName
+$sessionId = "iPhoto-windows-scan-playback-{0}" -f (Get-Date -Format "yyyyMMdd-HHmmss")
+$sessionDir = Join-Path $OutputRoot $sessionId
+$zipPath = Join-Path $OutputRoot "$sessionId.zip"
+New-Item -ItemType Directory -Force -Path $sessionDir | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $sessionDir "app-logs") | Out-Null
+
+if (-not ("IPhotoDiag.NativeMethods" -as [type])) {
+    Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+namespace IPhotoDiag {
+    public static class NativeMethods {
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsHungAppWindow(IntPtr windowHandle);
+
+        [DllImport("user32.dll")]
+        public static extern uint GetGuiResources(IntPtr processHandle, uint flag);
+    }
+}
+"@
+}
+
+$stdoutPath = Join-Path $sessionDir "stdout.log"
+$stderrPath = Join-Path $sessionDir "stderr.log"
+$stackPath = Join-Path $sessionDir "runtime_stacks.log"
+$detailPath = Join-Path $sessionDir "detail_events.jsonl"
+$markerPath = Join-Path $sessionDir "reproduction_markers.jsonl"
+$metricsPath = Join-Path $sessionDir "process_metrics.csv"
+$systemPath = Join-Path $sessionDir "system.json"
+$eventPath = Join-Path $sessionDir "windows_application_events.json"
+$startedAt = Get-Date
+
+"utc_time,pid,cpu_seconds,working_set_mb,private_mb,handles,threads,gdi_objects," +
+    "user_objects,has_main_window,is_hung" |
+    Set-Content -LiteralPath $metricsPath -Encoding UTF8
+Write-SystemSnapshot -Target $systemPath -Launch $launch -SessionId $sessionId `
+    -RepositoryRoot $repositoryRoot
+
+$diagnosticEnvironment = [ordered]@{
+    IPHOTO_LOG_DIR = (Join-Path $sessionDir "app-logs")
+    IPHOTO_DETAIL_PROFILE = "1"
+    IPHOTO_DETAIL_PROFILE_PATH = $detailPath
+    IPHOTO_PERF_LOG = "1"
+    IPHOTO_PERF_PRIVACY_SAFE = "1"
+    IPHOTO_PERF_PRIVACY_SALT = [Guid]::NewGuid().ToString("N")
+    IPHOTO_RUNTIME_DIAG = "1"
+    IPHOTO_RUNTIME_DIAG_STACK_PATH = $stackPath
+    IPHOTO_RUNTIME_DIAG_INTERVAL_SEC = "5"
+    IPHOTO_STARTUP_HANG_DIAG = "1"
+    PYTHONFAULTHANDLER = "1"
+    QT_LOGGING_RULES = "qt.qpa.gl=true;qt.rhi.*=true;qt.multimedia.*=true"
+}
+$previousEnvironment = @{}
+foreach ($key in $diagnosticEnvironment.Keys) {
+    $previousEnvironment[$key] = [Environment]::GetEnvironmentVariable($key, "Process")
+    [Environment]::SetEnvironmentVariable(
+        $key,
+        [string]$diagnosticEnvironment[$key],
+        "Process"
+    )
+}
+
+$process = $null
+$collectorError = $null
+try {
+    $startParameters = @{
+        FilePath = $launch.FilePath
+        WorkingDirectory = $launch.WorkingDirectory
+        PassThru = $true
+        RedirectStandardOutput = $stdoutPath
+        RedirectStandardError = $stderrPath
+    }
+    if ($launch.Arguments.Count -gt 0) {
+        $startParameters["ArgumentList"] = $launch.Arguments
+    }
+    $process = Start-Process @startParameters
+    Add-ReproductionMarker -MarkerPath $markerPath -Marker "application_started" `
+        -ProcessId $process.Id
+
+    Write-Host ""
+    Write-Host "iPhoto diagnostic collection started (PID $($process.Id))." -ForegroundColor Cyan
+    Write-Host "1. Reproduce scanning until still photos become blank / Edit stops responding."
+    Write-Host "2. When the problem is visible, return here and press R once."
+    Write-Host "3. Then close iPhoto normally. If it cannot close, press Q here to stop it."
+    Write-Host "Collection automatically stops after $MaxMinutes minutes."
+    Write-Host ""
+
+    $deadline = (Get-Date).AddMinutes($MaxMinutes)
+    $nextSample = Get-Date
+    while (-not $process.HasExited -and (Get-Date) -lt $deadline) {
+        $now = Get-Date
+        if ($now -ge $nextSample) {
+            Write-ProcessMetric -Process $process -Target $metricsPath
+            $nextSample = $now.AddSeconds(1)
+        }
+        try {
+            if ([Console]::KeyAvailable) {
+                $key = [Console]::ReadKey($true).Key
+                if ($key -eq [ConsoleKey]::R) {
+                    Add-ReproductionMarker -MarkerPath $markerPath `
+                        -Marker "problem_reproduced" -ProcessId $process.Id
+                    Write-Host "Reproduction marker recorded." -ForegroundColor Yellow
+                }
+                elseif ($key -eq [ConsoleKey]::Q) {
+                    Add-ReproductionMarker -MarkerPath $markerPath `
+                        -Marker "collector_forced_stop" -ProcessId $process.Id
+                    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+                    break
+                }
+            }
+        }
+        catch {}
+        Start-Sleep -Milliseconds 200
+        $process.Refresh()
+    }
+    if (-not $process.HasExited) {
+        Add-ReproductionMarker -MarkerPath $markerPath -Marker "collector_timeout" `
+            -ProcessId $process.Id
+        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    }
+    try {
+        $process.WaitForExit(5000) | Out-Null
+    }
+    catch {}
+    Add-ReproductionMarker -MarkerPath $markerPath -Marker "application_exited" `
+        -ProcessId $process.Id
+}
+catch {
+    $collectorError = $_.Exception.Message
+    Write-Warning "Collector encountered an error: $collectorError"
+}
+finally {
+    foreach ($key in $diagnosticEnvironment.Keys) {
+        [Environment]::SetEnvironmentVariable(
+            $key,
+            $previousEnvironment[$key],
+            "Process"
+        )
+    }
+}
+
+Start-Sleep -Seconds 1
+Collect-ApplicationEvents -StartTime $startedAt -Target $eventPath
+if ($collectorError) {
+    "collector_error=$collectorError" |
+        Set-Content -LiteralPath (Join-Path $sessionDir "collector_error.txt") -Encoding UTF8
+}
+
+$replacementValues = New-Object System.Collections.Generic.List[object]
+foreach ($replacement in @(
+    [pscustomobject]@{ Original = $env:USERPROFILE; Token = "<USERPROFILE>" },
+    [pscustomobject]@{ Original = $env:LOCALAPPDATA; Token = "<LOCALAPPDATA>" },
+    [pscustomobject]@{ Original = $env:APPDATA; Token = "<APPDATA>" },
+    [pscustomobject]@{ Original = $env:TEMP; Token = "<TEMP>" },
+    [pscustomobject]@{ Original = $repositoryRoot; Token = "<REPOSITORY>" },
+    [pscustomobject]@{ Original = (Split-Path -Parent $launch.FilePath); Token = "<APP_DIR>" },
+    [pscustomobject]@{ Original = $LibraryRootToRedact; Token = "<LIBRARY_ROOT>" }
+)) {
+    if ($replacement.Original) {
+        $replacementValues.Add($replacement) | Out-Null
+        $jsonEscaped = $replacement.Original.Replace('\', '\\')
+        if ($jsonEscaped -ne $replacement.Original) {
+            $replacementValues.Add([pscustomobject]@{
+                Original = $jsonEscaped
+                Token = $replacement.Token
+            }) | Out-Null
+        }
+    }
+}
+Protect-TextArtifacts -Root $sessionDir -Replacements @($replacementValues)
+
+$manifest = Get-ChildItem -LiteralPath $sessionDir -Recurse -File | ForEach-Object {
+    [pscustomobject]@{
+        file = $_.FullName.Substring($sessionDir.Length + 1).Replace("\", "/")
+        bytes = $_.Length
+        sha256 = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash
+    }
+}
+$manifest | ConvertTo-Json -Depth 3 |
+    Set-Content -LiteralPath (Join-Path $sessionDir "manifest.json") -Encoding UTF8
+
+if (Test-Path -LiteralPath $zipPath) {
+    Remove-Item -LiteralPath $zipPath -Force
+}
+Compress-Archive -Path (Join-Path $sessionDir "*") -DestinationPath $zipPath -CompressionLevel Optimal
+
+Write-Host ""
+Write-Host "Diagnostic bundle created:" -ForegroundColor Green
+Write-Host $zipPath
+Write-Host "Please review the ZIP if needed, then send that single file back."

--- a/tools/detail_benchmark.py
+++ b/tools/detail_benchmark.py
@@ -34,6 +34,7 @@ def summarize(paths: list[Path]) -> dict[str, Any]:
     event_counts: dict[str, int] = defaultdict(int)
     cache_tiers: dict[str, int] = defaultdict(int)
     backend_counts: dict[str, int] = defaultdict(int)
+    backend_decode_values: dict[str, list[float]] = defaultdict(list)
     fallback_counts: dict[str, int] = defaultdict(int)
     gui_tasks: list[float] = []
     for path in paths:
@@ -63,7 +64,14 @@ def summarize(paths: list[Path]) -> dict[str, Any]:
                 if stage == "surface_cache_hit" and isinstance(details, dict):
                     cache_tiers[str(details.get("tier") or "unknown")] += 1
                 if stage == "backend_selected" and isinstance(details, dict):
-                    backend_counts[str(details.get("backend") or "unknown")] += 1
+                    backend = str(details.get("backend") or "unknown")
+                    backend_counts[backend] += 1
+                    try:
+                        backend_decode_values[backend].append(
+                            max(0.0, float(details["duration_ms"]))
+                        )
+                    except (KeyError, TypeError, ValueError):
+                        pass
                 if stage == "decode_fallback" and isinstance(details, dict):
                     fallback_counts[str(details.get("fallback") or "unknown")] += 1
 
@@ -124,6 +132,10 @@ def summarize(paths: list[Path]) -> dict[str, Any]:
             "event_counts": dict(sorted(event_counts.items())),
             "surface_cache_hits": dict(sorted(cache_tiers.items())),
             "backend_distribution": dict(sorted(backend_counts.items())),
+            "backend_decode_ms": {
+                backend: _metric(samples)
+                for backend, samples in sorted(backend_decode_values.items())
+            },
             "fallback_distribution": dict(sorted(fallback_counts.items())),
             "decode_count": event_counts.get("backend_selected", 0),
             "gpu_upload_count": event_counts.get("gpu_upload", 0),


### PR DESCRIPTION
## Summary

- preserve the selected still and its resident render session while scan revisions reorder Gallery rows; all selection refresh lookup remains off the GUI thread
- make one immutable `MediaSelectionSnapshot` the cross-layer selection fact source, with one ordered `selectionChanged(snapshot, reason)` event
- atomically converge Session, Detail presentation, row/path/asset identity, and action targets after async fallback loading
- actively retry transient anchor resolution with cancelable 100/250/500ms tickets, without requiring another scan revision
- keep the Playback filmstrip visually stable across scan revisions by restoring the same asset at the same viewport position, never by stale numeric row
- route Windows JPEG/JFIF playback through Qt's scaled `QImageReader` decoder instead of the unsafe WIC `CopyPixels` path
- leave the Detail surface cache, GPU residency/hot-open path, thumbnail path, and non-JPEG Windows codec routing unchanged
- retain the index database's original 10-second lock wait while initializing WAL only once per database path

## Confirmed root cause

The Windows reproduction bundle disproved GUI-thread SQLite blocking as the remaining still-decode failure:

- the GUI heartbeat continued normally until the native failure
- Gallery revisions and selection anchors continued to converge
- both still-decode lanes stopped inside `detail_decode_windows.py::_copy_rgba`, at `IWICBitmapSource.CopyPixels`, on separate JPEG files
- after both lanes were occupied, every later still request queued indefinitely, matching the blank-still/Edit/fullscreen symptom while video continued on its independent Qt media path
- Windows Error Reporting then recorded `python312.dll` exception `0xc0000005`

The selection-anchor and one-time WAL changes remain upstream correctness/latency defenses, while the WIC JPEG access violation was the asset-count threshold failure.

## Selection state closure

`MediaSelectionSession` now stores one immutable snapshot containing a monotonically increasing version, state, authoritative row, path, and asset ID. An unresolved row is `None`; it is no longer conflated with an empty selection inside the state model. Compatibility getters still expose `-1` to legacy readers.

Every transition first replaces the complete snapshot and then publishes exactly one event with a reason: user selection, anchor pending/resolved, fallback pending/resolved, or cleared. The previous split `currentChanged`/`selectionStateChanged` signals are removed.

`DetailViewModel` is now a pure event-driven reconciler. `show_row()` submits one Session command and allocates one request generation. Async placeholder retry resubmits that command without recursion or another generation. When a fallback row becomes available, the Session's `FALLBACK_RESOLVED` event atomically moves the VM and presentation from A to B. Store refreshes update only metadata/chrome for an already matching resolved snapshot; they no longer propagate selection state.

Same-asset row relocation keeps the render key and request generation. Only a fallback to a different asset creates a new render generation. Pending presentation updates are deduplicated.

## Asset-operation safety

During `ANCHOR_RESOLVING`, Detail keeps the resident A surface and permits path-based Edit/Rotate/Share only when presentation path and asset ID match the snapshot. Favorite remains disabled until the row is authoritative.

During `FALLBACK_PENDING`, the old surface is transition-only and Favorite, Edit, Rotate, and Share are all disabled. Once B is resolved, every operation requires the current presentation to match the authoritative snapshot; Favorite additionally verifies the row DTO's row/path/asset ID before mutation.

Next/Previous accumulate intent while the anchor is unresolved and apply it relative to the authoritative relocated/fallback row. They never treat pending state as an empty selection or jump to row 0.

## Anchor retry liveness

A real worker `retry` result creates an immutable ticket containing anchor identity/version, collection revision, attempt, and delay. The Qt adapter owns a single-shot timer and uses bounded delays of 100ms, 250ms, and 500ms.

At expiry, the Store revalidates the complete ticket before submitting one single-row, `request_backfill=False`, non-viewport worker request. `find_row_by_path()` therefore remains on the Gallery worker and never runs on the GUI thread.

Resolved, missing, a new selection, a new revision, reset/rebind, and stale or out-of-order identity all cancel the ticket. Three failed attempts emit privacy-safe `selection_anchor_retry_exhausted` diagnostics and stop; no retry storm is possible. Retry results carry purpose/attempt metadata so viewport competition cannot advance or duplicate the retry sequence.

## Filmstrip stability

The previous filmstrip reset handler restored its selection by numeric row. A scan revision could remap that row to another asset, causing the strip to jump to the wrong photo and then jump back when the authoritative selection anchor resolved. Pending selection also temporarily removed the expanded current-tile geometry, producing additional horizontal movement.

The Gallery adapter retains the current asset's stable path and reanchors its visual row from the in-memory cache before Qt publishes the model reset. The filmstrip captures path, asset ID, and viewport x-position; after reset it maps the resolved source row through the spacer proxy and restores the same asset at the same x-position. If the anchor is not cached yet, it preserves the exact scroll value and never falls through to the stale row. No database or filesystem lookup is added to this path.

## SQLite contention policy

`configure_sqlite_connection()` accepts an explicit busy timeout. The index `DatabaseManager` passes 10000ms to both `sqlite3.connect()` and `PRAGMA busy_timeout`, preserving the previous 10-second lock-wait behavior while retaining WAL-once initialization. Tests read the effective PRAGMA and verify both short connections receive 10000ms.

## Playback performance contract

The workaround is deliberately limited to `.jpg`, `.jpeg`, `.jpe`, and `.jfif` on Windows. Cache hits and resident GPU textures do not enter the decoder, so hot Playback opening is unchanged. Qt keeps the same viewport-sized decode target and requests scaled JPEG decode instead of materializing a full-resolution image.

The new snapshot and retry work runs only on selection transitions or collection revisions. Normal Playback open adds no database or filesystem access. Selection pinning is now owned solely by `MediaSelectionSession`; the redundant Detail-layer `pin_row()` was removed, leaving one bounded in-memory pin instead of two. A hot-path regression test rejects path lookup and verifies exactly one pin.

`backend_selected` includes worker decode duration, and the packaged benchmark runbook supports same-machine/same-sample Windows comparison for `jpeg-cold` and `jpeg-hot-gpu`, while retaining the existing absolute `click_to_image` limits of 150ms cold and 80ms GPU-hot.

## Diagnostics collector

From a current source checkout, close all iPhoto instances and run:

```powershell
powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1 `
  -LibraryRootToRedact "D:\Path\To\Your\PhotoLibrary"
```

The collector resolves the source-mode virtual-environment launcher to the actual GUI child PID, and converts the redaction list to an object array before packaging for Windows PowerShell 5.1. It does not copy photos, thumbnails, the SQLite index, settings, or credentials. Detailed instructions are in `docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md`.

## Validation

- full local suite: `3063 passed, 16 skipped`
- Selection/Detail/Gallery/Playback focused suite: `266 passed`
- cross-layer regression covers A visible -> anchor missing -> uncached fallback -> `FALLBACK_PENDING` -> row-loaded B -> atomic Session/Detail/presentation/action convergence
- action regressions cover Favorite/Edit/Rotate/Share identity and pending-state guards
- retry regressions cover last-revision convergence, 100/250/500ms bounds, exhaustion, cancellation, stale tickets, adapter timers, request metadata, and worker-thread-only lookup
- performance regression verifies the normal Playback selection path performs no path lookup and exactly one in-memory pin
- architecture checks: passed (`23 passed` plus boundary script)
- Ruff fatal/error/import gate: passed for changed files
- compileall and `git diff --check`: passed

CI was not awaited per maintainer direction; the complete local validation above is green.
