### PR TITLE
Fix Maps marker flicker and large-library stalls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,36 @@ permissions:
   contents: read
 
 jobs:
+  maps-scale-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libegl1 libgl1 libxkbcommon0 libpulse0
+
+      - name: Install Maps scale-contract dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run 1k, 10k, and 50k marker clustering contract
+        env:
+          IPHOTO_RUN_MAPS_SCALE_CONTRACT: "1"
+          QT_QPA_PLATFORM: offscreen
+        run: python -m pytest -q tests/contracts/test_map_marker_scale_contract.py
+
   pets-scale-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ line-length = 100
 testpaths = ["tests"]
 addopts = "-ra -p no:pytestqt"
 markers = [
+    "maps_scale_contract: large synthetic map marker clustering contract",
     "pets_model_contract: real official YOLOX model and image contract",
     "pets_scale_contract: large synthetic Pets incremental-index contract",
 ]

--- a/src/iPhoto/gui/ui/tasks/thumbnail_cache.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_cache.py
@@ -16,6 +16,13 @@ from ....utils.pathutils import ensure_work_dir
 LOGGER = logging.getLogger(__name__)
 
 
+def _cache_digest(abs_path: Path) -> str:
+    """Return the stable digest used by every cache version of an asset."""
+
+    path_str = str(abs_path.resolve())
+    return hashlib.blake2b(path_str.encode("utf-8"), digest_size=20).hexdigest()
+
+
 def safe_unlink(path: Path) -> None:
     """
     Safely delete a file, handling permission errors gracefully.
@@ -61,10 +68,37 @@ def generate_cache_path(library_root: Path, abs_path: Path, size: QSize, stamp: 
         Path: The path to the cache file for the thumbnail image.
     """
     # Use absolute path for global uniqueness
-    path_str = str(abs_path.resolve())
-    digest = hashlib.blake2b(path_str.encode("utf-8"), digest_size=20).hexdigest()
+    digest = _cache_digest(abs_path)
     filename = f"{digest}_{stamp}_{size.width()}x{size.height()}.png"
     return ensure_work_dir(library_root) / "thumbs" / filename
+
+
+def remove_cache_versions(
+    library_root: Path,
+    abs_path: Path,
+    size: QSize,
+    *,
+    keep_stamp: int | None = None,
+) -> None:
+    """Delete stamp-addressed cache files for one asset and thumbnail size."""
+
+    try:
+        cache_dir = ensure_work_dir(library_root) / "thumbs"
+        digest = _cache_digest(abs_path)
+        pattern = f"{digest}_*_{size.width()}x{size.height()}.png"
+        candidates = list(cache_dir.glob(pattern))
+    except OSError:
+        return
+
+    keep_path = (
+        generate_cache_path(library_root, abs_path, size, keep_stamp)
+        if keep_stamp is not None
+        else None
+    )
+    for candidate in candidates:
+        if keep_path is not None and candidate == keep_path:
+            continue
+        safe_unlink(candidate)
 
 
 def write_cache(canvas: QImage, path: Path) -> bool:  # pragma: no cover - worker helper

--- a/src/iPhoto/gui/ui/tasks/thumbnail_cache.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_cache.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import tempfile
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from PySide6.QtCore import QSize
@@ -12,8 +15,17 @@ from PySide6.QtGui import QImage
 
 from ....utils.pathutils import ensure_work_dir
 
-
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class CacheCleanupTarget:
+    """Cache selector with an optional generation-aware unlink operation."""
+
+    abs_path: Path
+    size: QSize
+    keep_stamp: int | None = None
+    unlink_candidate: Callable[[Path], None] | None = None
 
 
 def _cache_digest(abs_path: Path) -> str:
@@ -82,39 +94,106 @@ def remove_cache_versions(
 ) -> None:
     """Delete stamp-addressed cache files for one asset and thumbnail size."""
 
+    remove_cache_versions_many(
+        library_root,
+        [CacheCleanupTarget(abs_path, size, keep_stamp)],
+    )
+
+
+def remove_cache_versions_many(
+    library_root: Path,
+    targets: Iterable[CacheCleanupTarget],
+) -> None:
+    """Delete cache versions for many assets with one directory scan.
+
+    A target with a ``None`` stamp removes every matching version; otherwise
+    that exact version is retained.  Its optional unlink callback can enforce
+    generation ownership immediately before each file deletion.
+    Grouping selectors by digest keeps large removal batches near ``O(R + C)``
+    instead of scanning the thumbnail directory once per removed asset.
+    """
+
+    selectors: dict[
+        str,
+        dict[str, tuple[set[str] | None, Callable[[Path], None] | None]],
+    ] = {}
+    for target in targets:
+        try:
+            digest = _cache_digest(target.abs_path)
+        except OSError:
+            continue
+        suffix = f"_{target.size.width()}x{target.size.height()}.png"
+        digest_selectors = selectors.setdefault(digest, {})
+        if target.keep_stamp is None:
+            digest_selectors[suffix] = (None, target.unlink_candidate)
+            continue
+        keep_name = f"{digest}_{target.keep_stamp}{suffix}"
+        existing_selector = digest_selectors.get(suffix)
+        if existing_selector is None:
+            digest_selectors[suffix] = ({keep_name}, target.unlink_candidate)
+            continue
+        existing_keeps, existing_unlink = existing_selector
+        if existing_keeps is not None:
+            existing_keeps.add(keep_name)
+            digest_selectors[suffix] = (
+                existing_keeps,
+                target.unlink_candidate or existing_unlink,
+            )
+
+    if not selectors:
+        return
+
     try:
         cache_dir = ensure_work_dir(library_root) / "thumbs"
-        digest = _cache_digest(abs_path)
-        pattern = f"{digest}_*_{size.width()}x{size.height()}.png"
-        candidates = list(cache_dir.glob(pattern))
+        entries = os.scandir(cache_dir)
     except OSError:
         return
 
-    keep_path = (
-        generate_cache_path(library_root, abs_path, size, keep_stamp)
-        if keep_stamp is not None
-        else None
-    )
-    for candidate in candidates:
-        if keep_path is not None and candidate == keep_path:
-            continue
-        safe_unlink(candidate)
+    try:
+        with entries:
+            for entry in entries:
+                name = entry.name
+                digest_selectors = selectors.get(name[:40])
+                if digest_selectors is None:
+                    continue
+                for suffix, selector in digest_selectors.items():
+                    if not name.endswith(suffix):
+                        continue
+                    keep_names, unlink_candidate = selector
+                    if keep_names is None or name not in keep_names:
+                        candidate = Path(entry.path)
+                        if unlink_candidate is None:
+                            safe_unlink(candidate)
+                        else:
+                            unlink_candidate(candidate)
+                    break
+    except OSError:
+        return
 
 
 def write_cache(canvas: QImage, path: Path) -> bool:  # pragma: no cover - worker helper
-    """Write a thumbnail *canvas* to *path* atomically via a temp file."""
+    """Write *canvas* atomically using a writer-unique adjacent temp file."""
+
+    tmp_path: Path | None = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        file_descriptor, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+        )
+        tmp_path = Path(tmp_name)
+        os.close(file_descriptor)
         if canvas.save(str(tmp_path), "PNG"):
-            safe_unlink(path)
             try:
                 tmp_path.replace(path)
+                tmp_path = None
                 return True
             except OSError:
-                tmp_path.unlink(missing_ok=True)
-        else:  # pragma: no cover - Qt returns False on IO errors
-            tmp_path.unlink(missing_ok=True)
+                pass
     except Exception:
         pass
+    finally:
+        if tmp_path is not None:
+            safe_unlink(tmp_path)
     return False

--- a/src/iPhoto/gui/ui/tasks/thumbnail_job.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_job.py
@@ -181,6 +181,7 @@ class ThumbnailJob(QRunnable):
             self._emit_delivered(
                 self._make_local_key(actual_stamp),
                 image,
+                cache_path,
             )
         except RuntimeError:  # pragma: no cover - race with QObject deletion
             pass
@@ -216,6 +217,7 @@ class ThumbnailJob(QRunnable):
         self,
         key: Tuple[str, str, int, int, int],
         image: Optional[QImage],
+        cache_path: Optional[Path] = None,
     ) -> None:
         """Emit a result using the receiver's generation-aware signal shape."""
 
@@ -225,7 +227,13 @@ class ThumbnailJob(QRunnable):
         if self._generation_token is None:
             loader._delivered.emit(key, image, self._rel)
         else:
-            loader._delivered.emit(key, image, self._rel, self._generation_token)
+            loader._delivered.emit(
+                key,
+                image,
+                self._rel,
+                self._generation_token,
+                cache_path,
+            )
 
     def _render_media(self) -> Optional[QImage]:  # pragma: no cover - worker helper
         if self._is_video:

--- a/src/iPhoto/gui/ui/tasks/thumbnail_job.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_job.py
@@ -47,6 +47,7 @@ class ThumbnailJob(QRunnable):
         still_image_time: Optional[float],
         duration: Optional[float],
         cache_rel: Optional[str] = None,
+        generation_token: object | None = None,
     ) -> None:
         super().__init__()
         self._loader = loader
@@ -61,6 +62,7 @@ class ThumbnailJob(QRunnable):
         self._still_image_time = still_image_time
         self._duration = duration
         self._cache_rel = cache_rel
+        self._generation_token = generation_token
         self._job_root_str = str(album_root.resolve())
 
     def _make_local_key(self, stamp: int) -> Tuple[str, str, int, int, int]:
@@ -146,10 +148,9 @@ class ThumbnailJob(QRunnable):
                 loader = getattr(self, "_loader", None)
                 if loader:
                     try:
-                        loader._delivered.emit(
+                        self._emit_delivered(
                             self._make_local_key(0),
                             None,
-                            self._rel,
                         )
                     except RuntimeError:
                         pass
@@ -177,10 +178,9 @@ class ThumbnailJob(QRunnable):
                 pass
 
         try:
-            loader._delivered.emit(
+            self._emit_delivered(
                 self._make_local_key(actual_stamp),
                 image,
-                self._rel,
             )
         except RuntimeError:  # pragma: no cover - race with QObject deletion
             pass
@@ -191,7 +191,7 @@ class ThumbnailJob(QRunnable):
             try:
                 # Use 0 as stamp for missing files, though the loader will just use the base key
                 key = self._make_local_key(0)
-                loader._delivered.emit(key, None, self._rel)
+                self._emit_delivered(key, None)
             except RuntimeError:  # pragma: no cover - race with QObject deletion
                 pass
 
@@ -200,13 +200,32 @@ class ThumbnailJob(QRunnable):
         loader = getattr(self, "_loader", None)
         if loader:
             try:
-                loader._validation_success.emit(self._make_local_key(stamp))
+                key = self._make_local_key(stamp)
+                if self._generation_token is None:
+                    loader._validation_success.emit(key)
+                else:
+                    loader._validation_success.emit(key, self._generation_token)
             except RuntimeError:
                 # pragma: no cover - race with QObject deletion
                 pass
             except AttributeError:
                 # The loader may have been deleted or not fully initialized; safe to ignore.
                 pass
+
+    def _emit_delivered(
+        self,
+        key: Tuple[str, str, int, int, int],
+        image: Optional[QImage],
+    ) -> None:
+        """Emit a result using the receiver's generation-aware signal shape."""
+
+        loader = getattr(self, "_loader", None)
+        if loader is None:
+            return
+        if self._generation_token is None:
+            loader._delivered.emit(key, image, self._rel)
+        else:
+            loader._delivered.emit(key, image, self._rel, self._generation_token)
 
     def _render_media(self) -> Optional[QImage]:  # pragma: no cover - worker helper
         if self._is_video:

--- a/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
@@ -13,16 +13,20 @@ All public symbols are re-exported here for backward compatibility.
 
 from __future__ import annotations
 
-from collections import OrderedDict, deque
-from enum import IntEnum
 import logging
 import os
+import threading
+import weakref
+from collections import OrderedDict, deque
+from collections.abc import Callable, Iterable
+from enum import IntEnum
 from pathlib import Path
 from typing import Dict, Optional, Set, Tuple
 
 from PySide6.QtCore import (
     QCoreApplication,
     QObject,
+    QRunnable,
     QSize,
     QThreadPool,
     Signal,
@@ -34,15 +38,40 @@ from ....utils.pathutils import ensure_work_dir
 # Re-exported names – keep every symbol that downstream code may import
 # from ``iPhoto.gui.ui.tasks.thumbnail_loader``.
 from .thumbnail_cache import (  # noqa: F401
+    CacheCleanupTarget,
     generate_cache_path,
     remove_cache_versions,
+    remove_cache_versions_many,
     safe_unlink,
     stat_mtime_ns,
 )
 from .thumbnail_job import ThumbnailJob  # noqa: F401
 
-
 LOGGER = logging.getLogger(__name__)
+
+
+class _ThumbnailCacheCleanupJob(QRunnable):
+    """Low-priority batch cleanup that never scans the cache on the GUI path."""
+
+    def __init__(
+        self,
+        library_root: Path,
+        targets: Iterable[CacheCleanupTarget],
+    ) -> None:
+        super().__init__()
+        self._library_root = library_root
+        self._targets = tuple(
+            CacheCleanupTarget(
+                target.abs_path,
+                QSize(target.size.width(), target.size.height()),
+                target.keep_stamp,
+                target.unlink_candidate,
+            )
+            for target in targets
+        )
+
+    def run(self) -> None:  # pragma: no cover - executed in worker thread
+        remove_cache_versions_many(self._library_root, self._targets)
 
 
 class ThumbnailLoader(QObject):
@@ -85,6 +114,8 @@ class ThumbnailLoader(QObject):
         self._album_root_str: Optional[str] = None
         self._album_generation = 0
         self._rel_generations: Dict[str, int] = {}
+        self._generation_lock = threading.RLock()
+        self._evicted_rels: set[str] = set()
 
         self._memory: OrderedDict[Tuple[str, str, int, int], Tuple[int, QPixmap]] = OrderedDict()
         self._max_memory_items = 500
@@ -117,7 +148,8 @@ class ThumbnailLoader(QObject):
         self._validation_success.connect(self._handle_validation_success)
 
     def shutdown(self) -> None:
-        self._album_generation += 1
+        with self._generation_lock:
+            self._album_generation += 1
         self._pending_deque.clear()
         self._pending_keys.clear()
         self._pool.waitForDone()
@@ -135,8 +167,10 @@ class ThumbnailLoader(QObject):
     def reset_for_album(self, root: Path) -> None:
         if self._album_root and self._album_root == root:
             return
-        self._album_generation += 1
-        self._rel_generations.clear()
+        with self._generation_lock:
+            self._album_generation += 1
+            self._rel_generations.clear()
+            self._evicted_rels.clear()
         self._album_root = root
         self._album_root_str = str(root.resolve())
         self._memory.clear()
@@ -179,6 +213,8 @@ class ThumbnailLoader(QObject):
     ) -> Optional[QPixmap]:
         if self._album_root is None or self._album_root_str is None:
             return None
+
+        self._reactivate_evicted_rel(rel)
 
         # Fallback to album_root if library_root is not set
         lib_root = self._library_root if self._library_root else self._album_root
@@ -406,7 +442,24 @@ class ThumbnailLoader(QObject):
         self._drain_queue()
 
     def _generation_token(self, rel: str) -> tuple[int, int]:
-        return self._album_generation, self._rel_generations.get(rel, 0)
+        with self._generation_lock:
+            return self._album_generation, self._rel_generations.get(rel, 0)
+
+    def _advance_rel_generation(self, rel: str) -> tuple[int, int]:
+        """Advance one rel generation and return its new token."""
+
+        with self._generation_lock:
+            self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+            return self._album_generation, self._rel_generations[rel]
+
+    def _reactivate_evicted_rel(self, rel: str) -> None:
+        """Cancel deferred deletion when a removed path is requested again."""
+
+        with self._generation_lock:
+            if rel not in self._evicted_rels:
+                return
+            self._evicted_rels.discard(rel)
+            self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
 
     def _is_current_generation(
         self,
@@ -434,50 +487,94 @@ class ThumbnailLoader(QObject):
             return
 
         base_key = self._base_key(rel, QSize(512, 512))
-        if base_key not in self._memory:
-            # The stale stamp is unavailable, so the accepted replacement job
-            # will prune sibling disk versions once, not on every cache load.
-            self._disk_prune_needed.add(base_key)
-        self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+        # The current generation owns final disk reconciliation.  This also
+        # covers a stale active job that writes after invalidation.
+        self._disk_prune_needed.add(base_key)
+        self._advance_rel_generation(rel)
         self._clear_rel_request_state(rel)
 
     def evict(self, rel: str, abs_path: Path) -> None:
-        """Remove all known memory and disk cache state for a deleted asset."""
+        """Evict one deleted asset via the batch/background cleanup path."""
+
+        self.evict_many([(rel, abs_path)])
+
+    def evict_many(self, entries: Iterable[tuple[str, Path]]) -> None:
+        """Evict deleted assets without scanning the disk cache on the caller.
+
+        Memory and request state are removed synchronously so stale pixmaps
+        cannot be reused.  All disk selectors are then handled by one
+        low-priority worker and one thumbnail-directory scan.
+        """
 
         if self._album_root is None:
             return
 
-        self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
-        library_root = self._library_root or self._album_root
-        matching_entries = [key for key in self._memory if key[1] == rel]
-        cached_sizes = {(512, 512)}
-        cached_sizes.update((key[2], key[3]) for key in matching_entries)
-        for key in matching_entries:
-            self._memory.pop(key, None)
-        for width, height in cached_sizes:
-            remove_cache_versions(
-                library_root,
-                abs_path,
-                QSize(width, height),
-            )
-        self._disk_prune_needed = {
-            key for key in self._disk_prune_needed if key[1] != rel
-        }
+        removed_by_rel = dict(entries)
+        if not removed_by_rel:
+            return
 
-        self._clear_rel_request_state(rel)
+        removed_rels = set(removed_by_rel)
+        generation_tokens: dict[str, tuple[int, int]] = {}
+        with self._generation_lock:
+            for rel in removed_rels:
+                self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+                self._evicted_rels.add(rel)
+                generation_tokens[rel] = (
+                    self._album_generation,
+                    self._rel_generations[rel],
+                )
+
+        library_root = self._library_root or self._album_root
+        cached_sizes_by_rel = {
+            rel: {(512, 512)}
+            for rel in removed_rels
+        }
+        for key in list(self._memory):
+            rel = key[1]
+            if rel not in removed_rels:
+                continue
+            cached_sizes_by_rel[rel].add((key[2], key[3]))
+            self._memory.pop(key, None)
+
+        self._disk_prune_needed = {
+            key for key in self._disk_prune_needed if key[1] not in removed_rels
+        }
+        self._clear_rels_request_state(removed_rels)
+
+        cleanup_targets = [
+            CacheCleanupTarget(
+                removed_by_rel[rel],
+                QSize(width, height),
+                unlink_candidate=self._generation_guarded_unlink(
+                    rel,
+                    generation_tokens[rel],
+                ),
+            )
+            for rel, sizes in cached_sizes_by_rel.items()
+            for width, height in sizes
+        ]
+        self._schedule_cache_cleanup(library_root, cleanup_targets)
 
     def _clear_rel_request_state(self, rel: str) -> None:
         """Drop queued and terminal request state for one relative path."""
 
-        self._pending_keys = {k for k in self._pending_keys if k[1] != rel}
-        self._failures = {k for k in self._failures if k[1] != rel}
-        self._missing = {k for k in self._missing if k[1] != rel}
-        self._failure_counts = {k: v for k, v in self._failure_counts.items() if k[1] != rel}
-        self._job_specs = {k: v for k, v in self._job_specs.items() if k[1] != rel}
-        # Remove jobs for the invalidated rel from the pending deque to avoid zombie entries
+        self._clear_rels_request_state({rel})
+
+    def _clear_rels_request_state(self, rels: set[str]) -> None:
+        """Batch-drop queued and terminal request state for relative paths."""
+
+        self._pending_keys = {k for k in self._pending_keys if k[1] not in rels}
+        self._failures = {k for k in self._failures if k[1] not in rels}
+        self._missing = {k for k in self._missing if k[1] not in rels}
+        self._failure_counts = {
+            k: v for k, v in self._failure_counts.items() if k[1] not in rels
+        }
+        self._job_specs = {
+            k: v for k, v in self._job_specs.items() if k[1] not in rels
+        }
         self._pending_deque = deque(
             (key, job) for key, job in self._pending_deque
-            if key[1] != rel
+            if key[1] not in rels
         )
 
     def _discard_stale_cache_result(
@@ -486,17 +583,19 @@ class ThumbnailLoader(QObject):
         stamp: int,
         cache_path: Path | None,
     ) -> None:
-        """Delete a stale job's disk output when it cannot be current data."""
+        """Reconcile stale output without racing a current generation writer."""
 
         if cache_path is None:
+            return
+        # A current replacement owns sibling pruning after it is accepted.
+        # Never unlink a final path that its writer may still be replacing.
+        if base_key in self._pending_keys or base_key in self._job_specs:
+            self._disk_prune_needed.add(base_key)
             return
         current_entry = self._memory.get(base_key)
         if current_entry is not None:
             if current_entry[0] != stamp:
                 safe_unlink(cache_path)
-            return
-        # A replacement job will prune sibling versions when it is accepted.
-        if base_key in self._pending_keys or base_key in self._job_specs:
             return
         safe_unlink(cache_path)
 
@@ -524,14 +623,54 @@ class ThumbnailLoader(QObject):
 
         if spec is None or base_key not in self._disk_prune_needed:
             return
-        _, abs_path, size, _, _, library_root, *_ = spec
-        remove_cache_versions(
-            library_root,
-            abs_path,
-            size,
-            keep_stamp=current_stamp,
-        )
+        rel, abs_path, size, _, _, library_root, *_, generation_token = spec
         self._disk_prune_needed.discard(base_key)
+        self._schedule_cache_cleanup(
+            library_root,
+            [
+                CacheCleanupTarget(
+                    abs_path,
+                    size,
+                    current_stamp,
+                    self._generation_guarded_unlink(rel, generation_token),
+                )
+            ],
+        )
+
+    def _generation_guarded_unlink(
+        self,
+        rel: str,
+        generation_token: object,
+    ) -> Callable[[Path], None]:
+        """Return an unlink operation owned by one loader generation."""
+
+        loader_ref = weakref.ref(self)
+        expected_rel_generation = (
+            generation_token[1]
+            if isinstance(generation_token, tuple) and len(generation_token) == 2
+            else generation_token
+        )
+
+        def unlink_if_current(candidate: Path) -> None:
+            loader = loader_ref()
+            if loader is None:
+                safe_unlink(candidate)
+                return
+            with loader._generation_lock:
+                if loader._rel_generations.get(rel, 0) == expected_rel_generation:
+                    safe_unlink(candidate)
+
+        return unlink_if_current
+
+    def _schedule_cache_cleanup(
+        self,
+        library_root: Path,
+        targets: Iterable[CacheCleanupTarget],
+    ) -> None:
+        """Run cache pruning off the GUI thread at low priority."""
+
+        job = _ThumbnailCacheCleanupJob(library_root, targets)
+        self._pool.start(job, int(self.Priority.LOW))
 
     def _retry_after_failure(
         self,

--- a/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
@@ -33,7 +33,12 @@ from ....utils.pathutils import ensure_work_dir
 
 # Re-exported names – keep every symbol that downstream code may import
 # from ``iPhoto.gui.ui.tasks.thumbnail_loader``.
-from .thumbnail_cache import safe_unlink, stat_mtime_ns, generate_cache_path  # noqa: F401
+from .thumbnail_cache import (  # noqa: F401
+    generate_cache_path,
+    remove_cache_versions,
+    safe_unlink,
+    stat_mtime_ns,
+)
 from .thumbnail_job import ThumbnailJob  # noqa: F401
 
 
@@ -45,7 +50,7 @@ class ThumbnailLoader(QObject):
 
     ready = Signal(Path, str, QPixmap)
     cache_written = Signal(Path)
-    _delivered = Signal(object, object, str, object)
+    _delivered = Signal(object, object, str, object, object)
     _validation_success = Signal(object, object)
 
     class Priority(IntEnum):
@@ -90,6 +95,7 @@ class ThumbnailLoader(QObject):
         self._failures: Set[Tuple[str, str, int, int]] = set()
         self._missing: Set[Tuple[str, str, int, int]] = set()
         self._failure_counts: Dict[Tuple[str, str, int, int], int] = {}
+        self._disk_prune_needed: Set[Tuple[str, str, int, int]] = set()
         self._job_specs: Dict[
             Tuple[str, str, int, int],
             Tuple[
@@ -139,6 +145,7 @@ class ThumbnailLoader(QObject):
         self._failures.clear()
         self._missing.clear()
         self._failure_counts.clear()
+        self._disk_prune_needed.clear()
         self._job_specs.clear()
 
         # Ensure the thumbnail directory exists in the library root (if set)
@@ -335,12 +342,14 @@ class ThumbnailLoader(QObject):
         image: Optional[QImage],
         rel: str,
         generation_token: object | None = None,
+        cache_path: Path | None = None,
     ) -> None:
         base_key = full_key[:-1]
         stamp = full_key[-1]
 
         self._active_jobs_count = max(0, self._active_jobs_count - 1)
         if not self._is_current_generation(base_key, rel, generation_token):
+            self._discard_stale_cache_result(base_key, stamp, cache_path)
             self._drain_queue()
             return
 
@@ -369,6 +378,7 @@ class ThumbnailLoader(QObject):
             return
 
         self._failure_counts.pop(base_key, None)
+        self._remove_superseded_cache_versions(base_key, spec, stamp)
         self._job_specs.pop(base_key, None)
         self._memory[base_key] = (stamp, pixmap)
 
@@ -391,6 +401,8 @@ class ThumbnailLoader(QObject):
             self._drain_queue()
             return
         self._pending_keys.discard(base_key)
+        spec = self._job_specs.pop(base_key, None)
+        self._remove_superseded_cache_versions(base_key, spec, full_key[-1])
         self._drain_queue()
 
     def _generation_token(self, rel: str) -> tuple[int, int]:
@@ -411,22 +423,51 @@ class ThumbnailLoader(QObject):
         )
 
     def invalidate(self, rel: str) -> None:
+        """Invalidate in-flight work while preserving a stale cached thumbnail.
+
+        Keeping the memory entry lets the next request display the existing
+        pixmap immediately and pass its stamp to ``ThumbnailJob``.  The job can
+        then remove the old stamp-addressed disk file if the media changed.
+        """
+
+        if self._album_root is None:
+            return
+
+        base_key = self._base_key(rel, QSize(512, 512))
+        if base_key not in self._memory:
+            # The stale stamp is unavailable, so the accepted replacement job
+            # will prune sibling disk versions once, not on every cache load.
+            self._disk_prune_needed.add(base_key)
+        self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+        self._clear_rel_request_state(rel)
+
+    def evict(self, rel: str, abs_path: Path) -> None:
+        """Remove all known memory and disk cache state for a deleted asset."""
+
         if self._album_root is None:
             return
 
         self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
-        to_remove = [k for k in self._memory if k[1] == rel]
+        library_root = self._library_root or self._album_root
+        matching_entries = [key for key in self._memory if key[1] == rel]
+        cached_sizes = {(512, 512)}
+        cached_sizes.update((key[2], key[3]) for key in matching_entries)
+        for key in matching_entries:
+            self._memory.pop(key, None)
+        for width, height in cached_sizes:
+            remove_cache_versions(
+                library_root,
+                abs_path,
+                QSize(width, height),
+            )
+        self._disk_prune_needed = {
+            key for key in self._disk_prune_needed if key[1] != rel
+        }
 
-        for k in to_remove:
-            entry = self._memory.pop(k, None)
-            if entry:
-                stamp, pixmap = entry
-                del pixmap
-                # We intentionally do not delete the disk cache here.
-                # Invalidation primarily means "clear from memory and force a check".
-                # If the disk file is stale, ThumbnailJob will detect the timestamp mismatch
-                # and clean it up. If the disk file is still valid (e.g. invalidation triggered
-                # by a false alarm or metadata update), we want to reuse it.
+        self._clear_rel_request_state(rel)
+
+    def _clear_rel_request_state(self, rel: str) -> None:
+        """Drop queued and terminal request state for one relative path."""
 
         self._pending_keys = {k for k in self._pending_keys if k[1] != rel}
         self._failures = {k for k in self._failures if k[1] != rel}
@@ -438,6 +479,59 @@ class ThumbnailLoader(QObject):
             (key, job) for key, job in self._pending_deque
             if key[1] != rel
         )
+
+    def _discard_stale_cache_result(
+        self,
+        base_key: Tuple[str, str, int, int],
+        stamp: int,
+        cache_path: Path | None,
+    ) -> None:
+        """Delete a stale job's disk output when it cannot be current data."""
+
+        if cache_path is None:
+            return
+        current_entry = self._memory.get(base_key)
+        if current_entry is not None:
+            if current_entry[0] != stamp:
+                safe_unlink(cache_path)
+            return
+        # A replacement job will prune sibling versions when it is accepted.
+        if base_key in self._pending_keys or base_key in self._job_specs:
+            return
+        safe_unlink(cache_path)
+
+    def _remove_superseded_cache_versions(
+        self,
+        base_key: Tuple[str, str, int, int],
+        spec: Optional[
+            Tuple[
+                str,
+                Path,
+                QSize,
+                Optional[int],
+                Path,
+                Path,
+                bool,
+                bool,
+                Optional[float],
+                Optional[float],
+                object,
+            ]
+        ],
+        current_stamp: int,
+    ) -> None:
+        """Remove orphaned disk versions after accepting a current job."""
+
+        if spec is None or base_key not in self._disk_prune_needed:
+            return
+        _, abs_path, size, _, _, library_root, *_ = spec
+        remove_cache_versions(
+            library_root,
+            abs_path,
+            size,
+            keep_stamp=current_stamp,
+        )
+        self._disk_prune_needed.discard(base_key)
 
     def _retry_after_failure(
         self,

--- a/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
@@ -25,7 +25,6 @@ from PySide6.QtCore import (
     QObject,
     QSize,
     QThreadPool,
-    Qt,
     Signal,
 )
 from PySide6.QtGui import QImage, QPixmap
@@ -46,8 +45,8 @@ class ThumbnailLoader(QObject):
 
     ready = Signal(Path, str, QPixmap)
     cache_written = Signal(Path)
-    _delivered = Signal(object, object, str)
-    _validation_success = Signal(object)
+    _delivered = Signal(object, object, str, object)
+    _validation_success = Signal(object, object)
 
     class Priority(IntEnum):
         """
@@ -79,6 +78,8 @@ class ThumbnailLoader(QObject):
 
         self._album_root: Optional[Path] = None
         self._album_root_str: Optional[str] = None
+        self._album_generation = 0
+        self._rel_generations: Dict[str, int] = {}
 
         self._memory: OrderedDict[Tuple[str, str, int, int], Tuple[int, QPixmap]] = OrderedDict()
         self._max_memory_items = 500
@@ -102,6 +103,7 @@ class ThumbnailLoader(QObject):
                 bool,
                 Optional[float],
                 Optional[float],
+                object,
             ],
         ] = {}
 
@@ -109,6 +111,7 @@ class ThumbnailLoader(QObject):
         self._validation_success.connect(self._handle_validation_success)
 
     def shutdown(self) -> None:
+        self._album_generation += 1
         self._pending_deque.clear()
         self._pending_keys.clear()
         self._pool.waitForDone()
@@ -126,6 +129,8 @@ class ThumbnailLoader(QObject):
     def reset_for_album(self, root: Path) -> None:
         if self._album_root and self._album_root == root:
             return
+        self._album_generation += 1
+        self._rel_generations.clear()
         self._album_root = root
         self._album_root_str = str(root.resolve())
         self._memory.clear()
@@ -173,6 +178,7 @@ class ThumbnailLoader(QObject):
 
         fixed_size = QSize(512, 512)
         base_key = self._base_key(rel, fixed_size)
+        generation_token = self._generation_token(rel)
 
         if base_key in self._missing:
             return None
@@ -204,6 +210,7 @@ class ThumbnailLoader(QObject):
             is_video,
             still_image_time,
             duration,
+            generation_token,
         )
 
         self._store_job_spec(
@@ -218,6 +225,7 @@ class ThumbnailLoader(QObject):
             is_video,
             still_image_time,
             duration,
+            generation_token,
         )
 
         self._schedule_job(base_key, job)
@@ -257,6 +265,7 @@ class ThumbnailLoader(QObject):
         is_video: bool,
         still_image_time: Optional[float],
         duration: Optional[float],
+        generation_token: object,
     ) -> None:
         self._job_specs[base_key] = (
             rel,
@@ -269,6 +278,7 @@ class ThumbnailLoader(QObject):
             is_video,
             still_image_time,
             duration,
+            generation_token,
         )
 
     def _create_job_from_spec(
@@ -283,6 +293,7 @@ class ThumbnailLoader(QObject):
         is_video: bool,
         still_image_time: Optional[float],
         duration: Optional[float],
+        generation_token: object,
     ) -> ThumbnailJob:
         return ThumbnailJob(
             self,
@@ -296,6 +307,7 @@ class ThumbnailLoader(QObject):
             is_video=is_video,
             still_image_time=still_image_time,
             duration=duration,
+            generation_token=generation_token,
         )
 
     def _record_terminal_failure(
@@ -322,11 +334,16 @@ class ThumbnailLoader(QObject):
         full_key: Tuple[str, str, int, int, int],
         image: Optional[QImage],
         rel: str,
+        generation_token: object | None = None,
     ) -> None:
         base_key = full_key[:-1]
         stamp = full_key[-1]
 
         self._active_jobs_count = max(0, self._active_jobs_count - 1)
+        if not self._is_current_generation(base_key, rel, generation_token):
+            self._drain_queue()
+            return
+
         self._pending_keys.discard(base_key)
         spec = self._job_specs.get(base_key)
 
@@ -363,18 +380,41 @@ class ThumbnailLoader(QObject):
 
         self._drain_queue()
 
-    def _handle_validation_success(self, full_key: Tuple[str, str, int, int, int]) -> None:
+    def _handle_validation_success(
+        self,
+        full_key: Tuple[str, str, int, int, int],
+        generation_token: object | None = None,
+    ) -> None:
         base_key = full_key[:-1]
         self._active_jobs_count = max(0, self._active_jobs_count - 1)
+        if not self._is_current_generation(base_key, base_key[1], generation_token):
+            self._drain_queue()
+            return
         self._pending_keys.discard(base_key)
         self._drain_queue()
 
+    def _generation_token(self, rel: str) -> tuple[int, int]:
+        return self._album_generation, self._rel_generations.get(rel, 0)
 
+    def _is_current_generation(
+        self,
+        base_key: Tuple[str, str, int, int],
+        rel: str,
+        generation_token: object | None,
+    ) -> bool:
+        if generation_token is None:
+            return True
+        return (
+            self._album_root_str is not None
+            and base_key[0] == self._album_root_str
+            and generation_token == self._generation_token(rel)
+        )
 
     def invalidate(self, rel: str) -> None:
         if self._album_root is None:
             return
 
+        self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
         to_remove = [k for k in self._memory if k[1] == rel]
 
         for k in to_remove:
@@ -415,6 +455,7 @@ class ThumbnailLoader(QObject):
                 bool,
                 Optional[float],
                 Optional[float],
+                object,
             ]
         ],
     ) -> bool:
@@ -460,6 +501,7 @@ class ThumbnailLoader(QObject):
             is_video,
             still_image_time,
             duration,
+            generation_token,
         ) = spec
 
         retry_rel = stored_rel if stored_rel is not None else rel
@@ -481,6 +523,7 @@ class ThumbnailLoader(QObject):
             is_video,
             still_image_time,
             duration,
+            generation_token,
         )
 
         self._store_job_spec(
@@ -495,6 +538,7 @@ class ThumbnailLoader(QObject):
             is_video,
             still_image_time,
             duration,
+            generation_token,
         )
 
         self._schedule_job(base_key, retry_job)

--- a/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
+++ b/src/iPhoto/gui/ui/tasks/thumbnail_loader.py
@@ -19,6 +19,7 @@ import threading
 import weakref
 from collections import OrderedDict, deque
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
 from typing import Dict, Optional, Set, Tuple
@@ -29,6 +30,7 @@ from PySide6.QtCore import (
     QRunnable,
     QSize,
     QThreadPool,
+    QTimer,
     Signal,
 )
 from PySide6.QtGui import QImage, QPixmap
@@ -50,6 +52,23 @@ from .thumbnail_job import ThumbnailJob  # noqa: F401
 LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class _CacheCleanupOwnershipToken:
+    """Root activation and rel generation that own a deferred unlink."""
+
+    root_identity: str
+    root_epoch: int
+    rel_generation: int
+    rel_state: "_CacheCleanupRelState"
+
+
+@dataclass(slots=True)
+class _CacheCleanupRelState:
+    """Mutable generation state shared with cleanup guards for one rel."""
+
+    generation: int = 0
+
+
 class _ThumbnailCacheCleanupJob(QRunnable):
     """Low-priority batch cleanup that never scans the cache on the GUI path."""
 
@@ -57,6 +76,7 @@ class _ThumbnailCacheCleanupJob(QRunnable):
         self,
         library_root: Path,
         targets: Iterable[CacheCleanupTarget],
+        finished: Callable[[], None],
     ) -> None:
         super().__init__()
         self._library_root = library_root
@@ -69,9 +89,16 @@ class _ThumbnailCacheCleanupJob(QRunnable):
             )
             for target in targets
         )
+        self._finished = finished
 
     def run(self) -> None:  # pragma: no cover - executed in worker thread
-        remove_cache_versions_many(self._library_root, self._targets)
+        try:
+            remove_cache_versions_many(self._library_root, self._targets)
+        finally:
+            try:
+                self._finished()
+            except RuntimeError:
+                pass
 
 
 class ThumbnailLoader(QObject):
@@ -81,6 +108,9 @@ class ThumbnailLoader(QObject):
     cache_written = Signal(Path)
     _delivered = Signal(object, object, str, object, object)
     _validation_success = Signal(object, object)
+    _cache_cleanup_finished = Signal()
+
+    CACHE_CLEANUP_DEBOUNCE_MS = 100
 
     class Priority(IntEnum):
         """
@@ -116,6 +146,9 @@ class ThumbnailLoader(QObject):
         self._rel_generations: Dict[str, int] = {}
         self._generation_lock = threading.RLock()
         self._evicted_rels: set[str] = set()
+        self._root_activation_epochs: dict[str, int] = {}
+        self._active_root_epoch = 0
+        self._cleanup_rel_states: dict[str, _CacheCleanupRelState] = {}
 
         self._memory: OrderedDict[Tuple[str, str, int, int], Tuple[int, QPixmap]] = OrderedDict()
         self._max_memory_items = 500
@@ -144,14 +177,32 @@ class ThumbnailLoader(QObject):
             ],
         ] = {}
 
+        self._pending_cache_cleanup_targets: dict[
+            str,
+            tuple[Path, dict[tuple[str, int, int], CacheCleanupTarget]],
+        ] = {}
+        self._active_cache_cleanup_jobs = 0
+        self._cache_cleanup_timer = QTimer(self)
+        self._cache_cleanup_timer.setSingleShot(True)
+        self._cache_cleanup_timer.setInterval(self.CACHE_CLEANUP_DEBOUNCE_MS)
+        self._cache_cleanup_timer.timeout.connect(self._flush_cache_cleanup)
+
         self._delivered.connect(self._handle_result)
         self._validation_success.connect(self._handle_validation_success)
+        self._cache_cleanup_finished.connect(self._handle_cache_cleanup_finished)
 
     def shutdown(self) -> None:
         with self._generation_lock:
             self._album_generation += 1
         self._pending_deque.clear()
         self._pending_keys.clear()
+        self._cache_cleanup_timer.stop()
+        self._flush_cache_cleanup()
+        self._pool.waitForDone()
+        # A batch may have accumulated while a previous cleanup was active.
+        self._active_jobs_count = 0
+        self._active_cache_cleanup_jobs = 0
+        self._flush_cache_cleanup()
         self._pool.waitForDone()
 
     def set_library_root(self, root: Path) -> None:
@@ -167,12 +218,18 @@ class ThumbnailLoader(QObject):
     def reset_for_album(self, root: Path) -> None:
         if self._album_root and self._album_root == root:
             return
+        root_identity = str(root.resolve())
         with self._generation_lock:
             self._album_generation += 1
             self._rel_generations.clear()
             self._evicted_rels.clear()
+            self._cleanup_rel_states.clear()
+            self._active_root_epoch = (
+                self._root_activation_epochs.get(root_identity, 0) + 1
+            )
+            self._root_activation_epochs[root_identity] = self._active_root_epoch
         self._album_root = root
-        self._album_root_str = str(root.resolve())
+        self._album_root_str = root_identity
         self._memory.clear()
         self._pending_deque.clear()
         self._pending_keys.clear()
@@ -450,6 +507,7 @@ class ThumbnailLoader(QObject):
 
         with self._generation_lock:
             self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+            self._advance_cleanup_rel_generation_locked(rel)
             return self._album_generation, self._rel_generations[rel]
 
     def _reactivate_evicted_rel(self, rel: str) -> None:
@@ -460,6 +518,36 @@ class ThumbnailLoader(QObject):
                 return
             self._evicted_rels.discard(rel)
             self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+            self._advance_cleanup_rel_generation_locked(rel)
+
+    def _cleanup_rel_state_locked(self, rel: str) -> _CacheCleanupRelState:
+        state = self._cleanup_rel_states.get(rel)
+        if state is None:
+            state = _CacheCleanupRelState()
+            self._cleanup_rel_states[rel] = state
+        return state
+
+    def _advance_cleanup_rel_generation_locked(self, rel: str) -> int:
+        state = self._cleanup_rel_state_locked(rel)
+        state.generation += 1
+        return state.generation
+
+    def _cleanup_ownership_token_locked(
+        self,
+        rel: str,
+    ) -> _CacheCleanupOwnershipToken:
+        assert self._album_root_str is not None
+        state = self._cleanup_rel_state_locked(rel)
+        return _CacheCleanupOwnershipToken(
+            self._album_root_str,
+            self._active_root_epoch,
+            state.generation,
+            state,
+        )
+
+    def _cleanup_ownership_token(self, rel: str) -> _CacheCleanupOwnershipToken:
+        with self._generation_lock:
+            return self._cleanup_ownership_token_locked(rel)
 
     def _is_current_generation(
         self,
@@ -487,9 +575,11 @@ class ThumbnailLoader(QObject):
             return
 
         base_key = self._base_key(rel, QSize(512, 512))
-        # The current generation owns final disk reconciliation.  This also
-        # covers a stale active job that writes after invalidation.
-        self._disk_prune_needed.add(base_key)
+        if base_key not in self._memory:
+            # Without a known stamp, let the accepted generation reconcile
+            # unknown siblings.  A stale active result can also set this flag
+            # later if it finishes while its replacement is pending.
+            self._disk_prune_needed.add(base_key)
         self._advance_rel_generation(rel)
         self._clear_rel_request_state(rel)
 
@@ -514,15 +604,13 @@ class ThumbnailLoader(QObject):
             return
 
         removed_rels = set(removed_by_rel)
-        generation_tokens: dict[str, tuple[int, int]] = {}
+        cleanup_tokens: dict[str, _CacheCleanupOwnershipToken] = {}
         with self._generation_lock:
             for rel in removed_rels:
                 self._rel_generations[rel] = self._rel_generations.get(rel, 0) + 1
+                self._advance_cleanup_rel_generation_locked(rel)
                 self._evicted_rels.add(rel)
-                generation_tokens[rel] = (
-                    self._album_generation,
-                    self._rel_generations[rel],
-                )
+                cleanup_tokens[rel] = self._cleanup_ownership_token_locked(rel)
 
         library_root = self._library_root or self._album_root
         cached_sizes_by_rel = {
@@ -546,8 +634,7 @@ class ThumbnailLoader(QObject):
                 removed_by_rel[rel],
                 QSize(width, height),
                 unlink_candidate=self._generation_guarded_unlink(
-                    rel,
-                    generation_tokens[rel],
+                    cleanup_tokens[rel],
                 ),
             )
             for rel, sizes in cached_sizes_by_rel.items()
@@ -623,7 +710,7 @@ class ThumbnailLoader(QObject):
 
         if spec is None or base_key not in self._disk_prune_needed:
             return
-        rel, abs_path, size, _, _, library_root, *_, generation_token = spec
+        rel, abs_path, size, _, _, library_root, *_ = spec
         self._disk_prune_needed.discard(base_key)
         self._schedule_cache_cleanup(
             library_root,
@@ -632,24 +719,20 @@ class ThumbnailLoader(QObject):
                     abs_path,
                     size,
                     current_stamp,
-                    self._generation_guarded_unlink(rel, generation_token),
+                    self._generation_guarded_unlink(
+                        self._cleanup_ownership_token(rel),
+                    ),
                 )
             ],
         )
 
     def _generation_guarded_unlink(
         self,
-        rel: str,
-        generation_token: object,
+        ownership_token: _CacheCleanupOwnershipToken,
     ) -> Callable[[Path], None]:
-        """Return an unlink operation owned by one loader generation."""
+        """Return an unlink operation owned by one root activation and rel."""
 
         loader_ref = weakref.ref(self)
-        expected_rel_generation = (
-            generation_token[1]
-            if isinstance(generation_token, tuple) and len(generation_token) == 2
-            else generation_token
-        )
 
         def unlink_if_current(candidate: Path) -> None:
             loader = loader_ref()
@@ -657,7 +740,15 @@ class ThumbnailLoader(QObject):
                 safe_unlink(candidate)
                 return
             with loader._generation_lock:
-                if loader._rel_generations.get(rel, 0) == expected_rel_generation:
+                root_epoch = loader._root_activation_epochs.get(
+                    ownership_token.root_identity,
+                    0,
+                )
+                if (
+                    root_epoch == ownership_token.root_epoch
+                    and ownership_token.rel_state.generation
+                    == ownership_token.rel_generation
+                ):
                     safe_unlink(candidate)
 
         return unlink_if_current
@@ -667,10 +758,57 @@ class ThumbnailLoader(QObject):
         library_root: Path,
         targets: Iterable[CacheCleanupTarget],
     ) -> None:
-        """Run cache pruning off the GUI thread at low priority."""
+        """Accumulate cache pruning until a quiet window, then scan once."""
 
-        job = _ThumbnailCacheCleanupJob(library_root, targets)
-        self._pool.start(job, int(self.Priority.LOW))
+        root_identity = str(library_root)
+        root, pending_targets = self._pending_cache_cleanup_targets.setdefault(
+            root_identity,
+            (library_root, {}),
+        )
+        for target in targets:
+            target_key = (
+                str(target.abs_path),
+                target.size.width(),
+                target.size.height(),
+            )
+            pending_targets[target_key] = target
+        self._pending_cache_cleanup_targets[root_identity] = (root, pending_targets)
+        if self._active_cache_cleanup_jobs == 0:
+            self._cache_cleanup_timer.start()
+
+    def _flush_cache_cleanup(self) -> None:
+        """Start one cleanup scan per library root for the accumulated batch."""
+
+        if self._active_cache_cleanup_jobs > 0 or not self._pending_cache_cleanup_targets:
+            return
+        if self._active_jobs_count > 0:
+            # Validation/render results can keep adding targets.  Wait until
+            # that thumbnail wave settles so it produces one directory scan.
+            self._cache_cleanup_timer.start()
+            return
+        batches = tuple(self._pending_cache_cleanup_targets.values())
+        self._pending_cache_cleanup_targets.clear()
+        self._active_cache_cleanup_jobs = len(batches)
+        for library_root, targets in batches:
+            job = _ThumbnailCacheCleanupJob(
+                library_root,
+                targets.values(),
+                self._cache_cleanup_finished.emit,
+            )
+            self._pool.start(job, int(self.Priority.LOW))
+
+    def _handle_cache_cleanup_finished(self) -> None:
+        """Serialize cleanup batches and debounce targets received meanwhile."""
+
+        self._active_cache_cleanup_jobs = max(
+            0,
+            self._active_cache_cleanup_jobs - 1,
+        )
+        if (
+            self._active_cache_cleanup_jobs == 0
+            and self._pending_cache_cleanup_targets
+        ):
+            self._cache_cleanup_timer.start()
 
     def _retry_after_failure(
         self,

--- a/src/iPhoto/gui/ui/widgets/marker_controller.py
+++ b/src/iPhoto/gui/ui/widgets/marker_controller.py
@@ -300,6 +300,8 @@ class MarkerController(QObject):
     # always-on photo clusters.
     CITY_LABEL_FETCH_LEVEL = 5
     EXACT_PROJECTION_ASSET_LIMIT = 1_000
+    DENSITY_ADAPTATION_START_ASSET_COUNT = 1_000
+    DENSITY_ADAPTATION_FULL_ASSET_COUNT = 2_000
     TARGET_VISIBLE_CLUSTERS = 160.0
     ZOOM_THRESHOLD_REFERENCE = 7.0
     MAX_ZOOM_OUT_THRESHOLD_FACTOR = 6.0
@@ -381,7 +383,10 @@ class MarkerController(QObject):
                     self._thumbnail_loader.invalidate(incoming_asset.library_relative)
             for removed_rel in existing_by_rel.keys() - incoming_rels:
                 self._current_representative_rels.discard(removed_rel)
-                self._thumbnail_loader.invalidate(removed_rel)
+                self._thumbnail_loader.evict(
+                    removed_rel,
+                    existing_by_rel[removed_rel].absolute_path,
+                )
                 self.thumbnailInvalidated.emit(removed_rel)
 
         self._assets = normalized_assets
@@ -674,11 +679,11 @@ class MarkerController(QObject):
                 self.clustersUpdated.emit([])
             return
 
-        large_library = len(self._assets) > self.EXACT_PROJECTION_ASSET_LIMIT
+        density_factor = self._density_adaptation_factor(len(self._assets))
         threshold = self._cluster_threshold(
             width,
             height,
-            density_adaptive=large_library,
+            density_factor=density_factor,
         )
         cell_size = max(math.ceil(threshold), 1)
         margin = self._marker_size
@@ -751,7 +756,7 @@ class MarkerController(QObject):
         width: int,
         height: int,
         *,
-        density_adaptive: bool = False,
+        density_factor: float = 0.0,
     ) -> float:
         """Return a zoom- and viewport-aware marker clustering radius."""
 
@@ -762,14 +767,15 @@ class MarkerController(QObject):
             2.0 ** (zoom_delta / 2.0),
         )
         threshold = base_threshold * zoom_factor
-        if not density_adaptive:
+        density_factor = min(1.0, max(0.0, float(density_factor)))
+        if density_factor <= 0.0:
             return threshold
 
         viewport_area = float(max(1, width) * max(1, height))
         density_floor = math.sqrt(
             viewport_area / self.TARGET_VISIBLE_CLUSTERS
         )
-        density_weight = min(
+        density_weight = density_factor * min(
             1.0,
             zoom_delta / self.DENSITY_FULL_EFFECT_ZOOM_DELTA,
         )
@@ -777,6 +783,18 @@ class MarkerController(QObject):
             max(base_threshold, density_floor) - base_threshold
         ) * density_weight
         return max(threshold, density_threshold)
+
+    @classmethod
+    def _density_adaptation_factor(cls, asset_count: int) -> float:
+        """Return a smooth density ramp independent of projection dispatch."""
+
+        start = cls.DENSITY_ADAPTATION_START_ASSET_COUNT
+        full = cls.DENSITY_ADAPTATION_FULL_ASSET_COUNT
+        if asset_count <= start:
+            return 0.0
+        if asset_count >= full:
+            return 1.0
+        return float(asset_count - start) / float(full - start)
 
     def _publish_clusters(self, clusters: list[_MarkerCluster]) -> None:
         """Publish a stable cluster snapshot to the overlay and label layers."""
@@ -787,11 +805,14 @@ class MarkerController(QObject):
         }
         for cluster in clusters:
             cluster.bounding_rect = self._marker_rect(cluster.screen_pos)
-            self._ensure_thumbnail(cluster.representative)
 
         self._clusters = clusters
         self._update_city_annotations_for_clusters(self._clusters)
         self.clustersUpdated.emit(self._clusters)
+        # Publish the cluster set before synchronous cache hits so the overlay
+        # can pin the new viewport's representatives before inserting pixmaps.
+        for cluster in self._clusters:
+            self._ensure_thumbnail(cluster.representative)
 
     def _build_exact_projection_clusters(
         self,

--- a/src/iPhoto/gui/ui/widgets/marker_controller.py
+++ b/src/iPhoto/gui/ui/widgets/marker_controller.py
@@ -286,6 +286,7 @@ class MarkerController(QObject):
     citiesUpdated = Signal(list)
     markerActivated = Signal(list)
     thumbnailUpdated = Signal(str, QPixmap)
+    thumbnailInvalidated = Signal(str)
     thumbnailsInvalidated = Signal()
     _clustering_requested = Signal(int, object, int, int, float, float, float, float, int, int)
 
@@ -299,6 +300,7 @@ class MarkerController(QObject):
     TARGET_VISIBLE_CLUSTERS = 160.0
     ZOOM_THRESHOLD_REFERENCE = 7.0
     MAX_ZOOM_OUT_THRESHOLD_FACTOR = 6.0
+    DENSITY_FULL_EFFECT_ZOOM_DELTA = 3.0
 
     def __init__(
         self,
@@ -365,10 +367,17 @@ class MarkerController(QObject):
                 asset.library_relative: asset
                 for asset in self._assets
             }
+            incoming_rels = {
+                asset.library_relative
+                for asset in normalized_assets
+            }
             for incoming_asset in normalized_assets:
                 existing_asset = existing_by_rel.get(incoming_asset.library_relative)
                 if existing_asset is not None and incoming_asset != existing_asset:
                     self._thumbnail_loader.invalidate(incoming_asset.library_relative)
+            for removed_rel in existing_by_rel.keys() - incoming_rels:
+                self._thumbnail_loader.invalidate(removed_rel)
+                self.thumbnailInvalidated.emit(removed_rel)
 
         self._assets = normalized_assets
         self._library_root = library_root
@@ -654,7 +663,12 @@ class MarkerController(QObject):
                 self.clustersUpdated.emit([])
             return
 
-        threshold = self._cluster_threshold(width, height)
+        large_library = len(self._assets) > self.EXACT_PROJECTION_ASSET_LIMIT
+        threshold = self._cluster_threshold(
+            width,
+            height,
+            density_adaptive=large_library,
+        )
         cell_size = max(math.ceil(threshold), 1)
         margin = self._marker_size
 
@@ -721,7 +735,13 @@ class MarkerController(QObject):
             )
         self._publish_clusters(clusters)
 
-    def _cluster_threshold(self, width: int, height: int) -> float:
+    def _cluster_threshold(
+        self,
+        width: int,
+        height: int,
+        *,
+        density_adaptive: bool = False,
+    ) -> float:
         """Return a zoom- and viewport-aware marker clustering radius."""
 
         base_threshold = max(self._marker_size * 0.6, 48.0)
@@ -730,11 +750,22 @@ class MarkerController(QObject):
             self.MAX_ZOOM_OUT_THRESHOLD_FACTOR,
             2.0 ** (zoom_delta / 2.0),
         )
+        threshold = base_threshold * zoom_factor
+        if not density_adaptive:
+            return threshold
+
         viewport_area = float(max(1, width) * max(1, height))
-        density_threshold = math.sqrt(
+        density_floor = math.sqrt(
             viewport_area / self.TARGET_VISIBLE_CLUSTERS
         )
-        return max(base_threshold * zoom_factor, density_threshold)
+        density_weight = min(
+            1.0,
+            zoom_delta / self.DENSITY_FULL_EFFECT_ZOOM_DELTA,
+        )
+        density_threshold = base_threshold + (
+            max(base_threshold, density_floor) - base_threshold
+        ) * density_weight
+        return max(threshold, density_threshold)
 
     def _publish_clusters(self, clusters: list[_MarkerCluster]) -> None:
         """Publish a stable cluster snapshot to the overlay and label layers."""

--- a/src/iPhoto/gui/ui/widgets/marker_controller.py
+++ b/src/iPhoto/gui/ui/widgets/marker_controller.py
@@ -27,6 +27,7 @@ class _MarkerCluster:
     latitude_sum: float = 0.0
     longitude_sum: float = 0.0
     screen_pos: QPointF = field(default_factory=QPointF)
+    representative_screen_pos_approx: Optional[QPointF] = None
     screen_x_sum: float = 0.0
     screen_y_sum: float = 0.0
     bounding_rect: QRectF = field(default_factory=QRectF)
@@ -36,6 +37,8 @@ class _MarkerCluster:
 
         if not self.assets:
             self.assets.append(self.representative)
+        if self.representative_screen_pos_approx is None:
+            self.representative_screen_pos_approx = QPointF(self.screen_pos)
         self.latitude_sum = sum(asset.latitude for asset in self.assets)
         self.longitude_sum = sum(asset.longitude for asset in self.assets)
         count = len(self.assets)
@@ -321,6 +324,7 @@ class MarkerController(QObject):
         self._assets: list[GeotaggedAsset] = []
         self._library_root: Optional[Path] = None
         self._clusters: list[_MarkerCluster] = []
+        self._current_representative_rels: set[str] = set()
         self._city_annotations: list[CityAnnotation] = []
         self._view_center_x = 0.5
         self._view_center_y = 0.5
@@ -376,12 +380,14 @@ class MarkerController(QObject):
                 if existing_asset is not None and incoming_asset != existing_asset:
                     self._thumbnail_loader.invalidate(incoming_asset.library_relative)
             for removed_rel in existing_by_rel.keys() - incoming_rels:
+                self._current_representative_rels.discard(removed_rel)
                 self._thumbnail_loader.invalidate(removed_rel)
                 self.thumbnailInvalidated.emit(removed_rel)
 
         self._assets = normalized_assets
         self._library_root = library_root
         if not same_root:
+            self._current_representative_rels.clear()
             self._city_annotations = []
             self._thumbnail_loader.reset_for_album(library_root)
             self.thumbnailsInvalidated.emit()
@@ -394,6 +400,7 @@ class MarkerController(QObject):
         self._invalidate_cluster_request()
         self._assets = []
         self._clusters = []
+        self._current_representative_rels.clear()
         self._city_annotations = []
         self._library_root = None
         self._is_panning = False
@@ -500,6 +507,8 @@ class MarkerController(QObject):
 
         if self._library_root is None or root != self._library_root:
             return
+        if rel not in self._current_representative_rels:
+            return
         if pixmap.isNull():
             return
         self.thumbnailUpdated.emit(rel, pixmap)
@@ -564,6 +573,7 @@ class MarkerController(QObject):
         if not self._assets:
             self._invalidate_cluster_request()
             self._clusters = []
+            self._current_representative_rels.clear()
             if self._city_annotations:
                 self._city_annotations = []
                 self.citiesUpdated.emit([])
@@ -658,6 +668,7 @@ class MarkerController(QObject):
         width = self._map_widget.width()
         height = self._map_widget.height()
         if width <= 0 or height <= 0:
+            self._current_representative_rels.clear()
             if self._clusters:
                 self._clusters = []
                 self.clustersUpdated.emit([])
@@ -770,6 +781,10 @@ class MarkerController(QObject):
     def _publish_clusters(self, clusters: list[_MarkerCluster]) -> None:
         """Publish a stable cluster snapshot to the overlay and label layers."""
 
+        self._current_representative_rels = {
+            cluster.representative.library_relative
+            for cluster in clusters
+        }
         for cluster in clusters:
             cluster.bounding_rect = self._marker_rect(cluster.screen_pos)
             self._ensure_thumbnail(cluster.representative)
@@ -860,19 +875,35 @@ class MarkerController(QObject):
 
         for coarse_cluster in coarse_clusters:
             representative = coarse_cluster.representative
-            point = self._map_widget.project_lonlat(
+            exact_representative = self._map_widget.project_lonlat(
                 representative.longitude,
                 representative.latitude,
             )
-            if point is None:
+            if exact_representative is None:
                 continue
-            if point.x() < -margin or point.y() < -margin:
+            approximate_representative = (
+                coarse_cluster.representative_screen_pos_approx
+            )
+            if approximate_representative is None:
+                approximate_representative = coarse_cluster.screen_pos
+            corrected_centroid = QPointF(
+                coarse_cluster.screen_pos.x()
+                + exact_representative.x()
+                - approximate_representative.x(),
+                coarse_cluster.screen_pos.y()
+                + exact_representative.y()
+                - approximate_representative.y(),
+            )
+            if corrected_centroid.x() < -margin or corrected_centroid.y() < -margin:
                 continue
-            if point.x() > width + margin or point.y() > height + margin:
+            if (
+                corrected_centroid.x() > width + margin
+                or corrected_centroid.y() > height + margin
+            ):
                 continue
 
-            cell_x = int(point.x() // cell_size)
-            cell_y = int(point.y() // cell_size)
+            cell_x = int(corrected_centroid.x() // cell_size)
+            cell_y = int(corrected_centroid.y() // cell_size)
             candidates: list[_MarkerCluster] = []
             for dx in (-1, 0, 1):
                 for dy in (-1, 0, 1):
@@ -880,9 +911,16 @@ class MarkerController(QObject):
 
             assigned = False
             for target_cluster in candidates:
-                if self.distance(target_cluster.screen_pos, point) > threshold:
+                if (
+                    self.distance(target_cluster.screen_pos, corrected_centroid)
+                    > threshold
+                ):
                     continue
-                self._merge_coarse_cluster(target_cluster, coarse_cluster, point)
+                self._merge_coarse_cluster(
+                    target_cluster,
+                    coarse_cluster,
+                    corrected_centroid,
+                )
                 new_cell = (
                     int(target_cluster.screen_pos.x() // cell_size),
                     int(target_cluster.screen_pos.y() // cell_size),
@@ -903,9 +941,9 @@ class MarkerController(QObject):
                 continue
 
             asset_count = float(len(coarse_cluster.assets))
-            coarse_cluster.screen_pos = QPointF(point)
-            coarse_cluster.screen_x_sum = point.x() * asset_count
-            coarse_cluster.screen_y_sum = point.y() * asset_count
+            coarse_cluster.screen_pos = QPointF(corrected_centroid)
+            coarse_cluster.screen_x_sum = corrected_centroid.x() * asset_count
+            coarse_cluster.screen_y_sum = corrected_centroid.y() * asset_count
             coarse_cluster.cell = (cell_x, cell_y)  # type: ignore[attr-defined]
             refined_clusters.append(coarse_cluster)
             grid.setdefault((cell_x, cell_y), []).append(coarse_cluster)
@@ -916,7 +954,7 @@ class MarkerController(QObject):
     def _merge_coarse_cluster(
         target: _MarkerCluster,
         source: _MarkerCluster,
-        source_point: QPointF,
+        source_centroid: QPointF,
     ) -> None:
         """Merge an aggregate cluster without revisiting its individual assets."""
 
@@ -926,8 +964,8 @@ class MarkerController(QObject):
         target.assets.extend(source.assets)
         target.latitude_sum += source.latitude_sum
         target.longitude_sum += source.longitude_sum
-        target.screen_x_sum += source_point.x() * float(source_count)
-        target.screen_y_sum += source_point.y() * float(source_count)
+        target.screen_x_sum += source_centroid.x() * float(source_count)
+        target.screen_y_sum += source_centroid.y() * float(source_count)
         total_count = float(len(target.assets))
         target.screen_pos = QPointF(
             target.screen_x_sum / total_count,

--- a/src/iPhoto/gui/ui/widgets/marker_controller.py
+++ b/src/iPhoto/gui/ui/widgets/marker_controller.py
@@ -89,6 +89,19 @@ class _MarkerCluster:
         self.screen_y_sum = point.y() * count
 
 
+@dataclass(frozen=True)
+class _ClusterRequestContext:
+    """Immutable parameters associated with an in-flight worker request."""
+
+    request_id: int
+    width: int
+    height: int
+    threshold: float
+    cell_size: int
+    margin: int
+    refine_exact_projection: bool
+
+
 class _ClusterWorker(QObject):
     """Worker object that performs clustering on a dedicated thread."""
 
@@ -100,11 +113,17 @@ class _ClusterWorker(QObject):
     def __init__(self, parent: Optional[QObject] = None) -> None:
         super().__init__(parent)
         self._interrupted = False
+        self._cancel_before_request_id = 0
 
-    def interrupt(self) -> None:
+    def interrupt(self, next_request_id: Optional[int] = None) -> None:
         """Request cancellation of the currently running clustering job."""
 
         self._interrupted = True
+        if next_request_id is not None:
+            self._cancel_before_request_id = max(
+                self._cancel_before_request_id,
+                int(next_request_id),
+            )
 
     def build_clusters(
         self,
@@ -120,6 +139,9 @@ class _ClusterWorker(QObject):
         margin: int,
     ) -> None:
         """Project *assets* and aggregate them into clusters in screen space."""
+
+        if request_id < self._cancel_before_request_id:
+            return
 
         self._interrupted = False
 
@@ -138,7 +160,10 @@ class _ClusterWorker(QObject):
         clusters: list[_MarkerCluster] = []
 
         for asset in assets:
-            if self._interrupted:
+            if (
+                self._interrupted
+                or request_id < self._cancel_before_request_id
+            ):
                 return
 
             point = self._project_to_screen(
@@ -199,7 +224,10 @@ class _ClusterWorker(QObject):
                 clusters.append(cluster)
                 grid.setdefault((cell_x, cell_y), []).append(cluster)
 
-        if not self._interrupted:
+        if (
+            not self._interrupted
+            and request_id >= self._cancel_before_request_id
+        ):
             self.finished.emit(request_id, clusters)
 
     def _project_to_screen(
@@ -267,6 +295,10 @@ class MarkerController(QObject):
     # annotations so the renderer can draw lightweight labels alongside the
     # always-on photo clusters.
     CITY_LABEL_FETCH_LEVEL = 5
+    EXACT_PROJECTION_ASSET_LIMIT = 1_000
+    TARGET_VISIBLE_CLUSTERS = 160.0
+    ZOOM_THRESHOLD_REFERENCE = 7.0
+    MAX_ZOOM_OUT_THRESHOLD_FACTOR = 6.0
 
     def __init__(
         self,
@@ -313,40 +345,44 @@ class MarkerController(QObject):
         self._cluster_thread.finished.connect(self._cluster_worker.deleteLater)
         self._cluster_thread.start()
         self._cluster_request_id = 0
+        self._cluster_request_context: Optional[_ClusterRequestContext] = None
 
     def set_assets(self, assets: Iterable[GeotaggedAsset], library_root: Path) -> None:
         """Replace the asset catalogue shown on the map."""
 
         normalized_assets = [asset for asset in assets if isinstance(asset, GeotaggedAsset)]
         same_root = self._library_root == library_root
-        same_assets = (
-            same_root
-            and len(normalized_assets) == len(self._assets)
-            and all(
-                incoming_asset is existing_asset
-                for incoming_asset, existing_asset in zip(normalized_assets, self._assets)
-            )
-        )
+        same_assets = same_root and normalized_assets == self._assets
         if same_assets:
             self._schedule_cluster_update()
             return
 
         if not self._pending_click_survives_asset_update(normalized_assets, same_root):
             self._clear_pending_click()
+
+        if same_root:
+            existing_by_rel = {
+                asset.library_relative: asset
+                for asset in self._assets
+            }
+            for incoming_asset in normalized_assets:
+                existing_asset = existing_by_rel.get(incoming_asset.library_relative)
+                if existing_asset is not None and incoming_asset != existing_asset:
+                    self._thumbnail_loader.invalidate(incoming_asset.library_relative)
+
         self._assets = normalized_assets
         self._library_root = library_root
-        self._city_annotations = []
         if not same_root:
+            self._city_annotations = []
             self._thumbnail_loader.reset_for_album(library_root)
-        self.thumbnailsInvalidated.emit()
-        self.citiesUpdated.emit([])
+            self.thumbnailsInvalidated.emit()
+            self.citiesUpdated.emit([])
         self._schedule_cluster_update()
 
     def clear(self) -> None:
         """Remove all markers and cancel outstanding work."""
 
-        self._cluster_worker.interrupt()
-        self._cluster_request_id += 1
+        self._invalidate_cluster_request()
         self._assets = []
         self._clusters = []
         self._city_annotations = []
@@ -364,7 +400,7 @@ class MarkerController(QObject):
     def shutdown(self) -> None:
         """Stop worker threads so the application can exit cleanly."""
 
-        self._cluster_worker.interrupt()
+        self._invalidate_cluster_request()
         if self._cluster_thread.isRunning():
             self._cluster_thread.quit()
             self._cluster_thread.wait()
@@ -380,6 +416,7 @@ class MarkerController(QObject):
     def handle_pan(self, delta: QPointF) -> None:
         """Shift visible markers while the user drags the map."""
 
+        self._invalidate_cluster_request()
         self._is_panning = True
         if self._cluster_timer.isActive():
             self._cluster_timer.stop()
@@ -502,14 +539,21 @@ class MarkerController(QObject):
             return 3
 
     def _schedule_cluster_update(self) -> None:
+        self._invalidate_cluster_request()
         if self._is_panning:
             return
         self._cluster_timer.start()
 
+    def _invalidate_cluster_request(self) -> None:
+        """Cancel worker output that no longer matches the current map state."""
+
+        self._cluster_request_id += 1
+        self._cluster_request_context = None
+        self._cluster_worker.interrupt(self._cluster_request_id)
+
     def _rebuild_clusters(self) -> None:
         if not self._assets:
-            self._cluster_worker.interrupt()
-            self._cluster_request_id += 1
+            self._invalidate_cluster_request()
             self._clusters = []
             if self._city_annotations:
                 self._city_annotations = []
@@ -610,13 +654,14 @@ class MarkerController(QObject):
                 self.clustersUpdated.emit([])
             return
 
-        threshold = max(self._marker_size * 0.6, 48.0)
-        cell_size = max(int(threshold), 1)
+        threshold = self._cluster_threshold(width, height)
+        cell_size = max(math.ceil(threshold), 1)
         margin = self._marker_size
 
-        self._cluster_worker.interrupt()
-        self._cluster_request_id += 1
-        if self._prefer_exact_screen_projection:
+        if (
+            self._prefer_exact_screen_projection
+            and len(self._assets) <= self.EXACT_PROJECTION_ASSET_LIMIT
+        ):
             clusters = self._build_exact_projection_clusters(
                 width=width,
                 height=height,
@@ -628,6 +673,15 @@ class MarkerController(QObject):
             return
 
         request_id = self._cluster_request_id
+        self._cluster_request_context = _ClusterRequestContext(
+            request_id=request_id,
+            width=width,
+            height=height,
+            threshold=float(threshold),
+            cell_size=cell_size,
+            margin=margin,
+            refine_exact_projection=self._prefer_exact_screen_projection,
+        )
         self._clustering_requested.emit(
             request_id,
             self._assets,
@@ -646,10 +700,41 @@ class MarkerController(QObject):
     ) -> None:
         """Receive freshly computed clusters from the worker thread."""
 
-        if request_id != self._cluster_request_id:
+        context = self._cluster_request_context
+        if (
+            context is None
+            or request_id != self._cluster_request_id
+            or request_id != context.request_id
+            or self._is_panning
+        ):
             return
 
+        self._cluster_request_context = None
+        if context.refine_exact_projection:
+            clusters = self._refine_exact_projection_clusters(
+                clusters,
+                width=context.width,
+                height=context.height,
+                threshold=context.threshold,
+                cell_size=context.cell_size,
+                margin=context.margin,
+            )
         self._publish_clusters(clusters)
+
+    def _cluster_threshold(self, width: int, height: int) -> float:
+        """Return a zoom- and viewport-aware marker clustering radius."""
+
+        base_threshold = max(self._marker_size * 0.6, 48.0)
+        zoom_delta = max(0.0, self.ZOOM_THRESHOLD_REFERENCE - self._view_zoom)
+        zoom_factor = min(
+            self.MAX_ZOOM_OUT_THRESHOLD_FACTOR,
+            2.0 ** (zoom_delta / 2.0),
+        )
+        viewport_area = float(max(1, width) * max(1, height))
+        density_threshold = math.sqrt(
+            viewport_area / self.TARGET_VISIBLE_CLUSTERS
+        )
+        return max(base_threshold * zoom_factor, density_threshold)
 
     def _publish_clusters(self, clusters: list[_MarkerCluster]) -> None:
         """Publish a stable cluster snapshot to the overlay and label layers."""
@@ -726,6 +811,97 @@ class MarkerController(QObject):
                 grid.setdefault((cell_x, cell_y), []).append(cluster)
 
         return clusters
+
+    def _refine_exact_projection_clusters(
+        self,
+        coarse_clusters: Sequence[_MarkerCluster],
+        *,
+        width: int,
+        height: int,
+        threshold: float,
+        cell_size: int,
+        margin: int,
+    ) -> list[_MarkerCluster]:
+        """Refine coarse worker clusters with bounded native projections."""
+
+        grid: Dict[tuple[int, int], list[_MarkerCluster]] = {}
+        refined_clusters: list[_MarkerCluster] = []
+
+        for coarse_cluster in coarse_clusters:
+            representative = coarse_cluster.representative
+            point = self._map_widget.project_lonlat(
+                representative.longitude,
+                representative.latitude,
+            )
+            if point is None:
+                continue
+            if point.x() < -margin or point.y() < -margin:
+                continue
+            if point.x() > width + margin or point.y() > height + margin:
+                continue
+
+            cell_x = int(point.x() // cell_size)
+            cell_y = int(point.y() // cell_size)
+            candidates: list[_MarkerCluster] = []
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    candidates.extend(grid.get((cell_x + dx, cell_y + dy), []))
+
+            assigned = False
+            for target_cluster in candidates:
+                if self.distance(target_cluster.screen_pos, point) > threshold:
+                    continue
+                self._merge_coarse_cluster(target_cluster, coarse_cluster, point)
+                new_cell = (
+                    int(target_cluster.screen_pos.x() // cell_size),
+                    int(target_cluster.screen_pos.y() // cell_size),
+                )
+                old_cell = getattr(target_cluster, "cell", None)
+                if old_cell != new_cell:
+                    if old_cell in grid:
+                        try:
+                            grid[old_cell].remove(target_cluster)
+                        except ValueError:
+                            pass
+                    grid.setdefault(new_cell, []).append(target_cluster)
+                    target_cluster.cell = new_cell  # type: ignore[attr-defined]
+                assigned = True
+                break
+
+            if assigned:
+                continue
+
+            asset_count = float(len(coarse_cluster.assets))
+            coarse_cluster.screen_pos = QPointF(point)
+            coarse_cluster.screen_x_sum = point.x() * asset_count
+            coarse_cluster.screen_y_sum = point.y() * asset_count
+            coarse_cluster.cell = (cell_x, cell_y)  # type: ignore[attr-defined]
+            refined_clusters.append(coarse_cluster)
+            grid.setdefault((cell_x, cell_y), []).append(coarse_cluster)
+
+        return refined_clusters
+
+    @staticmethod
+    def _merge_coarse_cluster(
+        target: _MarkerCluster,
+        source: _MarkerCluster,
+        source_point: QPointF,
+    ) -> None:
+        """Merge an aggregate cluster without revisiting its individual assets."""
+
+        source_count = len(source.assets)
+        if source_count <= 0:
+            return
+        target.assets.extend(source.assets)
+        target.latitude_sum += source.latitude_sum
+        target.longitude_sum += source.longitude_sum
+        target.screen_x_sum += source_point.x() * float(source_count)
+        target.screen_y_sum += source_point.y() * float(source_count)
+        total_count = float(len(target.assets))
+        target.screen_pos = QPointF(
+            target.screen_x_sum / total_count,
+            target.screen_y_sum / total_count,
+        )
 
     def _cluster_label(
         self, cluster: _MarkerCluster

--- a/src/iPhoto/gui/ui/widgets/marker_controller.py
+++ b/src/iPhoto/gui/ui/widgets/marker_controller.py
@@ -381,13 +381,15 @@ class MarkerController(QObject):
                 existing_asset = existing_by_rel.get(incoming_asset.library_relative)
                 if existing_asset is not None and incoming_asset != existing_asset:
                     self._thumbnail_loader.invalidate(incoming_asset.library_relative)
-            for removed_rel in existing_by_rel.keys() - incoming_rels:
+            removed_entries = [
+                (removed_rel, existing_by_rel[removed_rel].absolute_path)
+                for removed_rel in sorted(existing_by_rel.keys() - incoming_rels)
+            ]
+            for removed_rel, _absolute_path in removed_entries:
                 self._current_representative_rels.discard(removed_rel)
-                self._thumbnail_loader.evict(
-                    removed_rel,
-                    existing_by_rel[removed_rel].absolute_path,
-                )
                 self.thumbnailInvalidated.emit(removed_rel)
+            if removed_entries:
+                self._thumbnail_loader.evict_many(removed_entries)
 
         self._assets = normalized_assets
         self._library_root = library_root

--- a/src/iPhoto/gui/ui/widgets/photo_map_view.py
+++ b/src/iPhoto/gui/ui/widgets/photo_map_view.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from logging import getLogger
 from pathlib import Path
-from typing import Dict, Iterable, Optional, cast
+from typing import Iterable, Optional, cast
 
 from PySide6.QtCore import QObject, QRectF, Qt, QEvent, Signal, Slot
 from PySide6.QtGui import (
@@ -74,6 +75,7 @@ def _configure_opaque_map_container(
 class _MarkerLayer(QWidget):
     """Transparent overlay that paints thumbnail clusters with callout arrows."""
 
+    MAX_PIXMAPS = 512
     MARKER_SIZE = 72
     THUMBNAIL_NATIVE_SIZE = 192
     THUMBNAIL_DISPLAY_SIZE = 56
@@ -88,7 +90,7 @@ class _MarkerLayer(QWidget):
         # events which are handled by :class:`PhotoMapView` and the map widget.
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
         self._clusters: list[_MarkerCluster] = []
-        self._pixmaps: Dict[str, QPixmap] = {}
+        self._pixmaps: OrderedDict[str, QPixmap] = OrderedDict()
         self._placeholder = self._create_placeholder()
         self._badge_font = QFont()
         self._badge_font.setBold(True)
@@ -126,7 +128,16 @@ class _MarkerLayer(QWidget):
         if pixmap.isNull():
             return
         self._pixmaps[rel] = pixmap
+        self._pixmaps.move_to_end(rel)
+        while len(self._pixmaps) > self.MAX_PIXMAPS:
+            self._pixmaps.popitem(last=False)
         self.update()
+
+    def remove_thumbnail(self, rel: str) -> None:
+        """Remove one obsolete marker thumbnail without disturbing the rest."""
+
+        if self._pixmaps.pop(rel, None) is not None:
+            self.update()
 
     def clear_pixmaps(self) -> None:
         """Drop cached pixmaps so outdated thumbnails are not reused."""
@@ -175,6 +186,8 @@ class _MarkerLayer(QWidget):
         thumbnail = self._pixmaps.get(cluster.representative.library_relative)
         if thumbnail is None:
             thumbnail = self._placeholder
+        else:
+            self._pixmaps.move_to_end(cluster.representative.library_relative)
         if not thumbnail.isNull():
             thumb_rect = QRectF(
                 rect.left() + border,
@@ -615,6 +628,7 @@ class PhotoMapView(QWidget):
         self._marker_controller.citiesUpdated.connect(self._handle_city_annotations)
         self._marker_controller.markerActivated.connect(self._on_marker_activated)
         self._marker_controller.thumbnailUpdated.connect(self._overlay.set_thumbnail)
+        self._marker_controller.thumbnailInvalidated.connect(self._overlay.remove_thumbnail)
         self._marker_controller.thumbnailsInvalidated.connect(self._overlay.clear_pixmaps)
         if self._assets_library_root is not None:
             self._marker_controller.set_assets(self._assets, self._assets_library_root)

--- a/src/iPhoto/gui/ui/widgets/photo_map_view.py
+++ b/src/iPhoto/gui/ui/widgets/photo_map_view.py
@@ -90,6 +90,7 @@ class _MarkerLayer(QWidget):
         # events which are handled by :class:`PhotoMapView` and the map widget.
         self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
         self._clusters: list[_MarkerCluster] = []
+        self._visible_rels: set[str] = set()
         self._pixmaps: OrderedDict[str, QPixmap] = OrderedDict()
         self._placeholder = self._create_placeholder()
         self._badge_font = QFont()
@@ -120,6 +121,11 @@ class _MarkerLayer(QWidget):
         """Replace the rendered clusters and schedule a repaint."""
 
         self._clusters = list(items)
+        self._visible_rels = {
+            cluster.representative.library_relative
+            for cluster in self._clusters
+        }
+        self._trim_pixmaps()
         self.update()
 
     def set_thumbnail(self, rel: str, pixmap: QPixmap) -> None:
@@ -129,9 +135,24 @@ class _MarkerLayer(QWidget):
             return
         self._pixmaps[rel] = pixmap
         self._pixmaps.move_to_end(rel)
-        while len(self._pixmaps) > self.MAX_PIXMAPS:
-            self._pixmaps.popitem(last=False)
+        self._trim_pixmaps()
         self.update()
+
+    def _trim_pixmaps(self) -> None:
+        """Bound history entries without evicting currently visible markers."""
+
+        while len(self._pixmaps) > self.MAX_PIXMAPS:
+            eviction_rel = next(
+                (
+                    cached_rel
+                    for cached_rel in self._pixmaps
+                    if cached_rel not in self._visible_rels
+                ),
+                None,
+            )
+            if eviction_rel is None:
+                return
+            self._pixmaps.pop(eviction_rel, None)
 
     def remove_thumbnail(self, rel: str) -> None:
         """Remove one obsolete marker thumbnail without disturbing the rest."""

--- a/tests/contracts/test_map_marker_scale_contract.py
+++ b/tests/contracts/test_map_marker_scale_contract.py
@@ -97,7 +97,11 @@ def _exercise_scale(root: Path, count: int) -> dict[str, int]:
         provides_place_labels=True,
     )
     controller._view_zoom = 2.0
-    threshold = controller._cluster_threshold(width, height)
+    threshold = controller._cluster_threshold(
+        width,
+        height,
+        density_adaptive=True,
+    )
     cell_size = max(math.ceil(threshold), 1)
     worker = _CountingClusterWorker()
     finished: list[list] = []

--- a/tests/contracts/test_map_marker_scale_contract.py
+++ b/tests/contracts/test_map_marker_scale_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import os
+import time
 from dataclasses import replace
 from pathlib import Path
 
@@ -14,9 +15,14 @@ pytest.importorskip(
 )
 
 from PySide6.QtCore import QObject, QPointF
+from PySide6.QtWidgets import QApplication
 
 from iPhoto.application.dtos import GeotaggedAsset
-from iPhoto.gui.ui.widgets.marker_controller import MarkerController, _ClusterWorker
+from iPhoto.gui.ui.widgets.marker_controller import (
+    MarkerController,
+    _ClusterWorker,
+    _MarkerCluster,
+)
 
 
 pytestmark = pytest.mark.maps_scale_contract
@@ -56,6 +62,17 @@ class _CountingExactMap:
         return QPointF(x, y)
 
 
+class _FixedExactMap(_CountingExactMap):
+    def __init__(self, point: QPointF) -> None:
+        super().__init__(800, 600)
+        self._point = point
+
+    def project_lonlat(self, lon: float, lat: float) -> QPointF:
+        del lon, lat
+        self.project_calls += 1
+        return QPointF(self._point)
+
+
 class _NullThumbnailLoader(QObject):
     def reset_for_album(self, root: Path) -> None:
         del root
@@ -68,20 +85,89 @@ class _NullThumbnailLoader(QObject):
         return None
 
 
-def test_map_clustering_scales_structurally_to_50k(tmp_path: Path) -> None:
-    if os.environ.get("IPHOTO_RUN_MAPS_SCALE_CONTRACT") != "1":
-        pytest.skip("large synthetic contract is run by the maps-scale-contract PR job")
+def test_map_clustering_scales_structurally_to_50k(
+    tmp_path: Path,
+) -> None:
+    _require_scale_contract()
 
     metrics = [
         _exercise_scale(tmp_path, count)
         for count in (1_000, 10_000, 50_000)
     ]
 
-    for item in metrics:
+    exact_item = metrics[0]
+    assert exact_item["worker_projection_calls"] == 0
+    assert exact_item["native_projection_calls"] == exact_item["asset_count"]
+    assert exact_item["refined_asset_count"] == exact_item["asset_count"]
+
+    for item in metrics[1:]:
         assert item["worker_projection_calls"] == item["asset_count"]
         assert item["native_projection_calls"] == item["coarse_cluster_count"]
         assert item["native_projection_calls"] < item["asset_count"]
         assert item["refined_asset_count"] == item["asset_count"]
+
+
+def test_exact_refinement_preserves_coarse_centroid_contract(tmp_path: Path) -> None:
+    _require_scale_contract()
+    assets = _synthetic_assets(tmp_path, 2)
+    map_widget = _FixedExactMap(QPointF(110.0, 100.0))
+    controller = MarkerController(
+        map_widget,
+        _NullThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=True,
+    )
+    coarse_cluster = _MarkerCluster(
+        representative=assets[0],
+        assets=assets,
+        screen_pos=QPointF(200.0, 100.0),
+        representative_screen_pos_approx=QPointF(100.0, 100.0),
+    )
+
+    try:
+        refined = controller._refine_exact_projection_clusters(
+            [coarse_cluster],
+            width=800,
+            height=600,
+            threshold=271.0,
+            cell_size=271,
+            margin=72,
+        )
+    finally:
+        controller.shutdown()
+
+    assert len(refined) == 1
+    assert refined[0].screen_pos == QPointF(210.0, 100.0)
+    assert refined[0].screen_pos != QPointF(110.0, 100.0)
+
+
+def test_production_dispatch_is_geometrically_stable_at_1000_boundary(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    _require_scale_contract()
+    exact_assets = _boundary_assets(tmp_path, 1_000)
+    hybrid_assets = _boundary_assets(tmp_path, 1_001)
+
+    exact_clusters, exact_calls = _run_production_dispatch(
+        tmp_path,
+        exact_assets,
+        qapp,
+    )
+    hybrid_clusters, hybrid_calls = _run_production_dispatch(
+        tmp_path,
+        hybrid_assets,
+        qapp,
+    )
+
+    assert exact_calls == 1_000
+    assert hybrid_calls == 1
+    assert len(exact_clusters) == len(hybrid_clusters) == 1
+    assert len(exact_clusters[0].assets) == 1_000
+    assert len(hybrid_clusters[0].assets) == 1_001
+    assert abs(exact_clusters[0].screen_pos.x() - hybrid_clusters[0].screen_pos.x()) < 1.0
+    assert hybrid_clusters[0].screen_pos.x() > 150.0
 
 
 def _exercise_scale(root: Path, count: int) -> dict[str, int]:
@@ -97,6 +183,22 @@ def _exercise_scale(root: Path, count: int) -> dict[str, int]:
         provides_place_labels=True,
     )
     controller._view_zoom = 2.0
+    if count <= MarkerController.EXACT_PROJECTION_ASSET_LIMIT:
+        controller._assets = assets
+        controller._library_root = root
+        try:
+            controller._rebuild_photo_clusters()
+            clusters = list(controller._clusters)
+        finally:
+            controller.shutdown()
+        return {
+            "asset_count": count,
+            "worker_projection_calls": 0,
+            "coarse_cluster_count": len(clusters),
+            "native_projection_calls": map_widget.project_calls,
+            "refined_asset_count": sum(len(cluster.assets) for cluster in clusters),
+        }
+
     threshold = controller._cluster_threshold(
         width,
         height,
@@ -140,6 +242,58 @@ def _exercise_scale(root: Path, count: int) -> dict[str, int]:
         "native_projection_calls": map_widget.project_calls,
         "refined_asset_count": sum(len(cluster.assets) for cluster in refined),
     }
+
+
+def _run_production_dispatch(
+    root: Path,
+    assets: list[GeotaggedAsset],
+    qapp: QApplication,
+) -> tuple[list[_MarkerCluster], int]:
+    map_widget = _CountingExactMap(1_024, 600)
+    controller = MarkerController(
+        map_widget,
+        _NullThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=True,
+    )
+    controller._assets = assets
+    controller._library_root = root
+    controller._view_center_x = 0.5
+    controller._view_center_y = 0.5
+    controller._view_zoom = 2.0
+
+    try:
+        controller._rebuild_photo_clusters()
+        deadline = time.monotonic() + 5.0
+        while (
+            controller._cluster_request_context is not None
+            and time.monotonic() < deadline
+        ):
+            qapp.processEvents()
+            time.sleep(0.005)
+        assert controller._cluster_request_context is None
+        return list(controller._clusters), map_widget.project_calls
+    finally:
+        controller.shutdown()
+
+
+def _boundary_assets(root: Path, count: int) -> list[GeotaggedAsset]:
+    assets = _synthetic_assets(root, count)
+    longitudes = (-144.84375, -74.53125)
+    return [
+        replace(
+            asset,
+            longitude=longitudes[index % 2],
+            latitude=0.0,
+        )
+        for index, asset in enumerate(assets)
+    ]
+
+
+def _require_scale_contract() -> None:
+    if os.environ.get("IPHOTO_RUN_MAPS_SCALE_CONTRACT") != "1":
+        pytest.skip("large synthetic contract is run by the maps-scale-contract PR job")
 
 
 def _synthetic_assets(root: Path, count: int) -> list[GeotaggedAsset]:

--- a/tests/contracts/test_map_marker_scale_contract.py
+++ b/tests/contracts/test_map_marker_scale_contract.py
@@ -73,12 +73,47 @@ class _FixedExactMap(_CountingExactMap):
         return QPointF(self._point)
 
 
+class _MercatorExactMap:
+    zoom = 5.0
+
+    def __init__(self, width: int, height: int) -> None:
+        self._width = width
+        self._height = height
+        self.project_calls = 0
+
+    def width(self) -> int:
+        return self._width
+
+    def height(self) -> int:
+        return self._height
+
+    def prefers_exact_screen_projection(self) -> bool:
+        return True
+
+    def project_lonlat(self, lon: float, lat: float) -> QPointF:
+        self.project_calls += 1
+        world_size = 256.0 * (2.0 ** self.zoom)
+        top_left_x = world_size * 0.5 - self._width / 2.0
+        top_left_y = world_size * 0.5 - self._height / 2.0
+        world_x = (float(lon) + 180.0) / 360.0 * world_size
+        bounded_lat = max(min(float(lat), 85.05112878), -85.05112878)
+        sin_lat = math.sin(math.radians(bounded_lat))
+        world_y = (
+            0.5
+            - math.log((1.0 + sin_lat) / (1.0 - sin_lat)) / (4.0 * math.pi)
+        ) * world_size
+        return QPointF(world_x - top_left_x, world_y - top_left_y)
+
+
 class _NullThumbnailLoader(QObject):
     def reset_for_album(self, root: Path) -> None:
         del root
 
     def invalidate(self, rel: str) -> None:
         del rel
+
+    def evict(self, rel: str, abs_path: Path) -> None:
+        del rel, abs_path
 
     def request(self, *args, **kwargs):
         del args, kwargs
@@ -170,6 +205,32 @@ def test_production_dispatch_is_geometrically_stable_at_1000_boundary(
     assert hybrid_clusters[0].screen_pos.x() > 150.0
 
 
+def test_production_dispatch_preserves_membership_at_1000_boundary(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    _require_scale_contract()
+    exact_assets = _membership_boundary_assets(tmp_path, 1_000)
+    hybrid_assets = _membership_boundary_assets(tmp_path, 1_001)
+
+    exact_clusters, exact_calls = _run_membership_dispatch(
+        tmp_path,
+        exact_assets,
+        qapp,
+    )
+    hybrid_clusters, hybrid_calls = _run_membership_dispatch(
+        tmp_path,
+        hybrid_assets,
+        qapp,
+    )
+
+    assert exact_calls == 1_000
+    assert hybrid_calls == 2
+    assert len(exact_clusters) == len(hybrid_clusters) == 2
+    assert [len(cluster.assets) for cluster in exact_clusters] == [1, 1]
+    assert [len(cluster.assets) for cluster in hybrid_clusters] == [1, 1]
+
+
 def _exercise_scale(root: Path, count: int) -> dict[str, int]:
     width = 1_920
     height = 1_080
@@ -202,7 +263,7 @@ def _exercise_scale(root: Path, count: int) -> dict[str, int]:
     threshold = controller._cluster_threshold(
         width,
         height,
-        density_adaptive=True,
+        density_factor=1.0,
     )
     cell_size = max(math.ceil(threshold), 1)
     worker = _CountingClusterWorker()
@@ -285,6 +346,66 @@ def _boundary_assets(root: Path, count: int) -> list[GeotaggedAsset]:
         replace(
             asset,
             longitude=longitudes[index % 2],
+            latitude=0.0,
+        )
+        for index, asset in enumerate(assets)
+    ]
+
+
+def _run_membership_dispatch(
+    root: Path,
+    assets: list[GeotaggedAsset],
+    qapp: QApplication,
+) -> tuple[list[_MarkerCluster], int]:
+    map_widget = _MercatorExactMap(2_560, 1_440)
+    controller = MarkerController(
+        map_widget,
+        _NullThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=True,
+    )
+    controller._assets = assets
+    controller._library_root = root
+    controller._view_center_x = 0.5
+    controller._view_center_y = 0.5
+    controller._view_zoom = 5.0
+
+    try:
+        controller._rebuild_photo_clusters()
+        deadline = time.monotonic() + 5.0
+        while (
+            controller._cluster_request_context is not None
+            and time.monotonic() < deadline
+        ):
+            qapp.processEvents()
+            time.sleep(0.005)
+        assert controller._cluster_request_context is None
+        return list(controller._clusters), map_widget.project_calls
+    finally:
+        controller.shutdown()
+
+
+def _membership_boundary_assets(
+    root: Path,
+    count: int,
+) -> list[GeotaggedAsset]:
+    assets = _synthetic_assets(root, count)
+    world_size = 256.0 * (2.0 ** 5.0)
+    top_left_x = world_size * 0.5 - 2_560.0 / 2.0
+
+    def longitude_at(screen_x: float) -> float:
+        return (screen_x + top_left_x) / world_size * 360.0 - 180.0
+
+    visible_longitudes = (longitude_at(100.0), longitude_at(205.0))
+    return [
+        replace(
+            asset,
+            longitude=(
+                visible_longitudes[index]
+                if index < len(visible_longitudes)
+                else 179.0
+            ),
             latitude=0.0,
         )
         for index, asset in enumerate(assets)

--- a/tests/contracts/test_map_marker_scale_contract.py
+++ b/tests/contracts/test_map_marker_scale_contract.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "PySide6",
+    reason="PySide6 is required for map marker scale contracts",
+    exc_type=ImportError,
+)
+
+from PySide6.QtCore import QObject, QPointF
+
+from iPhoto.application.dtos import GeotaggedAsset
+from iPhoto.gui.ui.widgets.marker_controller import MarkerController, _ClusterWorker
+
+
+pytestmark = pytest.mark.maps_scale_contract
+
+
+class _CountingClusterWorker(_ClusterWorker):
+    def __init__(self) -> None:
+        super().__init__()
+        self.project_calls = 0
+
+    def _project_to_screen(self, *args, **kwargs):
+        self.project_calls += 1
+        return super()._project_to_screen(*args, **kwargs)
+
+
+class _CountingExactMap:
+    zoom = 2.0
+
+    def __init__(self, width: int, height: int) -> None:
+        self._width = width
+        self._height = height
+        self.project_calls = 0
+
+    def width(self) -> int:
+        return self._width
+
+    def height(self) -> int:
+        return self._height
+
+    def prefers_exact_screen_projection(self) -> bool:
+        return True
+
+    def project_lonlat(self, lon: float, lat: float) -> QPointF:
+        self.project_calls += 1
+        x = (float(lon) + 180.0) / 360.0 * float(self._width)
+        y = (90.0 - float(lat)) / 180.0 * float(self._height)
+        return QPointF(x, y)
+
+
+class _NullThumbnailLoader(QObject):
+    def reset_for_album(self, root: Path) -> None:
+        del root
+
+    def invalidate(self, rel: str) -> None:
+        del rel
+
+    def request(self, *args, **kwargs):
+        del args, kwargs
+        return None
+
+
+def test_map_clustering_scales_structurally_to_50k(tmp_path: Path) -> None:
+    if os.environ.get("IPHOTO_RUN_MAPS_SCALE_CONTRACT") != "1":
+        pytest.skip("large synthetic contract is run by the maps-scale-contract PR job")
+
+    metrics = [
+        _exercise_scale(tmp_path, count)
+        for count in (1_000, 10_000, 50_000)
+    ]
+
+    for item in metrics:
+        assert item["worker_projection_calls"] == item["asset_count"]
+        assert item["native_projection_calls"] == item["coarse_cluster_count"]
+        assert item["native_projection_calls"] < item["asset_count"]
+        assert item["refined_asset_count"] == item["asset_count"]
+
+
+def _exercise_scale(root: Path, count: int) -> dict[str, int]:
+    width = 1_920
+    height = 1_080
+    assets = _synthetic_assets(root, count)
+    map_widget = _CountingExactMap(width, height)
+    controller = MarkerController(
+        map_widget,
+        _NullThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=True,
+    )
+    controller._view_zoom = 2.0
+    threshold = controller._cluster_threshold(width, height)
+    cell_size = max(math.ceil(threshold), 1)
+    worker = _CountingClusterWorker()
+    finished: list[list] = []
+    worker.finished.connect(lambda _request_id, clusters: finished.append(list(clusters)))
+
+    try:
+        worker.build_clusters(
+            1,
+            assets,
+            width,
+            height,
+            0.5,
+            0.5,
+            2.0,
+            threshold,
+            cell_size,
+            72,
+        )
+        assert len(finished) == 1
+        coarse_clusters = finished[0]
+        refined = controller._refine_exact_projection_clusters(
+            coarse_clusters,
+            width=width,
+            height=height,
+            threshold=threshold,
+            cell_size=cell_size,
+            margin=72,
+        )
+    finally:
+        controller.shutdown()
+
+    return {
+        "asset_count": count,
+        "worker_projection_calls": worker.project_calls,
+        "coarse_cluster_count": len(coarse_clusters),
+        "native_projection_calls": map_widget.project_calls,
+        "refined_asset_count": sum(len(cluster.assets) for cluster in refined),
+    }
+
+
+def _synthetic_assets(root: Path, count: int) -> list[GeotaggedAsset]:
+    template = GeotaggedAsset(
+        library_relative="0.jpg",
+        album_relative="0.jpg",
+        absolute_path=root / "0.jpg",
+        album_path=root,
+        asset_id="0",
+        latitude=0.0,
+        longitude=0.0,
+        is_image=True,
+        is_video=False,
+        still_image_time=None,
+        duration=None,
+        location_name=None,
+        live_photo_group_id=None,
+        live_partner_rel=None,
+    )
+    return [
+        replace(
+            template,
+            library_relative=f"{index}.jpg",
+            album_relative=f"{index}.jpg",
+            absolute_path=root / f"{index}.jpg",
+            asset_id=str(index),
+            longitude=-179.0 + 358.0 * float(index % 512) / 511.0,
+            latitude=-80.0 + 160.0 * float((index // 512) % 256) / 255.0,
+        )
+        for index in range(count)
+    ]

--- a/tests/contracts/test_map_marker_scale_contract.py
+++ b/tests/contracts/test_map_marker_scale_contract.py
@@ -115,6 +115,9 @@ class _NullThumbnailLoader(QObject):
     def evict(self, rel: str, abs_path: Path) -> None:
         del rel, abs_path
 
+    def evict_many(self, entries: list[tuple[str, Path]]) -> None:
+        del entries
+
     def request(self, *args, **kwargs):
         del args, kwargs
         return None

--- a/tests/test_map_viewport.py
+++ b/tests/test_map_viewport.py
@@ -25,3 +25,17 @@ def test_compute_view_state_uses_dynamic_max_tile_zoom() -> None:
     assert dynamic_state.fetch_zoom == 12
     assert math.isclose(dynamic_state.scaled_tile_size, 256 * (2 ** 0.25))
     assert legacy_state.fetch_zoom == 6
+
+
+def test_legacy_tiles_keep_original_zoom_scale_lock() -> None:
+    state = compute_view_state(
+        0.5,
+        0.5,
+        8.5,
+        1024,
+        768,
+        256,
+    )
+
+    assert state.fetch_zoom == 6
+    assert math.isclose(state.scaled_tile_size, 256 * (2 ** (8.5 - 6.0)))

--- a/tests/test_marker_controller_place_labels.py
+++ b/tests/test_marker_controller_place_labels.py
@@ -383,6 +383,11 @@ def test_marker_controller_threshold_grows_when_zooming_out(
         )
         controller._view_zoom = 10.0
         zoomed_in = controller._cluster_threshold(1_920, 1_080)
+        large_zoomed_in = controller._cluster_threshold(
+            3_840,
+            2_160,
+            density_adaptive=True,
+        )
         zoomed_in_clusters = controller._build_exact_projection_clusters(
             width=800,
             height=600,
@@ -390,12 +395,20 @@ def test_marker_controller_threshold_grows_when_zooming_out(
             cell_size=max(math.ceil(zoomed_in), 1),
             margin=72,
         )
+        controller._view_zoom = 6.0
+        small_library_threshold = controller._cluster_threshold(3_840, 2_160)
+        large_library_threshold = controller._cluster_threshold(
+            3_840,
+            2_160,
+            density_adaptive=True,
+        )
     finally:
         controller.shutdown()
 
-    density_floor = (1_920 * 1_080 / MarkerController.TARGET_VISIBLE_CLUSTERS) ** 0.5
     assert zoomed_out > zoomed_in
-    assert zoomed_in >= density_floor
+    assert zoomed_in == 48.0
+    assert large_zoomed_in == 48.0
+    assert large_library_threshold > small_library_threshold
     assert len(zoomed_out_clusters) < len(zoomed_in_clusters)
 
 
@@ -516,6 +529,36 @@ def test_marker_controller_preserves_thumbnails_for_same_library_refresh(
     assert loader.reset_calls == [tmp_path]
     assert loader.invalidate_calls == [asset.library_relative]
     assert len(invalidations) == first_invalidations
+
+
+def test_marker_controller_evicts_only_removed_same_library_thumbnails(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    loader = _DummyThumbnailLoader()
+    controller = MarkerController(
+        _DummyMapWidget(),
+        loader,
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    assets = _assets_at(tmp_path, 2)
+    removed: list[str] = []
+    full_invalidations: list[bool] = []
+    controller.thumbnailInvalidated.connect(removed.append)
+    controller.thumbnailsInvalidated.connect(lambda: full_invalidations.append(True))
+
+    try:
+        controller.set_assets(assets, tmp_path)
+        controller.set_assets([assets[0]], tmp_path)
+    finally:
+        controller.shutdown()
+
+    assert removed == [assets[1].library_relative]
+    assert loader.invalidate_calls == [assets[1].library_relative]
+    assert full_invalidations == [True]
 
 
 def test_marker_controller_invalidates_all_thumbnails_when_library_changes(

--- a/tests/test_marker_controller_place_labels.py
+++ b/tests/test_marker_controller_place_labels.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import math
 import os
+import time
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -11,7 +14,11 @@ pytest.importorskip("PySide6.QtCore", reason="QtCore is required for marker cont
 from PySide6.QtCore import QObject, QPointF, QRectF
 from PySide6.QtWidgets import QApplication
 
-from iPhoto.gui.ui.widgets.marker_controller import MarkerController, _MarkerCluster
+from iPhoto.gui.ui.widgets.marker_controller import (
+    MarkerController,
+    _ClusterRequestContext,
+    _MarkerCluster,
+)
 from maps.map_widget.map_renderer import CityAnnotation
 from iPhoto.library.runtime_controller import GeotaggedAsset
 
@@ -55,10 +62,14 @@ class _DummyThumbnailLoader(QObject):
     def __init__(self) -> None:
         super().__init__()
         self.reset_calls: list[Path] = []
+        self.invalidate_calls: list[str] = []
 
     def reset_for_album(self, root: Path) -> None:
         self.reset_calls.append(root)
         return None
+
+    def invalidate(self, rel: str) -> None:
+        self.invalidate_calls.append(rel)
 
     def request(self, *args, **kwargs):
         return None
@@ -81,6 +92,28 @@ def _asset(tmp_path: Path) -> GeotaggedAsset:
         live_photo_group_id=None,
         live_partner_rel=None,
     )
+
+
+def _assets_at(
+    tmp_path: Path,
+    count: int,
+    *,
+    latitude: float = 20.0,
+    longitude: float = 10.0,
+) -> list[GeotaggedAsset]:
+    template = _asset(tmp_path)
+    return [
+        replace(
+            template,
+            library_relative=f"{index}.jpg",
+            album_relative=f"{index}.jpg",
+            absolute_path=tmp_path / f"{index}.jpg",
+            asset_id=str(index),
+            latitude=latitude,
+            longitude=longitude,
+        )
+        for index in range(count)
+    ]
 
 
 def _clickable_cluster(asset: GeotaggedAsset) -> _MarkerCluster:
@@ -188,6 +221,220 @@ def test_marker_controller_uses_exact_screen_projection_when_requested(
     assert controller._clusters[1].screen_pos == QPointF(620.0, 420.0)
 
 
+def test_marker_controller_keeps_small_exact_projection_on_gui_thread(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    assets = _assets_at(tmp_path, MarkerController.EXACT_PROJECTION_ASSET_LIMIT)
+    map_widget = _ExactProjectionMapWidget(
+        {(10.0, 20.0): QPointF(400.0, 300.0)},
+        zoom=7.0,
+    )
+    controller = MarkerController(
+        map_widget,
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    controller._assets = assets
+    controller._library_root = tmp_path
+    controller._view_zoom = 7.0
+
+    try:
+        controller._rebuild_photo_clusters()
+    finally:
+        controller.shutdown()
+
+    assert len(map_widget.project_calls) == len(assets)
+    assert len(controller._clusters) == 1
+
+
+def test_marker_controller_uses_hybrid_projection_for_large_asset_sets(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    assets = _assets_at(
+        tmp_path,
+        MarkerController.EXACT_PROJECTION_ASSET_LIMIT + 1,
+        latitude=0.0,
+        longitude=0.0,
+    )
+    map_widget = _ExactProjectionMapWidget(
+        {(0.0, 0.0): QPointF(400.0, 300.0)},
+        zoom=7.0,
+    )
+    controller = MarkerController(
+        map_widget,
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    controller._assets = assets
+    controller._library_root = tmp_path
+    controller._view_center_x = 0.5
+    controller._view_center_y = 0.5
+    controller._view_zoom = 7.0
+
+    try:
+        controller._rebuild_photo_clusters()
+        deadline = time.monotonic() + 3.0
+        while controller._cluster_request_context is not None and time.monotonic() < deadline:
+            qapp.processEvents()
+            time.sleep(0.01)
+    finally:
+        controller.shutdown()
+
+    assert controller._cluster_request_context is None
+    assert len(controller._clusters) == 1
+    assert len(controller._clusters[0].assets) == len(assets)
+    assert map_widget.project_calls == [(0.0, 0.0)]
+
+
+def test_marker_controller_refines_and_merges_coarse_clusters_without_asset_walk(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    first, second, outside = (
+        _assets_at(tmp_path, 1, latitude=10.0, longitude=10.0)[0],
+        _assets_at(tmp_path, 1, latitude=20.0, longitude=20.0)[0],
+        _assets_at(tmp_path, 1, latitude=30.0, longitude=30.0)[0],
+    )
+    map_widget = _ExactProjectionMapWidget(
+        {
+            (10.0, 10.0): QPointF(100.0, 100.0),
+            (20.0, 20.0): QPointF(120.0, 100.0),
+            (30.0, 30.0): QPointF(1_000.0, 100.0),
+        }
+    )
+    controller = MarkerController(
+        map_widget,
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    coarse_clusters = [
+        _MarkerCluster(representative=first, assets=[first], screen_pos=QPointF(90.0, 90.0)),
+        _MarkerCluster(representative=second, assets=[second], screen_pos=QPointF(110.0, 90.0)),
+        _MarkerCluster(representative=outside, assets=[outside], screen_pos=QPointF(700.0, 90.0)),
+    ]
+
+    try:
+        refined = controller._refine_exact_projection_clusters(
+            coarse_clusters,
+            width=800,
+            height=600,
+            threshold=48.0,
+            cell_size=48,
+            margin=0,
+        )
+    finally:
+        controller.shutdown()
+
+    assert len(refined) == 1
+    assert {asset.latitude for asset in refined[0].assets} == {10.0, 20.0}
+    assert len(map_widget.project_calls) == len(coarse_clusters)
+
+
+def test_marker_controller_threshold_grows_when_zooming_out(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    assets = [
+        replace(
+            _asset(tmp_path),
+            library_relative=f"{index}.jpg",
+            album_relative=f"{index}.jpg",
+            absolute_path=tmp_path / f"{index}.jpg",
+            asset_id=str(index),
+            longitude=float(index),
+        )
+        for index in range(10)
+    ]
+    map_widget = _ExactProjectionMapWidget(
+        {
+            (float(index), 20.0): QPointF(50.0 + float(index) * 70.0, 300.0)
+            for index in range(10)
+        }
+    )
+    controller = MarkerController(
+        map_widget,
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    controller._assets = assets
+
+    try:
+        controller._view_zoom = 2.0
+        zoomed_out = controller._cluster_threshold(1_920, 1_080)
+        zoomed_out_clusters = controller._build_exact_projection_clusters(
+            width=800,
+            height=600,
+            threshold=zoomed_out,
+            cell_size=max(math.ceil(zoomed_out), 1),
+            margin=72,
+        )
+        controller._view_zoom = 10.0
+        zoomed_in = controller._cluster_threshold(1_920, 1_080)
+        zoomed_in_clusters = controller._build_exact_projection_clusters(
+            width=800,
+            height=600,
+            threshold=zoomed_in,
+            cell_size=max(math.ceil(zoomed_in), 1),
+            margin=72,
+        )
+    finally:
+        controller.shutdown()
+
+    density_floor = (1_920 * 1_080 / MarkerController.TARGET_VISIBLE_CLUSTERS) ** 0.5
+    assert zoomed_out > zoomed_in
+    assert zoomed_in >= density_floor
+    assert len(zoomed_out_clusters) < len(zoomed_in_clusters)
+
+
+def test_marker_controller_rejects_stale_worker_results_after_pan(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    controller = MarkerController(
+        _DummyMapWidget(),
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    stale_id = controller._cluster_request_id
+    controller._cluster_request_context = _ClusterRequestContext(
+        request_id=stale_id,
+        width=800,
+        height=600,
+        threshold=48.0,
+        cell_size=48,
+        margin=72,
+        refine_exact_projection=False,
+    )
+    stale_cluster = _MarkerCluster(
+        representative=_asset(tmp_path),
+        screen_pos=QPointF(100.0, 100.0),
+    )
+
+    try:
+        controller.handle_pan(QPointF(1.0, 0.0))
+        controller._handle_clustering_finished(stale_id, [stale_cluster])
+    finally:
+        controller.shutdown()
+
+    assert controller._clusters == []
+
+
 def test_marker_controller_reuses_existing_map_state_when_assets_are_unchanged(
     qapp: QApplication,
     tmp_path: Path,
@@ -236,6 +483,67 @@ def test_marker_controller_reuses_existing_map_state_when_assets_are_unchanged(
     assert loader.reset_calls == [tmp_path]
     assert len(invalidations) == first_invalidations
     assert len(city_updates) == first_city_updates
+
+
+def test_marker_controller_preserves_thumbnails_for_same_library_refresh(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    loader = _DummyThumbnailLoader()
+    controller = MarkerController(
+        _DummyMapWidget(),
+        loader,
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    invalidations: list[bool] = []
+    controller.thumbnailsInvalidated.connect(lambda: invalidations.append(True))
+    asset = _asset(tmp_path)
+
+    try:
+        controller.set_assets([asset], tmp_path)
+        first_invalidations = len(invalidations)
+
+        controller.set_assets([replace(asset)], tmp_path)
+        assert loader.invalidate_calls == []
+
+        controller.set_assets([replace(asset, latitude=asset.latitude + 1.0)], tmp_path)
+        qapp.processEvents()
+    finally:
+        controller.shutdown()
+
+    assert loader.reset_calls == [tmp_path]
+    assert loader.invalidate_calls == [asset.library_relative]
+    assert len(invalidations) == first_invalidations
+
+
+def test_marker_controller_invalidates_all_thumbnails_when_library_changes(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    loader = _DummyThumbnailLoader()
+    controller = MarkerController(
+        _DummyMapWidget(),
+        loader,
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    invalidations: list[bool] = []
+    controller.thumbnailsInvalidated.connect(lambda: invalidations.append(True))
+    replacement_root = tmp_path / "replacement"
+
+    try:
+        controller.set_assets([_asset(tmp_path)], tmp_path)
+        controller.set_assets([_asset(replacement_root)], replacement_root)
+        controller.clear()
+    finally:
+        controller.shutdown()
+
+    assert loader.reset_calls == [tmp_path, replacement_root]
+    assert invalidations == [True, True, True]
 
 
 def test_marker_controller_emits_raw_marker_assets(

--- a/tests/test_marker_controller_place_labels.py
+++ b/tests/test_marker_controller_place_labels.py
@@ -65,6 +65,7 @@ class _DummyThumbnailLoader(QObject):
         self.reset_calls: list[Path] = []
         self.invalidate_calls: list[str] = []
         self.evict_calls: list[tuple[str, Path]] = []
+        self.evict_many_calls: list[list[tuple[str, Path]]] = []
 
     def reset_for_album(self, root: Path) -> None:
         self.reset_calls.append(root)
@@ -75,6 +76,9 @@ class _DummyThumbnailLoader(QObject):
 
     def evict(self, rel: str, abs_path: Path) -> None:
         self.evict_calls.append((rel, abs_path))
+
+    def evict_many(self, entries: list[tuple[str, Path]]) -> None:
+        self.evict_many_calls.append(list(entries))
 
     def request(self, *args, **kwargs):
         return None
@@ -638,7 +642,7 @@ def test_marker_controller_evicts_only_removed_same_library_thumbnails(
         thumbnail_size=192,
         provides_place_labels=False,
     )
-    assets = _assets_at(tmp_path, 2)
+    assets = _assets_at(tmp_path, 3)
     removed: list[str] = []
     full_invalidations: list[bool] = []
     controller.thumbnailInvalidated.connect(removed.append)
@@ -650,10 +654,17 @@ def test_marker_controller_evicts_only_removed_same_library_thumbnails(
     finally:
         controller.shutdown()
 
-    assert removed == [assets[1].library_relative]
+    assert removed == [
+        assets[1].library_relative,
+        assets[2].library_relative,
+    ]
     assert loader.invalidate_calls == []
-    assert loader.evict_calls == [
-        (assets[1].library_relative, assets[1].absolute_path)
+    assert loader.evict_calls == []
+    assert loader.evict_many_calls == [
+        [
+            (assets[1].library_relative, assets[1].absolute_path),
+            (assets[2].library_relative, assets[2].absolute_path),
+        ]
     ]
     assert full_invalidations == [True]
 

--- a/tests/test_marker_controller_place_labels.py
+++ b/tests/test_marker_controller_place_labels.py
@@ -12,6 +12,7 @@ pytest.importorskip("PySide6", reason="PySide6 is required for marker controller
 pytest.importorskip("PySide6.QtCore", reason="QtCore is required for marker controller tests", exc_type=ImportError)
 
 from PySide6.QtCore import QObject, QPointF, QRectF
+from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import QApplication
 
 from iPhoto.gui.ui.widgets.marker_controller import (
@@ -298,11 +299,10 @@ def test_marker_controller_refines_and_merges_coarse_clusters_without_asset_walk
     tmp_path: Path,
 ) -> None:
     del qapp
-    first, second, outside = (
-        _assets_at(tmp_path, 1, latitude=10.0, longitude=10.0)[0],
-        _assets_at(tmp_path, 1, latitude=20.0, longitude=20.0)[0],
-        _assets_at(tmp_path, 1, latitude=30.0, longitude=30.0)[0],
-    )
+    first = _assets_at(tmp_path, 1, latitude=10.0, longitude=10.0)[0]
+    second_group = _assets_at(tmp_path, 3, latitude=20.0, longitude=20.0)
+    second = second_group[0]
+    outside = _assets_at(tmp_path, 1, latitude=30.0, longitude=30.0)[0]
     map_widget = _ExactProjectionMapWidget(
         {
             (10.0, 10.0): QPointF(100.0, 100.0),
@@ -319,7 +319,12 @@ def test_marker_controller_refines_and_merges_coarse_clusters_without_asset_walk
     )
     coarse_clusters = [
         _MarkerCluster(representative=first, assets=[first], screen_pos=QPointF(90.0, 90.0)),
-        _MarkerCluster(representative=second, assets=[second], screen_pos=QPointF(110.0, 90.0)),
+        _MarkerCluster(
+            representative=second,
+            assets=second_group,
+            screen_pos=QPointF(160.0, 90.0),
+            representative_screen_pos_approx=QPointF(110.0, 90.0),
+        ),
         _MarkerCluster(representative=outside, assets=[outside], screen_pos=QPointF(700.0, 90.0)),
     ]
 
@@ -328,8 +333,8 @@ def test_marker_controller_refines_and_merges_coarse_clusters_without_asset_walk
             coarse_clusters,
             width=800,
             height=600,
-            threshold=48.0,
-            cell_size=48,
+            threshold=100.0,
+            cell_size=100,
             margin=0,
         )
     finally:
@@ -337,7 +342,49 @@ def test_marker_controller_refines_and_merges_coarse_clusters_without_asset_walk
 
     assert len(refined) == 1
     assert {asset.latitude for asset in refined[0].assets} == {10.0, 20.0}
+    assert len(refined[0].assets) == 4
+    assert refined[0].screen_pos == QPointF(152.5, 100.0)
     assert len(map_widget.project_calls) == len(coarse_clusters)
+
+
+def test_marker_controller_refinement_preserves_corrected_coarse_centroid(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    first, second = _assets_at(tmp_path, 2)
+    map_widget = _ExactProjectionMapWidget(
+        {(first.longitude, first.latitude): QPointF(110.0, 100.0)}
+    )
+    controller = MarkerController(
+        map_widget,
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    coarse_cluster = _MarkerCluster(
+        representative=first,
+        assets=[first, second],
+        screen_pos=QPointF(200.0, 100.0),
+        representative_screen_pos_approx=QPointF(100.0, 100.0),
+    )
+
+    try:
+        refined = controller._refine_exact_projection_clusters(
+            [coarse_cluster],
+            width=800,
+            height=600,
+            threshold=271.0,
+            cell_size=271,
+            margin=72,
+        )
+    finally:
+        controller.shutdown()
+
+    assert len(refined) == 1
+    assert refined[0].screen_pos == QPointF(210.0, 100.0)
+    assert refined[0].screen_pos != QPointF(110.0, 100.0)
 
 
 def test_marker_controller_threshold_grows_when_zooming_out(
@@ -559,6 +606,40 @@ def test_marker_controller_evicts_only_removed_same_library_thumbnails(
     assert removed == [assets[1].library_relative]
     assert loader.invalidate_calls == [assets[1].library_relative]
     assert full_invalidations == [True]
+
+
+def test_marker_controller_ignores_thumbnails_from_old_viewport(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    first, second = _assets_at(tmp_path, 2)
+    controller = MarkerController(
+        _DummyMapWidget(),
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    controller._library_root = tmp_path
+    updates: list[str] = []
+    controller.thumbnailUpdated.connect(lambda rel, _pixmap: updates.append(rel))
+    pixmap = QPixmap(2, 2)
+
+    try:
+        controller._publish_clusters(
+            [_MarkerCluster(representative=first, screen_pos=QPointF(100.0, 100.0))]
+        )
+        controller.handle_thumbnail_ready(tmp_path, first.library_relative, pixmap)
+        controller._publish_clusters(
+            [_MarkerCluster(representative=second, screen_pos=QPointF(200.0, 100.0))]
+        )
+        controller.handle_thumbnail_ready(tmp_path, first.library_relative, pixmap)
+        controller.handle_thumbnail_ready(tmp_path, second.library_relative, pixmap)
+    finally:
+        controller.shutdown()
+
+    assert updates == [first.library_relative, second.library_relative]
 
 
 def test_marker_controller_invalidates_all_thumbnails_when_library_changes(

--- a/tests/test_marker_controller_place_labels.py
+++ b/tests/test_marker_controller_place_labels.py
@@ -64,6 +64,7 @@ class _DummyThumbnailLoader(QObject):
         super().__init__()
         self.reset_calls: list[Path] = []
         self.invalidate_calls: list[str] = []
+        self.evict_calls: list[tuple[str, Path]] = []
 
     def reset_for_album(self, root: Path) -> None:
         self.reset_calls.append(root)
@@ -71,6 +72,9 @@ class _DummyThumbnailLoader(QObject):
 
     def invalidate(self, rel: str) -> None:
         self.invalidate_calls.append(rel)
+
+    def evict(self, rel: str, abs_path: Path) -> None:
+        self.evict_calls.append((rel, abs_path))
 
     def request(self, *args, **kwargs):
         return None
@@ -433,7 +437,7 @@ def test_marker_controller_threshold_grows_when_zooming_out(
         large_zoomed_in = controller._cluster_threshold(
             3_840,
             2_160,
-            density_adaptive=True,
+            density_factor=1.0,
         )
         zoomed_in_clusters = controller._build_exact_projection_clusters(
             width=800,
@@ -447,7 +451,7 @@ def test_marker_controller_threshold_grows_when_zooming_out(
         large_library_threshold = controller._cluster_threshold(
             3_840,
             2_160,
-            density_adaptive=True,
+            density_factor=1.0,
         )
     finally:
         controller.shutdown()
@@ -457,6 +461,49 @@ def test_marker_controller_threshold_grows_when_zooming_out(
     assert large_zoomed_in == 48.0
     assert large_library_threshold > small_library_threshold
     assert len(zoomed_out_clusters) < len(zoomed_in_clusters)
+
+
+def test_marker_controller_density_threshold_ramps_across_projection_boundary(
+    qapp: QApplication,
+) -> None:
+    del qapp
+    controller = MarkerController(
+        _DummyMapWidget(zoom=5.0),
+        _DummyThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    controller._view_zoom = 5.0
+
+    try:
+        factor_1000 = controller._density_adaptation_factor(1_000)
+        factor_1001 = controller._density_adaptation_factor(1_001)
+        factor_2000 = controller._density_adaptation_factor(2_000)
+        threshold_1000 = controller._cluster_threshold(
+            2_560,
+            1_440,
+            density_factor=factor_1000,
+        )
+        threshold_1001 = controller._cluster_threshold(
+            2_560,
+            1_440,
+            density_factor=factor_1001,
+        )
+        threshold_2000 = controller._cluster_threshold(
+            2_560,
+            1_440,
+            density_factor=factor_2000,
+        )
+    finally:
+        controller.shutdown()
+
+    assert factor_1000 == 0.0
+    assert factor_1001 == pytest.approx(0.001)
+    assert factor_2000 == 1.0
+    assert threshold_1000 == 96.0
+    assert threshold_1001 == threshold_1000
+    assert threshold_2000 > threshold_1001
 
 
 def test_marker_controller_rejects_stale_worker_results_after_pan(
@@ -604,7 +651,10 @@ def test_marker_controller_evicts_only_removed_same_library_thumbnails(
         controller.shutdown()
 
     assert removed == [assets[1].library_relative]
-    assert loader.invalidate_calls == [assets[1].library_relative]
+    assert loader.invalidate_calls == []
+    assert loader.evict_calls == [
+        (assets[1].library_relative, assets[1].absolute_path)
+    ]
     assert full_invalidations == [True]
 
 
@@ -640,6 +690,41 @@ def test_marker_controller_ignores_thumbnails_from_old_viewport(
         controller.shutdown()
 
     assert updates == [first.library_relative, second.library_relative]
+
+
+def test_marker_controller_publishes_clusters_before_cached_thumbnails(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    asset = _asset(tmp_path)
+    cached_pixmap = QPixmap(2, 2)
+
+    class _CachedThumbnailLoader(_DummyThumbnailLoader):
+        def request(self, *args, **kwargs):
+            del args, kwargs
+            return cached_pixmap
+
+    controller = MarkerController(
+        _DummyMapWidget(),
+        _CachedThumbnailLoader(),
+        marker_size=72,
+        thumbnail_size=192,
+        provides_place_labels=False,
+    )
+    controller._library_root = tmp_path
+    publication_order: list[str] = []
+    controller.clustersUpdated.connect(lambda _clusters: publication_order.append("clusters"))
+    controller.thumbnailUpdated.connect(lambda _rel, _pixmap: publication_order.append("thumbnail"))
+
+    try:
+        controller._publish_clusters(
+            [_MarkerCluster(representative=asset, screen_pos=QPointF(100.0, 100.0))]
+        )
+    finally:
+        controller.shutdown()
+
+    assert publication_order == ["clusters", "thumbnail"]
 
 
 def test_marker_controller_invalidates_all_thumbnails_when_library_changes(

--- a/tests/test_photo_map_view.py
+++ b/tests/test_photo_map_view.py
@@ -152,6 +152,12 @@ class _DummyThumbnailLoader(QObject):
         del root
         return None
 
+    def invalidate(self, rel: str) -> None:
+        del rel
+
+    def evict(self, rel: str, abs_path: Path) -> None:
+        del rel, abs_path
+
     def request(self, *args, **kwargs):
         del args, kwargs
         return None
@@ -645,6 +651,53 @@ def test_marker_layer_uses_bounded_lru_and_supports_precise_removal(
     layer.remove_thumbnail("first.jpg")
 
     assert list(layer._pixmaps) == ["third.jpg"]
+
+
+def test_marker_layer_pins_all_visible_thumbnails_above_history_limit(
+    qapp: QApplication,
+    tmp_path: Path,
+) -> None:
+    del qapp
+    layer = photo_map_view_module._MarkerLayer()
+    layer.MAX_PIXMAPS = 2
+
+    def cluster(rel: str, x: float) -> photo_map_view_module._MarkerCluster:
+        asset = photo_map_view_module.GeotaggedAsset(
+            library_relative=rel,
+            album_relative=rel,
+            absolute_path=tmp_path / rel,
+            album_path=tmp_path,
+            asset_id=rel,
+            latitude=0.0,
+            longitude=0.0,
+            is_image=True,
+            is_video=False,
+            still_image_time=None,
+            duration=None,
+            location_name=None,
+            live_photo_group_id=None,
+            live_partner_rel=None,
+        )
+        return photo_map_view_module._MarkerCluster(
+            representative=asset,
+            screen_pos=QPointF(x, 100.0),
+        )
+
+    clusters = [
+        cluster("first.jpg", 100.0),
+        cluster("second.jpg", 200.0),
+        cluster("third.jpg", 300.0),
+    ]
+    pixmap = QPixmap(2, 2)
+    layer.set_clusters(clusters)
+    for item in clusters:
+        layer.set_thumbnail(item.representative.library_relative, pixmap)
+
+    assert list(layer._pixmaps) == ["first.jpg", "second.jpg", "third.jpg"]
+
+    layer.set_clusters(clusters[1:])
+
+    assert list(layer._pixmaps) == ["second.jpg", "third.jpg"]
 
 
 def test_photo_map_view_routes_marker_assets_through_interaction_service(

--- a/tests/test_photo_map_view.py
+++ b/tests/test_photo_map_view.py
@@ -164,6 +164,7 @@ class _DummyMarkerController(QObject):
     clusterActivated = Signal(list)
     markerActivated = Signal(list)
     thumbnailUpdated = Signal(str, QPixmap)
+    thumbnailInvalidated = Signal(str)
     thumbnailsInvalidated = Signal()
 
     def __init__(self, *args, **kwargs) -> None:
@@ -619,6 +620,31 @@ def test_marker_callout_background_is_opaque(qapp: QApplication, tmp_path) -> No
     assert sample.red() == 255
     assert sample.green() == 255
     assert sample.blue() == 255
+
+
+def test_marker_layer_uses_bounded_lru_and_supports_precise_removal(
+    qapp: QApplication,
+) -> None:
+    del qapp
+    layer = photo_map_view_module._MarkerLayer()
+    layer.MAX_PIXMAPS = 2
+    first = QPixmap(2, 2)
+    first.fill(Qt.GlobalColor.red)
+    second = QPixmap(2, 2)
+    second.fill(Qt.GlobalColor.green)
+    third = QPixmap(2, 2)
+    third.fill(Qt.GlobalColor.blue)
+
+    layer.set_thumbnail("first.jpg", first)
+    layer.set_thumbnail("second.jpg", second)
+    layer.set_thumbnail("first.jpg", first)
+    layer.set_thumbnail("third.jpg", third)
+
+    assert list(layer._pixmaps) == ["first.jpg", "third.jpg"]
+
+    layer.remove_thumbnail("first.jpg")
+
+    assert list(layer._pixmaps) == ["third.jpg"]
 
 
 def test_photo_map_view_routes_marker_assets_through_interaction_service(

--- a/tests/test_photo_map_view.py
+++ b/tests/test_photo_map_view.py
@@ -158,6 +158,9 @@ class _DummyThumbnailLoader(QObject):
     def evict(self, rel: str, abs_path: Path) -> None:
         del rel, abs_path
 
+    def evict_many(self, entries: list[tuple[str, Path]]) -> None:
+        del entries
+
     def request(self, *args, **kwargs):
         del args, kwargs
         return None

--- a/tests/test_thumbnail_loader.py
+++ b/tests/test_thumbnail_loader.py
@@ -299,6 +299,7 @@ def test_thumbnail_loader_accepted_result_removes_superseded_disk_versions(
     image.fill(Qt.GlobalColor.green)
 
     loader._handle_result((*key, 2), image, rel, generation)
+    loader._flush_cache_cleanup()
     assert loader._pool.waitForDone(4_000)
 
     assert not old_path.exists()
@@ -325,6 +326,7 @@ def test_thumbnail_loader_evict_removes_all_known_disk_versions(
         cache_path.write_bytes(b"cached")
 
     loader.evict(rel, path)
+    loader._flush_cache_cleanup()
     assert loader._pool.waitForDone(4_000)
 
     assert key not in loader._memory
@@ -352,8 +354,36 @@ def test_thumbnail_loader_evict_many_clears_memory_before_background_cleanup(
     loader.evict_many(removed)
 
     assert loader._memory == {}
+    assert manual_pool.jobs == []
+    loader._flush_cache_cleanup()
     assert len(manual_pool.jobs) == 1
     assert manual_pool.priorities == [int(ThumbnailLoader.Priority.LOW)]
+
+
+def test_cleanup_accumulator_flushes_once_after_quiet_window(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+
+    loader.evict_many(
+        [
+            ("first.jpg", tmp_path / "first.jpg"),
+            ("second.jpg", tmp_path / "second.jpg"),
+        ]
+    )
+    assert manual_pool.jobs == []
+
+    deadline = time.monotonic() + 1.0
+    while not manual_pool.jobs and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+
+    assert len(manual_pool.jobs) == 1
+    assert len(manual_pool.jobs[0]._targets) == 2
 
 
 def test_deferred_eviction_does_not_delete_reactivated_rel_cache(
@@ -374,6 +404,7 @@ def test_deferred_eviction_does_not_delete_reactivated_rel_cache(
     cache_path.write_bytes(b"new-current-cache")
 
     loader.evict(rel, path)
+    loader._flush_cache_cleanup()
     assert len(manual_pool.jobs) == 1
 
     loader._max_active_jobs = 0
@@ -507,6 +538,7 @@ def test_stale_result_defers_shared_disk_cleanup_to_current_generation(
         current_cache_path,
     )
 
+    loader._flush_cache_cleanup()
     assert len(manual_pool.jobs) == 1
     manual_pool.jobs[0].run()
     assert not stale_cache_path.exists()
@@ -553,6 +585,7 @@ def test_deferred_reconciliation_cannot_prune_a_newer_generation(
     image = QImage(2, 2, QImage.Format.Format_ARGB32)
 
     loader._handle_result((*key, 1), image, rel, first_generation, first_cache_path)
+    loader._flush_cache_cleanup()
     assert len(manual_pool.jobs) == 1
 
     loader.invalidate(rel)
@@ -560,6 +593,153 @@ def test_deferred_reconciliation_cannot_prune_a_newer_generation(
 
     assert first_cache_path.exists()
     assert next_cache_path.exists()
+
+
+def test_changed_asset_reconciliation_coalesces_into_one_directory_scan(
+    tmp_path: Path,
+) -> None:
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    size = QSize(512, 512)
+    changed_count = 100
+
+    for index in range(changed_count):
+        rel = f"changed-{index}.jpg"
+        path = tmp_path / rel
+        key = loader._base_key(rel, size)
+        loader.invalidate(rel)
+        generation = loader._generation_token(rel)
+        loader._store_job_spec(
+            key,
+            rel,
+            path,
+            size,
+            None,
+            tmp_path,
+            tmp_path,
+            True,
+            False,
+            None,
+            None,
+            generation,
+        )
+        loader._pending_keys.add(key)
+        loader._active_jobs_count += 1
+        loader._handle_validation_success((*key, index + 1), generation)
+
+    assert manual_pool.jobs == []
+    assert sum(
+        len(targets)
+        for _root, targets in loader._pending_cache_cleanup_targets.values()
+    ) == changed_count
+
+    with patch(
+        "iPhoto.gui.ui.tasks.thumbnail_cache.os.scandir",
+        wraps=os.scandir,
+    ) as scandir:
+        loader._flush_cache_cleanup()
+        assert len(manual_pool.jobs) == 1
+        assert len(manual_pool.jobs[0]._targets) == changed_count
+        manual_pool.jobs[0].run()
+
+    assert scandir.call_count == 1
+
+
+def test_invalidation_with_known_stamp_skips_directory_reconciliation(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    rel = "metadata-only.jpg"
+    path = tmp_path / rel
+    size = QSize(512, 512)
+    key = loader._base_key(rel, size)
+    loader._memory[key] = (123, QPixmap(2, 2))
+
+    loader.invalidate(rel)
+    generation = loader._generation_token(rel)
+    loader._store_job_spec(
+        key,
+        rel,
+        path,
+        size,
+        123,
+        tmp_path,
+        tmp_path,
+        True,
+        False,
+        None,
+        None,
+        generation,
+    )
+    loader._pending_keys.add(key)
+    loader._active_jobs_count = 1
+    loader._handle_validation_success((*key, 123), generation)
+    loader._flush_cache_cleanup()
+
+    assert manual_pool.jobs == []
+
+
+def test_deferred_cleanup_rejects_cross_library_aba_generation(
+    tmp_path: Path,
+) -> None:
+    library_a = tmp_path / "library-a"
+    library_b = tmp_path / "library-b"
+    loader = ThumbnailLoader()
+    loader.reset_for_album(library_a)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    rel = "DCIM/001.jpg"
+    path = library_a / rel
+    size = QSize(512, 512)
+    current_cache_path = generate_cache_path(library_a, path, size, 1)
+    current_cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    loader.evict(rel, path)
+    loader._flush_cache_cleanup()
+    assert len(manual_pool.jobs) == 1
+
+    loader.reset_for_album(library_b)
+    loader.reset_for_album(library_a)
+    loader.invalidate(rel)
+    assert loader._generation_token(rel)[1] == 1
+    current_cache_path.write_bytes(b"current-a-epoch")
+
+    manual_pool.jobs[0].run()
+
+    assert current_cache_path.exists()
+
+
+def test_deferred_cleanup_can_finish_while_its_library_is_inactive(
+    tmp_path: Path,
+) -> None:
+    library_a = tmp_path / "library-a"
+    library_b = tmp_path / "library-b"
+    loader = ThumbnailLoader()
+    loader.reset_for_album(library_a)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    rel = "DCIM/removed.jpg"
+    path = library_a / rel
+    size = QSize(512, 512)
+    old_cache_path = generate_cache_path(library_a, path, size, 1)
+    old_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    old_cache_path.write_bytes(b"removed")
+
+    loader.evict(rel, path)
+    loader._flush_cache_cleanup()
+    assert len(manual_pool.jobs) == 1
+
+    loader.reset_for_album(library_b)
+    manual_pool.jobs[0].run()
+
+    assert not old_cache_path.exists()
 
 
 def test_stale_validation_does_not_clear_current_pending_job(tmp_path: Path) -> None:

--- a/tests/test_thumbnail_loader.py
+++ b/tests/test_thumbnail_loader.py
@@ -1,6 +1,8 @@
 import hashlib
 import os
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import patch
 
@@ -18,7 +20,14 @@ from PySide6.QtTest import QSignalSpy
 from PySide6.QtWidgets import QApplication
 
 from iPhoto.config import WORK_DIR_NAME
-from iPhoto.gui.ui.tasks.thumbnail_loader import ThumbnailLoader, generate_cache_path, safe_unlink
+from iPhoto.gui.ui.tasks.thumbnail_cache import write_cache
+from iPhoto.gui.ui.tasks.thumbnail_loader import (
+    CacheCleanupTarget,
+    ThumbnailLoader,
+    generate_cache_path,
+    remove_cache_versions_many,
+    safe_unlink,
+)
 from iPhoto.io.sidecar import save_adjustments
 
 try:
@@ -33,6 +42,16 @@ except Exception as exc:  # pragma: no cover - pillow missing or broken
 def _create_image(path: Path) -> None:
     image = Image.new("RGB", (16, 16), color="red")
     image.save(path)
+
+
+class _ManualPool:
+    def __init__(self) -> None:
+        self.jobs = []
+        self.priorities: list[int] = []
+
+    def start(self, job, priority: int = 0) -> None:
+        self.jobs.append(job)
+        self.priorities.append(priority)
 
 
 def test_generate_cache_path_basic(tmp_path: Path) -> None:
@@ -280,6 +299,7 @@ def test_thumbnail_loader_accepted_result_removes_superseded_disk_versions(
     image.fill(Qt.GlobalColor.green)
 
     loader._handle_result((*key, 2), image, rel, generation)
+    assert loader._pool.waitForDone(4_000)
 
     assert not old_path.exists()
     assert current_path.exists()
@@ -305,9 +325,241 @@ def test_thumbnail_loader_evict_removes_all_known_disk_versions(
         cache_path.write_bytes(b"cached")
 
     loader.evict(rel, path)
+    assert loader._pool.waitForDone(4_000)
 
     assert key not in loader._memory
     assert all(not cache_path.exists() for cache_path in cache_paths)
+
+
+def test_thumbnail_loader_evict_many_clears_memory_before_background_cleanup(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    size = QSize(512, 512)
+    removed = [
+        (f"removed-{index}.jpg", tmp_path / f"removed-{index}.jpg")
+        for index in range(3)
+    ]
+    for index, (rel, _path) in enumerate(removed):
+        loader._memory[loader._base_key(rel, size)] = (index, QPixmap(2, 2))
+
+    loader.evict_many(removed)
+
+    assert loader._memory == {}
+    assert len(manual_pool.jobs) == 1
+    assert manual_pool.priorities == [int(ThumbnailLoader.Priority.LOW)]
+
+
+def test_deferred_eviction_does_not_delete_reactivated_rel_cache(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    rel = "recreated.jpg"
+    path = tmp_path / rel
+    size = QSize(512, 512)
+    cache_path = generate_cache_path(tmp_path, path, size, 1)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(b"new-current-cache")
+
+    loader.evict(rel, path)
+    assert len(manual_pool.jobs) == 1
+
+    loader._max_active_jobs = 0
+    loader.request(rel, path, size, is_image=True)
+    manual_pool.jobs[0].run()
+
+    assert cache_path.exists()
+
+
+def test_remove_cache_versions_many_scans_thumbnail_directory_once(
+    tmp_path: Path,
+) -> None:
+    size = QSize(512, 512)
+    first_path = tmp_path / "first.jpg"
+    second_path = tmp_path / "second.jpg"
+    survivor_path = tmp_path / "survivor.jpg"
+    removed_paths = [
+        generate_cache_path(tmp_path, asset_path, size, stamp)
+        for asset_path in (first_path, second_path)
+        for stamp in (1, 2)
+    ]
+    survivor_cache_path = generate_cache_path(tmp_path, survivor_path, size, 1)
+    removed_paths[0].parent.mkdir(parents=True, exist_ok=True)
+    for cache_path in [*removed_paths, survivor_cache_path]:
+        cache_path.write_bytes(b"cached")
+
+    with patch(
+        "iPhoto.gui.ui.tasks.thumbnail_cache.os.scandir",
+        wraps=os.scandir,
+    ) as scandir:
+        remove_cache_versions_many(
+            tmp_path,
+            [
+                CacheCleanupTarget(first_path, size),
+                CacheCleanupTarget(second_path, size),
+            ],
+        )
+
+    assert scandir.call_count == 1
+    assert all(not cache_path.exists() for cache_path in removed_paths)
+    assert survivor_cache_path.exists()
+
+
+def test_write_cache_uses_unique_temp_files_for_concurrent_writers(
+    tmp_path: Path,
+) -> None:
+    barrier = threading.Barrier(2)
+    destination = tmp_path / "shared.png"
+
+    class _ConcurrentCanvas:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def save(self, path: str, image_format: str) -> bool:
+            assert image_format == "PNG"
+            Path(path).write_bytes(self._payload)
+            barrier.wait(timeout=2.0)
+            return True
+
+    payloads = (b"first-writer", b"second-writer")
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda payload: write_cache(_ConcurrentCanvas(payload), destination),
+                payloads,
+            )
+        )
+
+    assert results == [True, True]
+    assert destination.read_bytes() in payloads
+    assert not [path for path in tmp_path.iterdir() if path.name.endswith(".tmp")]
+
+
+def test_stale_result_defers_shared_disk_cleanup_to_current_generation(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    rel = "race.jpg"
+    path = tmp_path / rel
+    size = QSize(512, 512)
+    key = loader._base_key(rel, size)
+    stale_generation = loader._generation_token(rel)
+    loader.invalidate(rel)
+    current_generation = loader._generation_token(rel)
+    loader._store_job_spec(
+        key,
+        rel,
+        path,
+        size,
+        None,
+        tmp_path,
+        tmp_path,
+        True,
+        False,
+        None,
+        None,
+        current_generation,
+    )
+    loader._pending_keys.add(key)
+    loader._active_jobs_count = 2
+    stale_cache_path = generate_cache_path(tmp_path, path, size, 1)
+    current_cache_path = generate_cache_path(tmp_path, path, size, 2)
+    stale_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_cache_path.write_bytes(b"stale")
+    current_cache_path.write_bytes(b"current")
+    stale_image = QImage(2, 2, QImage.Format.Format_ARGB32)
+    current_image = QImage(2, 2, QImage.Format.Format_ARGB32)
+
+    loader._handle_result(
+        (*key, 1),
+        stale_image,
+        rel,
+        stale_generation,
+        stale_cache_path,
+    )
+
+    assert stale_cache_path.exists()
+    assert manual_pool.jobs == []
+
+    loader._handle_result(
+        (*key, 2),
+        current_image,
+        rel,
+        current_generation,
+        current_cache_path,
+    )
+
+    assert len(manual_pool.jobs) == 1
+    manual_pool.jobs[0].run()
+    assert not stale_cache_path.exists()
+    assert current_cache_path.exists()
+
+
+def test_deferred_reconciliation_cannot_prune_a_newer_generation(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    manual_pool = _ManualPool()
+    loader._pool = manual_pool
+    rel = "changed-again.jpg"
+    path = tmp_path / rel
+    size = QSize(512, 512)
+    key = loader._base_key(rel, size)
+    loader.invalidate(rel)
+    first_generation = loader._generation_token(rel)
+    loader._store_job_spec(
+        key,
+        rel,
+        path,
+        size,
+        None,
+        tmp_path,
+        tmp_path,
+        True,
+        False,
+        None,
+        None,
+        first_generation,
+    )
+    loader._pending_keys.add(key)
+    loader._active_jobs_count = 1
+    first_cache_path = generate_cache_path(tmp_path, path, size, 1)
+    next_cache_path = generate_cache_path(tmp_path, path, size, 2)
+    first_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    first_cache_path.write_bytes(b"first")
+    next_cache_path.write_bytes(b"next")
+    image = QImage(2, 2, QImage.Format.Format_ARGB32)
+
+    loader._handle_result((*key, 1), image, rel, first_generation, first_cache_path)
+    assert len(manual_pool.jobs) == 1
+
+    loader.invalidate(rel)
+    manual_pool.jobs[0].run()
+
+    assert first_cache_path.exists()
+    assert next_cache_path.exists()
 
 
 def test_stale_validation_does_not_clear_current_pending_job(tmp_path: Path) -> None:

--- a/tests/test_thumbnail_loader.py
+++ b/tests/test_thumbnail_loader.py
@@ -13,7 +13,7 @@ pytest.importorskip(
 pytest.importorskip("PySide6.QtTest", reason="Qt test utilities unavailable", exc_type=ImportError)
 
 from PySide6.QtCore import QSize, Qt
-from PySide6.QtGui import QImage
+from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtTest import QSignalSpy
 from PySide6.QtWidgets import QApplication
 
@@ -191,15 +191,123 @@ def test_thumbnail_loader_rejects_stale_generation_results(
     current_image.fill(Qt.GlobalColor.green)
     stale_image = QImage(2, 2, QImage.Format.Format_ARGB32)
     stale_image.fill(Qt.GlobalColor.red)
+    stale_cache_path = generate_cache_path(
+        tmp_path,
+        tmp_path / rel,
+        QSize(512, 512),
+        1,
+    )
+    stale_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_cache_path.write_bytes(b"stale")
     loader._active_jobs_count = 2
 
     loader._handle_result((*key, 2), current_image, rel, current_generation)
-    loader._handle_result((*key, 1), stale_image, rel, stale_generation)
+    loader._handle_result(
+        (*key, 1),
+        stale_image,
+        rel,
+        stale_generation,
+        stale_cache_path,
+    )
 
     stamp, pixmap = loader._memory[key]
     assert stamp == 2
     assert pixmap.toImage().pixelColor(0, 0) == current_image.pixelColor(0, 0)
     assert ready_spy.count() == 1
+    assert not stale_cache_path.exists()
+
+
+def test_thumbnail_loader_invalidation_preserves_stale_pixmap_and_stamp(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    rel = "changed.jpg"
+    path = tmp_path / rel
+    key = loader._base_key(rel, QSize(512, 512))
+    stale_pixmap = QPixmap(2, 2)
+    stale_pixmap.fill(Qt.GlobalColor.red)
+    loader._memory[key] = (123, stale_pixmap)
+    loader._max_active_jobs = 0
+
+    loader.invalidate(rel)
+    returned = loader.request(rel, path, QSize(192, 192), is_image=True)
+
+    assert loader._memory[key][0] == 123
+    assert returned is not None
+    assert returned.cacheKey() == stale_pixmap.cacheKey()
+    assert loader._job_specs[key][3] == 123
+    assert loader._job_specs[key][-1] == loader._generation_token(rel)
+
+
+def test_thumbnail_loader_accepted_result_removes_superseded_disk_versions(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    rel = "changed.jpg"
+    path = tmp_path / rel
+    size = QSize(512, 512)
+    key = loader._base_key(rel, size)
+    old_path = generate_cache_path(tmp_path, path, size, 1)
+    current_path = generate_cache_path(tmp_path, path, size, 2)
+    old_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.write_bytes(b"old")
+    current_path.write_bytes(b"current")
+    loader.invalidate(rel)
+    generation = loader._generation_token(rel)
+    loader._store_job_spec(
+        key,
+        rel,
+        path,
+        size,
+        1,
+        tmp_path,
+        tmp_path,
+        True,
+        False,
+        None,
+        None,
+        generation,
+    )
+    loader._pending_keys.add(key)
+    loader._active_jobs_count = 1
+    image = QImage(2, 2, QImage.Format.Format_ARGB32)
+    image.fill(Qt.GlobalColor.green)
+
+    loader._handle_result((*key, 2), image, rel, generation)
+
+    assert not old_path.exists()
+    assert current_path.exists()
+
+
+def test_thumbnail_loader_evict_removes_all_known_disk_versions(
+    tmp_path: Path,
+) -> None:
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    rel = "removed.jpg"
+    path = tmp_path / rel
+    size = QSize(512, 512)
+    key = loader._base_key(rel, size)
+    pixmap = QPixmap(2, 2)
+    loader._memory[key] = (1, pixmap)
+    cache_paths = [
+        generate_cache_path(tmp_path, path, size, stamp)
+        for stamp in (1, 2)
+    ]
+    cache_paths[0].parent.mkdir(parents=True, exist_ok=True)
+    for cache_path in cache_paths:
+        cache_path.write_bytes(b"cached")
+
+    loader.evict(rel, path)
+
+    assert key not in loader._memory
+    assert all(not cache_path.exists() for cache_path in cache_paths)
 
 
 def test_stale_validation_does_not_clear_current_pending_job(tmp_path: Path) -> None:

--- a/tests/test_thumbnail_loader.py
+++ b/tests/test_thumbnail_loader.py
@@ -12,7 +12,8 @@ pytest.importorskip(
 )
 pytest.importorskip("PySide6.QtTest", reason="Qt test utilities unavailable", exc_type=ImportError)
 
-from PySide6.QtCore import QSize
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QImage
 from PySide6.QtTest import QSignalSpy
 from PySide6.QtWidgets import QApplication
 
@@ -170,6 +171,50 @@ def test_thumbnail_loader_lru_eviction(tmp_path: Path, qapp: QApplication) -> No
     assert "IMG_3.JPG" not in rels
     assert "IMG_2.JPG" in rels
     assert "IMG_4.JPG" in rels
+
+
+def test_thumbnail_loader_rejects_stale_generation_results(
+    tmp_path: Path,
+    qapp: QApplication,
+) -> None:
+    del qapp
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    rel = "race.jpg"
+    key = loader._base_key(rel, QSize(512, 512))
+    stale_generation = loader._generation_token(rel)
+    loader.invalidate(rel)
+    current_generation = loader._generation_token(rel)
+    ready_spy = QSignalSpy(loader.ready)
+
+    current_image = QImage(2, 2, QImage.Format.Format_ARGB32)
+    current_image.fill(Qt.GlobalColor.green)
+    stale_image = QImage(2, 2, QImage.Format.Format_ARGB32)
+    stale_image.fill(Qt.GlobalColor.red)
+    loader._active_jobs_count = 2
+
+    loader._handle_result((*key, 2), current_image, rel, current_generation)
+    loader._handle_result((*key, 1), stale_image, rel, stale_generation)
+
+    stamp, pixmap = loader._memory[key]
+    assert stamp == 2
+    assert pixmap.toImage().pixelColor(0, 0) == current_image.pixelColor(0, 0)
+    assert ready_spy.count() == 1
+
+
+def test_stale_validation_does_not_clear_current_pending_job(tmp_path: Path) -> None:
+    loader = ThumbnailLoader()
+    loader.reset_for_album(tmp_path)
+    rel = "race.jpg"
+    key = loader._base_key(rel, QSize(512, 512))
+    stale_generation = loader._generation_token(rel)
+    loader.invalidate(rel)
+    loader._pending_keys.add(key)
+    loader._active_jobs_count = 1
+
+    loader._handle_validation_success((*key, 1), stale_generation)
+
+    assert key in loader._pending_keys
 
 
 def test_generate_cache_path_different_stamps(tmp_path: Path) -> None:

--- a/tests/test_thumbnail_loader_retry.py
+++ b/tests/test_thumbnail_loader_retry.py
@@ -32,6 +32,7 @@ def test_thumbnail_loader_retries_once_on_failure(tmp_path):
         False,
         None,
         None,
+        loader._generation_token(rel),
     )
     loader._pending_keys.add(base_key)
     loader._active_jobs_count = 1


### PR DESCRIPTION
## Summary

- preserve marker thumbnails during same-library rescans with generation-safe stale-while-revalidate
- retain changed assets' stale pixmap and stamp so metadata-only validation hits avoid disk reconciliation entirely
- accumulate genuinely required changed-asset reconciliation behind a quiet window; wait for the active thumbnail wave to settle, then process all targets with one low-priority directory scan per root
- batch removed-asset eviction: clear memory/request state once on the GUI thread, then prune matching disk versions with the same serialized cleanup pipeline
- bind deferred cleanup ownership to `(root identity, root activation epoch, rel generation)`, preventing A → B → A ABA deletion while still allowing an old root cleanup to finish when that root is merely inactive
- give every thumbnail writer a unique adjacent temp file and atomically replace the final cache path
- prevent stale callbacks and cleanup jobs from deleting cache files owned by a pending or newer generation, including delete-then-recreate of the same path
- publish asynchronous thumbnails only for current viewport representatives and pin all visible overlay pixmaps
- move large Native OsmAnd clustering to the background and preserve corrected coarse centroids during bounded exact refinement
- keep projection dispatch at 1000 assets while independently ramping density adaptation smoothly from 1000 to 2000 assets
- keep legacy vector tiles locked to fetch level 6 with the original zoom scaling formula
- run deterministic 1k/10k/50k Maps contracts in Actions, including centroid, geometry, and cluster-membership continuity at the 1000/1001 boundary

## Root cause

Same-library refreshes previously cleared every marker pixmap, while Native OsmAnd projected every GPS asset on the GUI thread. Incremental invalidation also lost cache ownership across active jobs, removed or changed assets could repeatedly scan the thumbnail directory, and concurrent writers shared the same deterministic `.tmp` path.

The controller and loader now treat changed and removed assets separately. Known stamps use exact-path cleanup and metadata-only validation does no directory scan. Unknown sibling reconciliation is coalesced across the whole active thumbnail wave, making a large changed batch approximately `O(M + C)` instead of `O(M × C)`. Cleanup jobs are serialized and run outside the GUI path.

Root-scoped activation epochs keep inactive-root cleanup valid without allowing an older activation to match a numerically repeated rel generation after A → B → A. Writer-unique temporary files and atomic replacement eliminate shared-temp races.

Density behavior remains independent from exact-versus-hybrid projection and increases gradually. The overlay pins current cluster representatives and applies its fixed limit only to history entries.

## User impact

Maps retain thumbnails through rescans and rapid pans without settling on placeholders. Large metadata rescans and delete operations no longer create repeated thumbnail-directory scans, and delayed work from an older library activation cannot remove the current cache. Large libraries avoid full-catalog native projection on the GUI thread, while high-zoom behavior and legacy tile magnification remain unchanged.

## Validation

- `OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 QT_QPA_PLATFORM=offscreen NUMBA_DISABLE_JIT=1 ./.venv/bin/pytest -q` — 3110 passed, 20 skipped
- `IPHOTO_RUN_MAPS_SCALE_CONTRACT=1 QT_QPA_PLATFORM=offscreen ./.venv/bin/pytest -q tests/contracts/test_map_marker_scale_contract.py` — 4 passed
- targeted thumbnail/marker/map-view regressions — 93 passed
- explicit coverage for 100-target single-scan coalescing, quiet-window flushing, known-stamp no-op reconciliation, A → B → A ABA rejection, inactive-root cleanup, concurrent writers, and delete/recreate ownership
- architecture checks, Python compileall, Ruff fatal/error and touched-file import checks, and `git diff --check` — passed
