### PR TITLE
Fix stale Live Photo playback events and media tool timeouts

### DIFF
--- a/src/iPhoto/errors/__init__.py
+++ b/src/iPhoto/errors/__init__.py
@@ -71,6 +71,10 @@ class ExternalToolError(IPhotoError):
     """Raised when an external tool such as exiftool or ffmpeg fails."""
 
 
+class ExternalToolTimeoutError(ExternalToolError):
+    """Raised when an external tool exceeds its bounded execution time."""
+
+
 class IndexCorruptedError(IPhotoError):
     """Raised when the cached index cannot be parsed."""
 

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -335,6 +335,7 @@ class PlaybackCoordinator(QObject):
         self._active_live_motion: Path | None = None
         self._active_live_still: Path | None = None
         self._active_live_asset_id: str = ""
+        self._active_live_media_generation: int | None = None
         self._resume_after_transition = False
         self._trim_in_ms = 0
         self._trim_out_ms = 0
@@ -468,6 +469,7 @@ class PlaybackCoordinator(QObject):
         self._active_live_motion = None
         self._active_live_still = None
         self._active_live_asset_id = ""
+        self._active_live_media_generation = None
         self._presented_still_generation = 0
         self._presented_still_source = None
         video_area = self._player_view.video_area
@@ -1186,6 +1188,7 @@ class PlaybackCoordinator(QObject):
         self._active_live_motion = None
         self._active_live_still = None
         self._active_live_asset_id = ""
+        self._active_live_media_generation = None
 
         self._reconcile_action_capabilities(presentation)
         self._info_button.setEnabled(True)
@@ -1512,7 +1515,7 @@ class PlaybackCoordinator(QObject):
         self._player_view.defer_still_updates(True)
         self._trim_in_ms = 0
         self._trim_out_ms = 0
-        self._player_view.video_area.begin_load(
+        self._active_live_media_generation = self._player_view.video_area.begin_load(
             motion_path,
             presentation.request_generation,
         )
@@ -1542,7 +1545,9 @@ class PlaybackCoordinator(QObject):
         if stop_motion:
             self._player_view.video_area.stop()
         self._active_live_motion = None
+        self._active_live_still = None
         self._active_live_asset_id = ""
+        self._active_live_media_generation = None
         self._player_view.defer_still_updates(False)
         if not self._player_view.apply_pending_still():
             if (
@@ -1562,7 +1567,23 @@ class PlaybackCoordinator(QObject):
         self._is_playing = False
         return True
 
-    def _handle_playback_finished(self) -> None:
+    @Slot(int, object, int)
+    def _handle_playback_finished(
+        self,
+        request_generation: int,
+        source: object,
+        media_generation: int,
+    ) -> None:
+        try:
+            finished_source = Path(source)
+        except TypeError:
+            return
+        if request_generation != getattr(self, "_detail_request_generation", 0):
+            return
+        if finished_source != getattr(self, "_active_live_motion", None):
+            return
+        if media_generation != getattr(self, "_active_live_media_generation", None):
+            return
         self._restore_live_still()
 
     def _hide_face_name_overlay(self, *, clear_annotations: bool) -> None:

--- a/src/iPhoto/gui/ui/tasks/video_frame_grabber.py
+++ b/src/iPhoto/gui/ui/tasks/video_frame_grabber.py
@@ -34,7 +34,10 @@ def grab_video_frame(
         trim_out_sec=trim_out_sec,
     ):
         # 1. Try PyAV first (direct memory access, faster)
-        pil_image = extract_frame_with_pyav(path, at=target, scale=target_size)
+        try:
+            pil_image = extract_frame_with_pyav(path, at=target, scale=target_size)
+        except ExternalToolTimeoutError:
+            return None
         if pil_image:
             return image_loader.qimage_from_pil(pil_image)
 

--- a/src/iPhoto/gui/ui/tasks/video_frame_grabber.py
+++ b/src/iPhoto/gui/ui/tasks/video_frame_grabber.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import QSize
 from PySide6.QtGui import QImage
 
 from ....config import THUMBNAIL_SEEK_GUARD_SEC
-from ....errors import ExternalToolError
+from ....errors import ExternalToolError, ExternalToolTimeoutError
 from ....utils import image_loader
 from ....utils.ffmpeg import extract_frame_with_pyav, extract_video_frame
 
@@ -48,6 +48,8 @@ def grab_video_frame(
             )
             if frame_data:
                 return image_loader.qimage_from_bytes(frame_data)
+        except ExternalToolTimeoutError:
+            return None
         except ExternalToolError:
             continue
 

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -173,6 +173,9 @@ class VideoArea(QWidget):
         self._video_frame_dispatch_pending = False
         self._video_frame_dispatch_generation: int | None = None
         self._media_generation = 0
+        self._end_detection_armed_media_generation: int | None = None
+        self._position_changed_handler = None
+        self._media_status_changed_handler = None
         self._detail_request_generation = 0
         self._presentation_committed = False
         self._awaiting_first_gpu_frame_generation: int | None = None
@@ -208,11 +211,10 @@ class VideoArea(QWidget):
         self._video_output_attached = True
         self._bind_video_sink_generation(self._media_generation)
 
-        self._player.positionChanged.connect(self._on_position_changed)
         self._player.durationChanged.connect(self._on_duration_changed)
         self._player.playbackStateChanged.connect(self._on_playback_state_changed)
-        self._player.mediaStatusChanged.connect(self._on_media_status_changed)
         self._player.errorOccurred.connect(self._on_error_occurred)
+        self._bind_end_detection_generation(self._media_generation)
         # --- End Media Player Setup ---
 
         self._overlay_margin = 48
@@ -909,6 +911,8 @@ class VideoArea(QWidget):
         """Invalidate queued frames and release every downstream frame owner."""
 
         self._media_generation += 1
+        self._end_detection_armed_media_generation = None
+        self._bind_end_detection_generation(self._media_generation)
         self._accept_video_frames = False
         self._resize_refit_timer.stop()
         self._resize_refit_pending = False
@@ -920,6 +924,46 @@ class VideoArea(QWidget):
         self._renderer.clear_frame()
         self._edit_viewer.clear()
         return self._media_generation
+
+    def _bind_end_detection_generation(self, generation: int) -> None:
+        """Bind end-producing player callbacks to one media generation."""
+
+        previous_position_handler = self._position_changed_handler
+        if previous_position_handler is not None:
+            try:
+                self._player.positionChanged.disconnect(previous_position_handler)
+            except (RuntimeError, TypeError):
+                pass
+
+        previous_status_handler = self._media_status_changed_handler
+        if previous_status_handler is not None:
+            try:
+                self._player.mediaStatusChanged.disconnect(previous_status_handler)
+            except (RuntimeError, TypeError):
+                pass
+
+        def _handle_position(position: int, *, bound_generation: int = generation) -> None:
+            self._on_position_changed(position, media_generation=bound_generation)
+
+        def _handle_status(
+            status: QMediaPlayer.MediaStatus,
+            *,
+            bound_generation: int = generation,
+        ) -> None:
+            self._on_media_status_changed(status, media_generation=bound_generation)
+
+        self._position_changed_handler = _handle_position
+        self._media_status_changed_handler = _handle_status
+        self._player.positionChanged.connect(_handle_position)
+        self._player.mediaStatusChanged.connect(_handle_status)
+
+    def _end_detection_is_armed(self, media_generation: int) -> bool:
+        """Return whether end detection belongs to the current presented media."""
+
+        return (
+            int(media_generation) == self._media_generation
+            and self._end_detection_armed_media_generation == self._media_generation
+        )
 
     def _bind_video_sink_generation(self, generation: int) -> None:
         """Bind sink delivery to one media generation so old queued calls expire."""
@@ -1122,17 +1166,46 @@ class VideoArea(QWidget):
         generation = self._awaiting_first_gpu_frame_generation
         if generation is None or generation != self._detail_request_generation:
             return
+        media_generation = self._media_generation
         self._awaiting_first_gpu_frame_generation = None
+        self._end_detection_armed_media_generation = media_generation
         self.mediaFirstFrameReady.emit(generation)
 
-    def _on_position_changed(self, position: int) -> None:
+        if not self._end_detection_is_armed(media_generation):
+            return
+        position = self._player.position()
         if self._trim_out_ms > self._trim_in_ms and position >= self._trim_out_ms:
+            self._on_position_changed(position, media_generation=media_generation)
+            return
+        if self._player.mediaStatus() == QMediaPlayer.MediaStatus.EndOfMedia:
+            self._on_media_status_changed(
+                QMediaPlayer.MediaStatus.EndOfMedia,
+                media_generation=media_generation,
+            )
+
+    def _on_position_changed(
+        self,
+        position: int,
+        *,
+        media_generation: int | None = None,
+    ) -> None:
+        event_generation = (
+            self._media_generation if media_generation is None else int(media_generation)
+        )
+        if event_generation != self._media_generation:
+            return
+        if (
+            self._end_detection_is_armed(event_generation)
+            and self._trim_out_ms > self._trim_in_ms
+            and position >= self._trim_out_ms
+        ):
             self._enter_end_hold(
                 end_pos=self._trim_out_ms,
                 hold_pos=max(
                     self._trim_in_ms,
                     self._trim_out_ms - VIDEO_COMPLETE_HOLD_BACKSTEP_MS,
                 ),
+                media_generation=event_generation,
             )
             return
         display_position = self._display_position(position)
@@ -1177,9 +1250,25 @@ class VideoArea(QWidget):
         if not is_playing and state == QMediaPlayer.PlaybackState.StoppedState:
             self.show_controls()
 
-    def _on_media_status_changed(self, status: QMediaPlayer.MediaStatus) -> None:
+    def _on_media_status_changed(
+        self,
+        status: QMediaPlayer.MediaStatus,
+        *,
+        media_generation: int | None = None,
+    ) -> None:
+        event_generation = (
+            self._media_generation if media_generation is None else int(media_generation)
+        )
+        if event_generation != self._media_generation:
+            return
         if status == QMediaPlayer.MediaStatus.EndOfMedia:
-            duration = self._trim_out_ms if self._trim_out_ms > self._trim_in_ms else self._player.duration()
+            if not self._end_detection_is_armed(event_generation):
+                return
+            duration = (
+                self._trim_out_ms
+                if self._trim_out_ms > self._trim_in_ms
+                else self._player.duration()
+            )
             if duration <= 0:
                 return
             position = self._player.position()
@@ -1190,6 +1279,7 @@ class VideoArea(QWidget):
             self._enter_end_hold(
                 end_pos=int(duration),
                 hold_pos=max(0, int(duration) - VIDEO_COMPLETE_HOLD_BACKSTEP_MS),
+                media_generation=event_generation,
             )
 
     def _on_error_occurred(self, _error: object, message: str) -> None:
@@ -1217,9 +1307,20 @@ class VideoArea(QWidget):
         self._player_bar.set_position(position)
         self.positionChanged.emit(position)
 
-    def _enter_end_hold(self, *, end_pos: int, hold_pos: int) -> None:
+    def _enter_end_hold(
+        self,
+        *,
+        end_pos: int,
+        hold_pos: int,
+        media_generation: int | None = None,
+    ) -> None:
         """Pause on the last frame while keeping the timeline cursor at the end."""
 
+        event_generation = (
+            self._media_generation if media_generation is None else int(media_generation)
+        )
+        if not self._end_detection_is_armed(event_generation):
+            return
         end_pos = max(0, int(end_pos))
         hold_pos = max(0, min(int(hold_pos), end_pos))
         if self._restart_from_trim_in_on_play and self._end_hold_display_ms == end_pos:
@@ -1229,7 +1330,7 @@ class VideoArea(QWidget):
             return
         finished_request_generation = self._detail_request_generation
         finished_source = self._current_source
-        finished_media_generation = self._media_generation
+        finished_media_generation = event_generation
         self._suppress_trim_pause = True
         self._end_hold_display_ms = end_pos
         self._restart_from_trim_in_on_play = True

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -95,7 +95,7 @@ class VideoArea(QWidget):
     controlsVisibleChanged = Signal(bool)
     fullscreenExitRequested = Signal()
     playbackStateChanged = Signal(bool)
-    playbackFinished = Signal()
+    playbackFinished = Signal(int, object, int)
     mediaLoadFailed = Signal(Path, str)
     nextItemRequested = Signal()
     prevItemRequested = Signal()
@@ -693,13 +693,13 @@ class VideoArea(QWidget):
             )
         )
 
-    def begin_load(self, path: Path, request_generation: int) -> None:
-        """Set the source without probing or reading sidecars on the GUI thread."""
+    def begin_load(self, path: Path, request_generation: int) -> int:
+        """Set the source on the GUI thread and return its media generation."""
 
         load_started = time.perf_counter()
         prev_source = self._current_source
         previous_duration_ms = self._current_duration_ms
-        self._begin_media_generation()
+        media_generation = self._begin_media_generation()
         self._detach_video_output()
         if sys.platform == "darwin" and prev_source is not None:
             # AVFoundation can keep the previous audio session alive unless
@@ -745,6 +745,7 @@ class VideoArea(QWidget):
             media_type="video",
             suffix=path.suffix.lower(),
         )
+        return media_generation
 
     def commit_presentation(self, state: VideoPresentationState) -> bool:
         """Apply prepared metadata and begin accepting current video frames."""
@@ -1226,6 +1227,9 @@ class VideoArea(QWidget):
             return
         if self._suppress_trim_pause:
             return
+        finished_request_generation = self._detail_request_generation
+        finished_source = self._current_source
+        finished_media_generation = self._media_generation
         self._suppress_trim_pause = True
         self._end_hold_display_ms = end_pos
         self._restart_from_trim_in_on_play = True
@@ -1234,7 +1238,11 @@ class VideoArea(QWidget):
         self._suppress_trim_pause = False
         self._sync_position_display(end_pos)
         self.show_controls()
-        self.playbackFinished.emit()
+        self.playbackFinished.emit(
+            finished_request_generation,
+            finished_source,
+            finished_media_generation,
+        )
 
     def _on_volume_changed(self, value: int) -> None:
         """Handle volume changes from the player bar."""

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 import time
+import weakref
 from pathlib import Path
 from typing import Mapping, Optional
 
@@ -176,6 +177,7 @@ class VideoArea(QWidget):
         self._end_detection_armed_media_generation: int | None = None
         self._position_changed_handler = None
         self._media_status_changed_handler = None
+        self._gpu_video_frame_presented_handler = None
         self._detail_request_generation = 0
         self._presentation_committed = False
         self._awaiting_first_gpu_frame_generation: int | None = None
@@ -245,8 +247,7 @@ class VideoArea(QWidget):
         self._wire_player_bar()
         self._wire_edit_viewer()
         self._renderer.nativeSizeChanged.connect(self.displaySizeChanged.emit)
-        self._renderer.videoFramePresented.connect(self._on_gpu_video_frame_presented)
-        self._edit_viewer.videoFramePresented.connect(self._on_gpu_video_frame_presented)
+        self._bind_gpu_presentation_generation(self._media_generation)
 
     # ------------------------------------------------------------------
     # Public API
@@ -913,6 +914,7 @@ class VideoArea(QWidget):
         self._media_generation += 1
         self._end_detection_armed_media_generation = None
         self._bind_end_detection_generation(self._media_generation)
+        self._bind_gpu_presentation_generation(self._media_generation)
         self._accept_video_frames = False
         self._resize_refit_timer.stop()
         self._resize_refit_pending = False
@@ -964,6 +966,31 @@ class VideoArea(QWidget):
             int(media_generation) == self._media_generation
             and self._end_detection_armed_media_generation == self._media_generation
         )
+
+    def _bind_gpu_presentation_generation(self, generation: int) -> None:
+        """Bind GPU frame completion to the media generation that queued it."""
+
+        previous = self._gpu_video_frame_presented_handler
+        if previous is not None:
+            for signal in (
+                self._renderer.videoFramePresented,
+                self._edit_viewer.videoFramePresented,
+            ):
+                try:
+                    signal.disconnect(previous)
+                except (RuntimeError, TypeError):
+                    pass
+
+        owner_ref = weakref.ref(self)
+
+        def _handle_presented(*, bound_generation: int = generation) -> None:
+            owner = owner_ref()
+            if owner is not None:
+                owner._on_gpu_video_frame_presented(media_generation=bound_generation)
+
+        self._gpu_video_frame_presented_handler = _handle_presented
+        self._renderer.videoFramePresented.connect(_handle_presented)
+        self._edit_viewer.videoFramePresented.connect(_handle_presented)
 
     def _bind_video_sink_generation(self, generation: int) -> None:
         """Bind sink delivery to one media generation so old queued calls expire."""
@@ -1160,27 +1187,35 @@ class VideoArea(QWidget):
         else:
             self._renderer.update_frame(frame)
 
-    def _on_gpu_video_frame_presented(self) -> None:
+    def _on_gpu_video_frame_presented(
+        self,
+        *,
+        media_generation: int | None = None,
+    ) -> None:
         """Release loading UI only after the current frame completed QRhi draw."""
 
+        event_generation = (
+            self._media_generation if media_generation is None else int(media_generation)
+        )
+        if event_generation != self._media_generation:
+            return
         generation = self._awaiting_first_gpu_frame_generation
         if generation is None or generation != self._detail_request_generation:
             return
-        media_generation = self._media_generation
         self._awaiting_first_gpu_frame_generation = None
-        self._end_detection_armed_media_generation = media_generation
+        self._end_detection_armed_media_generation = event_generation
         self.mediaFirstFrameReady.emit(generation)
 
-        if not self._end_detection_is_armed(media_generation):
+        if not self._end_detection_is_armed(event_generation):
             return
         position = self._player.position()
         if self._trim_out_ms > self._trim_in_ms and position >= self._trim_out_ms:
-            self._on_position_changed(position, media_generation=media_generation)
+            self._on_position_changed(position, media_generation=event_generation)
             return
         if self._player.mediaStatus() == QMediaPlayer.MediaStatus.EndOfMedia:
             self._on_media_status_changed(
                 QMediaPlayer.MediaStatus.EndOfMedia,
-                media_generation=media_generation,
+                media_generation=event_generation,
             )
 
     def _on_position_changed(

--- a/src/iPhoto/utils/ffmpeg.py
+++ b/src/iPhoto/utils/ffmpeg.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
     from PIL import Image
 
 _FFMPEG_LOG_LEVEL = "error"
+_FFPROBE_COMMAND_TIMEOUT_SECONDS = 15.0
+_FFMPEG_FRAME_COMMAND_TIMEOUT_SECONDS = 30.0
 _LINUX_180_HINT_CACHE: dict[str, bool] = {}
 _OPTIONAL_MODULE_UNSET = object()
 av: Any = _OPTIONAL_MODULE_UNSET
@@ -56,7 +58,11 @@ def _load_cv2() -> Any | None:
     return imported_cv2
 
 
-def _run_command(command: Sequence[str]) -> subprocess.CompletedProcess[bytes]:
+def _run_command(
+    command: Sequence[str],
+    *,
+    timeout_seconds: float,
+) -> subprocess.CompletedProcess[bytes]:
     """Execute *command* and return the completed process."""
 
     # Define startupinfo to hide the window on Windows
@@ -74,9 +80,16 @@ def _run_command(command: Sequence[str]) -> subprocess.CompletedProcess[bytes]:
             stderr=subprocess.PIPE,
             startupinfo=startupinfo,
             creationflags=getattr(subprocess, 'CREATE_NO_WINDOW', 0) if os.name == 'nt' else 0,
+            timeout=timeout_seconds,
         )
+    except subprocess.TimeoutExpired as exc:
+        tool_name = Path(command[0]).name if command else "external media tool"
+        raise ExternalToolError(
+            f"{tool_name} timed out after {timeout_seconds:g} seconds"
+        ) from exc
     except FileNotFoundError as exc:  # pragma: no cover - depends on environment
-        raise ExternalToolError("ffmpeg executable not found on PATH") from exc
+        tool_name = Path(command[0]).name if command else "External media tool"
+        raise ExternalToolError(f"{tool_name} executable not found on PATH") from exc
     return process
 
 
@@ -265,7 +278,10 @@ def _extract_with_ffmpeg(
         command += ["-q:v", "2"]
 
     command.append("pipe:1")
-    process = _run_command(command)
+    process = _run_command(
+        command,
+        timeout_seconds=_FFMPEG_FRAME_COMMAND_TIMEOUT_SECONDS,
+    )
 
     if process.returncode != 0 or not process.stdout:
         stderr = process.stderr.decode("utf-8", "ignore").strip()
@@ -572,7 +588,10 @@ def probe_media(source: Path) -> Dict[str, Any]:
     ]
 
     with media_access.read(source):
-        process = _run_command(command)
+        process = _run_command(
+            command,
+            timeout_seconds=_FFPROBE_COMMAND_TIMEOUT_SECONDS,
+        )
     if process.returncode != 0 or not process.stdout:
         stderr = process.stderr.decode("utf-8", "ignore").strip()
         raise ExternalToolError(

--- a/src/iPhoto/utils/ffmpeg.py
+++ b/src/iPhoto/utils/ffmpeg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, TYPE_CHECKING
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
 _FFMPEG_LOG_LEVEL = "error"
 _FFPROBE_COMMAND_TIMEOUT_SECONDS = 15.0
 _FFMPEG_FRAME_COMMAND_TIMEOUT_SECONDS = 30.0
+_PYAV_FRAME_TIMEOUT_SECONDS = 30.0
 _LINUX_180_HINT_CACHE: dict[str, bool] = {}
 _OPTIONAL_MODULE_UNSET = object()
 av: Any = _OPTIONAL_MODULE_UNSET
@@ -120,7 +122,11 @@ def extract_frame_with_pyav(
         return None
 
     try:
-        with av_module.open(str(source)) as container:
+        deadline = time.monotonic() + _PYAV_FRAME_TIMEOUT_SECONDS
+        with av_module.open(
+            str(source),
+            timeout=(_PYAV_FRAME_TIMEOUT_SECONDS, _PYAV_FRAME_TIMEOUT_SECONDS),
+        ) as container:
             if not container.streams.video:
                 return None
             stream = container.streams.video[0]
@@ -134,6 +140,11 @@ def extract_frame_with_pyav(
                 container.seek(target_pts, stream=stream)
 
             for frame in container.decode(stream):
+                if time.monotonic() >= deadline:
+                    raise ExternalToolTimeoutError(
+                        f"PyAV frame extraction timed out after "
+                        f"{_PYAV_FRAME_TIMEOUT_SECONDS:g} seconds"
+                    )
                 # We seeked to the nearest keyframe, so we may need to decode
                 # forward to reach the exact target time.
                 if frame.pts is None or frame.pts < target_pts:
@@ -165,8 +176,20 @@ def extract_frame_with_pyav(
 
                 return image
 
+            if time.monotonic() >= deadline:
+                raise ExternalToolTimeoutError(
+                    f"PyAV frame extraction timed out after "
+                    f"{_PYAV_FRAME_TIMEOUT_SECONDS:g} seconds"
+                )
             return None
 
+    except ExternalToolTimeoutError:
+        raise
+    except TimeoutError as exc:
+        raise ExternalToolTimeoutError(
+            f"PyAV frame extraction timed out after "
+            f"{_PYAV_FRAME_TIMEOUT_SECONDS:g} seconds"
+        ) from exc
     except Exception:
         # Fallback to other methods if PyAV fails for any reason
         return None

--- a/src/iPhoto/utils/ffmpeg.py
+++ b/src/iPhoto/utils/ffmpeg.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, TYPE_CHECKING
 
-from ..errors import ExternalToolError
+from ..errors import ExternalToolError, ExternalToolTimeoutError
 from .media_access import media_access
 
 if TYPE_CHECKING:
@@ -84,7 +84,7 @@ def _run_command(
         )
     except subprocess.TimeoutExpired as exc:
         tool_name = Path(command[0]).name if command else "external media tool"
-        raise ExternalToolError(
+        raise ExternalToolTimeoutError(
             f"{tool_name} timed out after {timeout_seconds:g} seconds"
         ) from exc
     except FileNotFoundError as exc:  # pragma: no cover - depends on environment
@@ -211,6 +211,8 @@ def extract_video_frame(
     with media_access.read(source):
         try:
             return _extract_with_ffmpeg(source, at=at, scale=scale, format=fmt)
+        except ExternalToolTimeoutError:
+            raise
         except ExternalToolError as exc:
             fallback = _extract_with_opencv(source, at=at, scale=scale, format=fmt)
             if fallback is not None:

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -1050,9 +1050,12 @@ def test_still_loading_failure_marks_transaction_terminal_and_disables_edit() ->
 def test_live_photo_fallback_reuses_the_asset_identity() -> None:
     coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
     still = Path("/fake/photo.heic")
-    coordinator._active_live_motion = Path("/fake/photo.mov")
+    motion = Path("/fake/photo.mov")
+    coordinator._detail_request_generation = 7
+    coordinator._active_live_motion = motion
     coordinator._active_live_still = still
     coordinator._active_live_asset_id = "asset-1"
+    coordinator._active_live_media_generation = 11
     transaction = DetailRenderTransaction(
         generation=7,
         asset_id="asset-1",
@@ -1072,13 +1075,52 @@ def test_live_photo_fallback_reuses_the_asset_identity() -> None:
     coordinator._player_bar = Mock(setEnabled=Mock())
     coordinator._refresh_face_name_overlay_for_current_presentation = Mock()
 
-    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._handle_playback_finished(coordinator, 7, motion, 11)
 
     coordinator._player_view.display_image.assert_called_once_with(
         still,
         transaction=transaction,
     )
     assert coordinator._active_live_asset_id == ""
+    assert coordinator._active_live_still is None
+    assert coordinator._active_live_media_generation is None
+
+
+def test_live_photo_finish_rejects_stale_rapid_navigation_events() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    motion_a = Path("/fake/a.mov")
+    motion_b = Path("/fake/b.mov")
+    motion_c = Path("/fake/c.mov")
+    coordinator._detail_request_generation = 23
+    coordinator._active_live_motion = motion_c
+    coordinator._active_live_media_generation = 103
+    coordinator._restore_live_still = Mock(return_value=True)
+
+    PlaybackCoordinator._handle_playback_finished(coordinator, 21, motion_a, 101)
+    PlaybackCoordinator._handle_playback_finished(coordinator, 22, motion_b, 102)
+
+    coordinator._restore_live_still.assert_not_called()
+
+    PlaybackCoordinator._handle_playback_finished(coordinator, 23, motion_c, 103)
+
+    coordinator._restore_live_still.assert_called_once_with()
+
+
+def test_live_photo_finish_rejects_previous_replay_of_same_motion() -> None:
+    coordinator = PlaybackCoordinator.__new__(PlaybackCoordinator)
+    motion = Path("/fake/photo.mov")
+    coordinator._detail_request_generation = 7
+    coordinator._active_live_motion = motion
+    coordinator._active_live_media_generation = 12
+    coordinator._restore_live_still = Mock(return_value=True)
+
+    PlaybackCoordinator._handle_playback_finished(coordinator, 7, motion, 11)
+
+    coordinator._restore_live_still.assert_not_called()
+
+    PlaybackCoordinator._handle_playback_finished(coordinator, 7, motion, 12)
+
+    coordinator._restore_live_still.assert_called_once_with()
 
 
 def test_live_photo_motion_preparation_failure_restores_pending_still() -> None:
@@ -1118,6 +1160,7 @@ def test_live_photo_motion_preparation_failure_restores_pending_still() -> None:
     coordinator._active_live_motion = motion
     coordinator._active_live_still = still
     coordinator._active_live_asset_id = "asset-1"
+    coordinator._active_live_media_generation = 11
     coordinator._player_view = Mock(
         video_area=Mock(stop=Mock()),
         defer_still_updates=Mock(),
@@ -1340,6 +1383,7 @@ def test_live_photo_motion_to_still_runs_overlay_and_prefetch(
     coordinator._active_live_motion = motion
     coordinator._active_live_still = still
     coordinator._active_live_asset_id = "asset-1"
+    coordinator._active_live_media_generation = 11
     coordinator._current_presentation = _make_presentation(
         path=str(still),
         asset_id="asset-1",
@@ -1360,7 +1404,7 @@ def test_live_photo_motion_to_still_runs_overlay_and_prefetch(
     coordinator._prefetch_neighbor_stills = Mock()
 
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
-    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._handle_playback_finished(coordinator, 7, motion, 11)
     PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
 
     if has_pending_still:
@@ -1419,7 +1463,7 @@ def test_live_photo_second_replay_restores_overlay_without_reopening_transaction
     coordinator._current_presentation = presentation
     coordinator._face_name_overlay = Mock()
     coordinator._player_view = Mock(
-        video_area=Mock(begin_load=Mock()),
+        video_area=Mock(begin_load=Mock(side_effect=[11, 12])),
         defer_still_updates=Mock(),
         apply_pending_still=Mock(return_value=False),
         display_image=Mock(),
@@ -1435,12 +1479,12 @@ def test_live_photo_second_replay_restores_overlay_without_reopening_transaction
 
     PlaybackCoordinator._autoplay_live_motion(coordinator, presentation)
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
-    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._handle_playback_finished(coordinator, 7, motion, 11)
     PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
 
     PlaybackCoordinator.replay_live_photo(coordinator)
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
-    PlaybackCoordinator._handle_playback_finished(coordinator)
+    PlaybackCoordinator._handle_playback_finished(coordinator, 7, motion, 12)
     PlaybackCoordinator._on_still_frame_presented(coordinator, still, 7)
 
     assert len(terminal_presentations) == 1

--- a/tests/test_utils_ffmpeg.py
+++ b/tests/test_utils_ffmpeg.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 from iPhoto.utils import ffmpeg
-from iPhoto.errors import ExternalToolError
+from iPhoto.errors import ExternalToolError, ExternalToolTimeoutError
 
 
 def _fake_completed_process(command: list[str], stdout: bytes = b"") -> subprocess.CompletedProcess[bytes]:
@@ -41,7 +41,7 @@ def test_run_command_forwards_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     ("tool_name", "timeout_seconds"),
     [("ffprobe", 15.0), ("ffmpeg", 30.0)],
 )
-def test_run_command_converts_timeout_to_external_tool_error(
+def test_run_command_converts_timeout_to_external_tool_timeout_error(
     monkeypatch: pytest.MonkeyPatch,
     tool_name: str,
     timeout_seconds: float,
@@ -55,7 +55,7 @@ def test_run_command_converts_timeout_to_external_tool_error(
     monkeypatch.setattr(subprocess, "run", raise_timeout)
 
     with pytest.raises(
-        ExternalToolError,
+        ExternalToolTimeoutError,
         match=rf"{tool_name} timed out after {int(timeout_seconds)} seconds",
     ):
         ffmpeg._run_command([tool_name, "movie.mov"], timeout_seconds=timeout_seconds)
@@ -599,6 +599,30 @@ def test_extract_video_frame_falls_back_to_opencv(monkeypatch: pytest.MonkeyPatc
     data = ffmpeg.extract_video_frame(input_path, at=0.1, scale=(100, 100), format="jpeg")
 
     assert data is fallback_data
+
+
+def test_extract_video_frame_timeout_does_not_fall_back_to_opencv(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker,
+    tmp_path: Path,
+) -> None:
+    """A bounded ffmpeg timeout must not enter the unbounded OpenCV path."""
+
+    input_path = tmp_path / "stalled.mov"
+    input_path.touch()
+    timeout_error = ExternalToolTimeoutError("ffmpeg timed out after 30 seconds")
+
+    def fake_ffmpeg(*args: object, **kwargs: object) -> bytes:
+        raise timeout_error
+
+    monkeypatch.setattr(ffmpeg, "_extract_with_ffmpeg", fake_ffmpeg)
+    fallback = mocker.patch.object(ffmpeg, "_extract_with_opencv")
+
+    with pytest.raises(ExternalToolTimeoutError) as exc_info:
+        ffmpeg.extract_video_frame(input_path, format="jpeg")
+
+    assert exc_info.value is timeout_error
+    fallback.assert_not_called()
 
 
 def test_extract_video_frame_propagates_error_when_no_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_utils_ffmpeg.py
+++ b/tests/test_utils_ffmpeg.py
@@ -18,6 +18,73 @@ def _fake_completed_process(command: list[str], stdout: bytes = b"") -> subproce
     return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr=b"")
 
 
+def test_run_command_forwards_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_subprocess_run(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[bytes]:
+        captured["command"] = command
+        captured.update(kwargs)
+        return _fake_completed_process(command, stdout=b"{}")
+
+    monkeypatch.setattr(subprocess, "run", fake_subprocess_run)
+
+    ffmpeg._run_command(["ffprobe", "movie.mov"], timeout_seconds=15.0)
+
+    assert captured["command"] == ["ffprobe", "movie.mov"]
+    assert captured["timeout"] == 15.0
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "timeout_seconds"),
+    [("ffprobe", 15.0), ("ffmpeg", 30.0)],
+)
+def test_run_command_converts_timeout_to_external_tool_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+    timeout_seconds: float,
+) -> None:
+    def raise_timeout(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[bytes]:
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", raise_timeout)
+
+    with pytest.raises(
+        ExternalToolError,
+        match=rf"{tool_name} timed out after {int(timeout_seconds)} seconds",
+    ):
+        ffmpeg._run_command([tool_name, "movie.mov"], timeout_seconds=timeout_seconds)
+
+
+def test_probe_media_uses_ffprobe_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    video = tmp_path / "movie.mov"
+    video.touch()
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[bytes]:
+        captured["command"] = command
+        captured["timeout"] = timeout_seconds
+        return _fake_completed_process(command, stdout=b"{}")
+
+    monkeypatch.setattr(ffmpeg, "_run_command", fake_run)
+
+    assert ffmpeg.probe_media(video) == {}
+    assert captured["command"][0] == "ffprobe"  # type: ignore[index]
+    assert captured["timeout"] == ffmpeg._FFPROBE_COMMAND_TIMEOUT_SECONDS
+
+
 @pytest.fixture(autouse=True)
 def _clear_rotation_probe_cache() -> None:
     ffmpeg._probe_video_rotation_info_cached.cache_clear()
@@ -406,10 +473,15 @@ def test_extract_video_frame_uses_yuv_format_for_jpeg(monkeypatch: pytest.Monkey
 
     input_path = tmp_path / "movie.mp4"
     input_path.touch()
-    captured: dict[str, list[str]] = {}
+    captured: dict[str, object] = {}
 
-    def fake_run(command: list[str]) -> subprocess.CompletedProcess[bytes]:
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[bytes]:
         captured["cmd"] = command
+        captured["timeout"] = timeout_seconds
         return _fake_completed_process(command, stdout=b"jpeg")
 
     monkeypatch.setattr(ffmpeg, "_run_command", fake_run)
@@ -419,6 +491,8 @@ def test_extract_video_frame_uses_yuv_format_for_jpeg(monkeypatch: pytest.Monkey
     assert data == b"jpeg"
     assert "cmd" in captured
     command = captured["cmd"]
+    assert isinstance(command, list)
+    assert captured["timeout"] == ffmpeg._FFMPEG_FRAME_COMMAND_TIMEOUT_SECONDS
 
     # Check for hardware acceleration
     assert "-hwaccel" in command
@@ -443,7 +517,12 @@ def test_extract_video_frame_uses_rgba_for_png(monkeypatch: pytest.MonkeyPatch, 
     input_path.touch()
     captured: dict[str, list[str]] = {}
 
-    def fake_run(command: list[str]) -> subprocess.CompletedProcess[bytes]:
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert timeout_seconds == ffmpeg._FFMPEG_FRAME_COMMAND_TIMEOUT_SECONDS
         captured["cmd"] = command
         return _fake_completed_process(command, stdout=b"png")
 
@@ -477,7 +556,12 @@ def test_extract_video_frame_without_scale_enforces_even_dimensions(monkeypatch:
     input_path.touch()
     captured: dict[str, list[str]] = {}
 
-    def fake_run(command: list[str]) -> subprocess.CompletedProcess[bytes]:
+    def fake_run(
+        command: list[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert timeout_seconds == ffmpeg._FFMPEG_FRAME_COMMAND_TIMEOUT_SECONDS
         captured["cmd"] = command
         return _fake_completed_process(command, stdout=b"jpeg")
 

--- a/tests/test_utils_ffmpeg_pyav.py
+++ b/tests/test_utils_ffmpeg_pyav.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from PIL import Image
 
+from iPhoto.errors import ExternalToolTimeoutError
 from iPhoto.utils import ffmpeg
 
 def test_extract_frame_with_pyav_returns_none_when_av_missing(monkeypatch):
@@ -37,7 +38,13 @@ def test_extract_frame_with_pyav_opens_container(mock_av, tmp_path):
     result = ffmpeg.extract_frame_with_pyav(video_path, at=1.0)
 
     # Assertions
-    mock_av.open.assert_called_with(str(video_path))
+    mock_av.open.assert_called_with(
+        str(video_path),
+        timeout=(
+            ffmpeg._PYAV_FRAME_TIMEOUT_SECONDS,
+            ffmpeg._PYAV_FRAME_TIMEOUT_SECONDS,
+        ),
+    )
     assert mock_container.seek.called
     assert result == mock_image
 
@@ -154,6 +161,41 @@ def test_extract_frame_with_pyav_exception_returns_none(mock_av, tmp_path):
     mock_av.open.side_effect = Exception("Boom")
     result = ffmpeg.extract_frame_with_pyav(tmp_path / "video.mp4")
     assert result is None
+
+
+@patch("iPhoto.utils.ffmpeg.av")
+def test_extract_frame_with_pyav_propagates_open_timeout(mock_av, tmp_path):
+    """A PyAV I/O timeout is terminal for the frame request."""
+
+    mock_av.open.side_effect = TimeoutError("timed out")
+
+    with pytest.raises(ExternalToolTimeoutError, match="PyAV frame extraction timed out"):
+        ffmpeg.extract_frame_with_pyav(tmp_path / "stalled.mp4")
+
+
+@patch("iPhoto.utils.ffmpeg.av")
+def test_extract_frame_with_pyav_enforces_total_decode_deadline(
+    mock_av,
+    monkeypatch,
+    tmp_path,
+):
+    """Repeated successful reads cannot exceed the total decode deadline."""
+
+    mock_container = MagicMock()
+    mock_av.open.return_value.__enter__.return_value = mock_container
+    mock_stream = MagicMock()
+    mock_stream.time_base = 1 / 30
+    mock_container.streams.video = [mock_stream]
+    mock_frame = MagicMock(pts=0)
+    mock_container.decode.return_value = [mock_frame]
+    monkeypatch.setattr(
+        ffmpeg.time,
+        "monotonic",
+        MagicMock(side_effect=[0.0, ffmpeg._PYAV_FRAME_TIMEOUT_SECONDS]),
+    )
+
+    with pytest.raises(ExternalToolTimeoutError, match="PyAV frame extraction timed out"):
+        ffmpeg.extract_frame_with_pyav(tmp_path / "slow.mp4", at=1.0)
 
 
 @patch("iPhoto.utils.ffmpeg.av")

--- a/tests/ui/tasks/test_video_frame_grabber.py
+++ b/tests/ui/tasks/test_video_frame_grabber.py
@@ -1,0 +1,41 @@
+"""Tests for bounded video frame fallback behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PySide6", reason="PySide6 is required for GUI tests", exc_type=ImportError)
+
+from PySide6.QtCore import QSize
+
+from iPhoto.errors import ExternalToolTimeoutError
+from iPhoto.gui.ui.tasks import video_frame_grabber
+
+
+def test_timeout_stops_additional_seek_attempts(mocker) -> None:
+    """One timed-out ffmpeg attempt terminates the whole frame request."""
+
+    source = Path("/fake/stalled.mov")
+    pyav = mocker.patch.object(
+        video_frame_grabber,
+        "extract_frame_with_pyav",
+        return_value=None,
+    )
+    ffmpeg = mocker.patch.object(
+        video_frame_grabber,
+        "extract_video_frame",
+        side_effect=ExternalToolTimeoutError("ffmpeg timed out after 30 seconds"),
+    )
+
+    result = video_frame_grabber.grab_video_frame(
+        source,
+        QSize(320, 240),
+        still_image_time=1.0,
+        duration=10.0,
+    )
+
+    assert result is None
+    pyav.assert_called_once()
+    ffmpeg.assert_called_once()

--- a/tests/ui/tasks/test_video_frame_grabber.py
+++ b/tests/ui/tasks/test_video_frame_grabber.py
@@ -39,3 +39,26 @@ def test_timeout_stops_additional_seek_attempts(mocker) -> None:
     assert result is None
     pyav.assert_called_once()
     ffmpeg.assert_called_once()
+
+
+def test_pyav_timeout_stops_before_ffmpeg_fallback(mocker) -> None:
+    """A timed-out PyAV decode cannot fall through to another decoder."""
+
+    source = Path("/fake/stalled-pyav.mov")
+    pyav = mocker.patch.object(
+        video_frame_grabber,
+        "extract_frame_with_pyav",
+        side_effect=ExternalToolTimeoutError("PyAV timed out after 30 seconds"),
+    )
+    ffmpeg = mocker.patch.object(video_frame_grabber, "extract_video_frame")
+
+    result = video_frame_grabber.grab_video_frame(
+        source,
+        QSize(320, 240),
+        still_image_time=1.0,
+        duration=10.0,
+    )
+
+    assert result is None
+    pyav.assert_called_once()
+    ffmpeg.assert_not_called()

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -82,6 +82,7 @@ class _FakeMediaPlayer:
         self._position = 0
         self._duration = 0
         self._state = QMediaPlayer.PlaybackState.StoppedState
+        self._media_status = QMediaPlayer.MediaStatus.NoMedia
         self._source = None
         self._audio_output = None
         self._video_output = None
@@ -106,6 +107,9 @@ class _FakeMediaPlayer:
 
     def playbackState(self):
         return self._state
+
+    def mediaStatus(self):
+        return self._media_status
 
     def play(self) -> None:
         self._state = QMediaPlayer.PlaybackState.PlayingState
@@ -750,6 +754,7 @@ class TestVideoArea:
     def test_end_of_media_backsteps_and_pauses(self, qapp, mocker):
         """When EndOfMedia fires, the player should backstep and pause."""
         va = VideoArea()
+        va._end_detection_armed_media_generation = va._media_generation
 
         mocker.patch.object(va._player, "duration", return_value=5000)
         mocker.patch.object(va._player, "position", return_value=5000)
@@ -793,6 +798,7 @@ class TestVideoArea:
         va._detail_request_generation = 7
         va._current_source = Path("/fake/live.mov")
         va._media_generation = 9
+        va._end_detection_armed_media_generation = 9
 
         mock_pause = mocker.patch.object(va._player, "pause")
         mock_set_pos = mocker.patch.object(va._player, "setPosition")
@@ -815,6 +821,7 @@ class TestVideoArea:
         va = VideoArea()
         va._trim_in_ms = 1200
         va._trim_out_ms = 4200
+        va._end_detection_armed_media_generation = va._media_generation
         position_spy = Mock()
         va.positionChanged.connect(position_spy)
 
@@ -889,6 +896,7 @@ class TestVideoArea:
         """The playhead should remain at the duration marker after EndOfMedia."""
 
         va = VideoArea()
+        va._end_detection_armed_media_generation = va._media_generation
         position_spy = Mock()
         va.positionChanged.connect(position_spy)
 
@@ -924,6 +932,86 @@ class TestVideoArea:
             call(5000),
         ]
 
+    def test_stale_bound_end_callbacks_are_rejected_after_new_first_frame(
+        self,
+        qapp,
+        mocker,
+    ) -> None:
+        """Late callbacks retain A's media generation after B is presented."""
+
+        va = VideoArea()
+        va.begin_load(Path("/fake/a.mov"), 21)
+        stale_position_handler = va._position_changed_handler
+        stale_status_handler = va._media_status_changed_handler
+
+        media_generation_b = va.begin_load(Path("/fake/b.mov"), 23)
+        va._trim_in_ms = 0
+        va._trim_out_ms = 5000
+        va._player._duration = 5000
+        va._player._position = 0
+        va._player._media_status = QMediaPlayer.MediaStatus.LoadedMedia
+        va._awaiting_first_gpu_frame_generation = 23
+        va._on_gpu_video_frame_presented()
+
+        pause = mocker.patch.object(va._player, "pause")
+        set_position = mocker.patch.object(va._player, "setPosition")
+        finished_spy = mocker.Mock()
+        va.playbackFinished.connect(finished_spy)
+
+        stale_position_handler(5000)
+        stale_status_handler(QMediaPlayer.MediaStatus.EndOfMedia)
+
+        pause.assert_not_called()
+        set_position.assert_not_called()
+        finished_spy.assert_not_called()
+
+        va._position_changed_handler(5000)
+
+        pause.assert_called_once_with()
+        set_position.assert_called_once_with(5000 - VIDEO_COMPLETE_HOLD_BACKSTEP_MS)
+        finished_spy.assert_called_once_with(
+            23,
+            Path("/fake/b.mov"),
+            media_generation_b,
+        )
+
+    def test_current_end_is_caught_up_only_after_first_gpu_frame(
+        self,
+        qapp,
+        mocker,
+    ) -> None:
+        """A legitimate early B end waits until B has presented a frame."""
+
+        va = VideoArea()
+        media_generation = va.begin_load(Path("/fake/short.mov"), 31)
+        va._trim_in_ms = 0
+        va._trim_out_ms = 100
+        va._player._duration = 100
+        va._player._position = 100
+        va._player._media_status = QMediaPlayer.MediaStatus.EndOfMedia
+        pause = mocker.patch.object(va._player, "pause")
+        set_position = mocker.patch.object(va._player, "setPosition")
+        finished_spy = mocker.Mock()
+        va.playbackFinished.connect(finished_spy)
+
+        va._position_changed_handler(100)
+        va._media_status_changed_handler(QMediaPlayer.MediaStatus.EndOfMedia)
+
+        pause.assert_not_called()
+        set_position.assert_not_called()
+        finished_spy.assert_not_called()
+
+        va._awaiting_first_gpu_frame_generation = 31
+        va._on_gpu_video_frame_presented()
+
+        pause.assert_called_once_with()
+        set_position.assert_called_once_with(100 - VIDEO_COMPLETE_HOLD_BACKSTEP_MS)
+        finished_spy.assert_called_once_with(
+            31,
+            Path("/fake/short.mov"),
+            media_generation,
+        )
+
     def test_load_video_clears_frame(self, qapp, mocker):
         """load_video should clear the renderer frame."""
         va = VideoArea()
@@ -951,6 +1039,7 @@ class TestVideoArea:
             return_value=(90, 1920, 1440),
         )
 
+        va._end_detection_armed_media_generation = va._media_generation
         media_generation = va.begin_load(Path("/fake/portrait.mov"), 7)
         va.commit_presentation(
             VideoPresentationState(7, {}, None, False, 90, 1920, 1440, False)
@@ -958,6 +1047,7 @@ class TestVideoArea:
 
         probe.assert_not_called()
         assert media_generation == va._media_generation
+        assert va._end_detection_armed_media_generation is None
         assert mock_set_rot.call_args_list[-1] == call(90, 1920, 1440)
 
     def test_load_video_handles_probe_failure(self, qapp, mocker):
@@ -1083,6 +1173,7 @@ class TestVideoArea:
         mock_set_source = mocker.patch.object(va._player, "setSource")
         mock_set_output = mocker.patch.object(va._player, "setVideoOutput")
         mock_clear = mocker.patch.object(va._renderer, "clear_frame")
+        va._end_detection_armed_media_generation = va._media_generation
 
         va.stop()
 
@@ -1094,6 +1185,7 @@ class TestVideoArea:
         mock_set_output.assert_called_once_with(None)
         # Renderer frame should be cleared
         mock_clear.assert_called_once()
+        assert va._end_detection_armed_media_generation is None
 
     def test_stop_releases_frames_and_detaches_sink_before_source_clear(self, qapp, mocker):
         """No backend teardown API may run while downstream frames are retained."""

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -790,6 +790,9 @@ class TestVideoArea:
         va = VideoArea()
         va._trim_in_ms = 1200
         va._trim_out_ms = 4200
+        va._detail_request_generation = 7
+        va._current_source = Path("/fake/live.mov")
+        va._media_generation = 9
 
         mock_pause = mocker.patch.object(va._player, "pause")
         mock_set_pos = mocker.patch.object(va._player, "setPosition")
@@ -798,11 +801,12 @@ class TestVideoArea:
         va.playbackFinished.connect(finished_spy)
 
         va._on_position_changed(4200)
+        va._on_position_changed(4200)
 
         mock_pause.assert_called_once()
         mock_set_pos.assert_called_once_with(4200 - VIDEO_COMPLETE_HOLD_BACKSTEP_MS)
         mock_show_controls.assert_called_once()
-        finished_spy.assert_called_once_with()
+        finished_spy.assert_called_once_with(7, Path("/fake/live.mov"), 9)
         assert va._restart_from_trim_in_on_play is True
 
     def test_trim_out_hold_keeps_timeline_cursor_at_out_point(self, qapp) -> None:
@@ -947,12 +951,13 @@ class TestVideoArea:
             return_value=(90, 1920, 1440),
         )
 
-        va.begin_load(Path("/fake/portrait.mov"), 7)
+        media_generation = va.begin_load(Path("/fake/portrait.mov"), 7)
         va.commit_presentation(
             VideoPresentationState(7, {}, None, False, 90, 1920, 1440, False)
         )
 
         probe.assert_not_called()
+        assert media_generation == va._media_generation
         assert mock_set_rot.call_args_list[-1] == call(90, 1920, 1440)
 
     def test_load_video_handles_probe_failure(self, qapp, mocker):

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -1012,6 +1012,36 @@ class TestVideoArea:
             media_generation,
         )
 
+    def test_same_source_replay_rejects_stale_gpu_completion(
+        self,
+        qapp,
+        mocker,
+    ) -> None:
+        """Replay A's queued GPU completion cannot arm replay B of the same source."""
+
+        va = VideoArea()
+        source = Path("/fake/live.mov")
+        va.begin_load(source, 7)
+        stale_gpu_handler = va._gpu_video_frame_presented_handler
+
+        media_generation_b = va.begin_load(source, 7)
+        current_gpu_handler = va._gpu_video_frame_presented_handler
+        va._awaiting_first_gpu_frame_generation = 7
+        first_frame_spy = mocker.Mock()
+        va.mediaFirstFrameReady.connect(first_frame_spy)
+
+        stale_gpu_handler()
+
+        assert va._awaiting_first_gpu_frame_generation == 7
+        assert va._end_detection_armed_media_generation is None
+        first_frame_spy.assert_not_called()
+
+        current_gpu_handler()
+
+        assert va._awaiting_first_gpu_frame_generation is None
+        assert va._end_detection_armed_media_generation == media_generation_b
+        first_frame_spy.assert_called_once_with(7)
+
     def test_load_video_clears_frame(self, qapp, mocker):
         """load_video should clear the renderer frame."""
         va = VideoArea()


### PR DESCRIPTION
## Summary

- identify playback-finished events by detail request, media source, and media generation so stale Live Photo events cannot stop a newer motion
- bound ffprobe metadata probes to 15 seconds and single-frame ffmpeg extraction to 30 seconds
- add rapid-navigation, same-source replay, signal payload, and subprocess-timeout regressions

## Validation

- targeted playback/ffmpeg suite: 242 passed, 2 skipped
- Detail/viewer regression suite: 153 passed, 1 skipped
- architecture check passed
- compileall passed