### PR TITLE
Fix cross-platform QRhi startup window lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,6 +219,10 @@ macOS, and Linux share one QRhi lifecycle: the final native surface hierarchy is
 prepared pre-show, while `ensure_feature("detail")` completes its non-native UI
 and QtMultimedia runtime post-paint. Platform allowlists, post-show surface
 creation, parentless surface warm-up, and hide/show workarounds are forbidden.
+The pre-show hierarchy is part of shell construction: failure is terminal and
+non-recoverable for that process. Startup-generation retry applies only after a
+valid visible shell exists; it must not claim to reconstruct the native
+hierarchy after `QMenuBar` has already created the top-level handle.
 
 ## Layer Boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,22 +202,23 @@ language has no bundled resource. The active stored language values are
 
 Desktop construction deliberately has two boundaries. The process first loads
 settings, configures graphics caches, creates `QApplication`, `RuntimeContext`,
-and the lightweight main-window shell, then calls `show()`. Only after the shell
-emits `firstPainted` may startup create hidden feature bundles, import and start
-`MainCoordinator`, resume library startup tasks, or select the initial
-collection. This is an architecture constraint rather than a timer-based
-optimization: optional feature imports must not migrate back above the first
-paint boundary.
+and the lightweight main-window shell. Before any widget that can force native
+handle creation (notably `QMenuBar`) is constructed, the hidden Detail surface
+shell and all three QRhi widgets are attached with their final parents. The
+window then calls `show()`. Only after the shell emits `firstPainted` may startup
+complete the Detail chrome/playback runtime, import and start `MainCoordinator`,
+resume library startup tasks, or select the initial collection. This is an
+architecture constraint rather than a timer-based optimization.
 
 `Ui_MainWindow.ensure_feature()` owns the on-demand lifetime of the detail,
 preview, Map, People, and Albums bundles. It caches each bundle and emits
 `featureCreated` so the window manager and coordinator can attach behavior to
 late-created widgets. Navigation may also call `ensure_feature()` if Map or the
-Albums dashboard was not constructed during the post-paint warm-up. On Windows
-and Linux, the QRhi-backed detail bundle is constructed before `show()` because
-inserting it into a visible top-level window can recreate the native window;
-preview and People remain post-paint. macOS keeps all three in the post-paint
-warm-up path.
+Albums dashboard was not constructed during the post-paint warm-up. Windows,
+macOS, and Linux share one QRhi lifecycle: the final native surface hierarchy is
+prepared pre-show, while `ensure_feature("detail")` completes its non-native UI
+and QtMultimedia runtime post-paint. Platform allowlists, post-show surface
+creation, parentless surface warm-up, and hide/show workarounds are forbidden.
 
 ## Layer Boundaries
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1004,6 +1004,10 @@ QtMultimedia, coordinators, and other optional work remain connected to
 boundary. Widget creation stays on the GUI thread and should be split across
 event-loop turns.
 
+Treat native-hierarchy preparation failure as `shell_initialization_failed`.
+It occurs before a valid retry-capable shell exists and must not be retried
+after a native menu or another widget has committed the top-level handle.
+
 Keep imports above that boundary narrow. In particular, importing
 `iPhoto.gui.main` or `MainWindow` must not load NumPy, Qt Multimedia, the
 People/Pets AI pipelines, map rendering, asset-import services, edit-session models, or

--- a/docs/development.md
+++ b/docs/development.md
@@ -995,10 +995,14 @@ See [docs/misc/BUILD_EXE.md](misc/BUILD_EXE.md) for detailed troubleshooting and
 
 ## Desktop Startup Performance
 
-The GUI startup contract is “paint the window shell, then warm optional
-features.” Do not use a zero-delay timer as a substitute for the boundary:
-startup work must be connected to `MainWindow.firstPainted`. Widget creation
-still belongs on the GUI thread and should be split across event-loop turns.
+The GUI startup contract is “stabilize the native hierarchy, paint the window
+shell, then warm optional features.” All Detail QRhi widgets must have their
+final parents before `show()`, and that hierarchy must be created before
+`QMenuBar` or another widget forces a native top-level handle. Detail chrome,
+QtMultimedia, coordinators, and other optional work remain connected to
+`MainWindow.firstPainted`; a zero-delay timer is not a substitute for that
+boundary. Widget creation stays on the GUI thread and should be split across
+event-loop turns.
 
 Keep imports above that boundary narrow. In particular, importing
 `iPhoto.gui.main` or `MainWindow` must not load NumPy, Qt Multimedia, the
@@ -1039,9 +1043,10 @@ Run the focused startup guardrails with:
 python -m pytest tests/gui/test_startup_import_boundary.py tests/gui/test_main.py
 ```
 
-On Windows, also verify that startup shows one stable top-level window. The
-detail feature intentionally remains pre-show there because adding its QRhi
-widgets after the window is visible can recreate the native window.
+On Windows, macOS, and Linux, verify that startup shows one stable top-level
+window and that Gallery → Detail renders through the selected backend. Do not
+move QRhi creation after `show()`, pre-create parentless surfaces, use a
+platform allowlist, or hide/show the window to mask a native transition.
 
 ---
 

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -17,11 +17,14 @@ from iPhoto.bootstrap.startup_profile import mark
 
 mark("module.before_qt_imports")
 from PySide6.QtCore import QEvent, QObject, QTimer, Qt, Signal  # noqa: E402, I001
-from PySide6.QtGui import QColor, QPalette, QSurfaceFormat  # noqa: E402
+from PySide6.QtGui import QColor, QPalette, QSurface, QSurfaceFormat  # noqa: E402
 from PySide6.QtWidgets import QApplication  # noqa: E402
 
 from iPhoto.bootstrap.qt_shader_cache import configure_shader_cache_environment  # noqa: E402
-from iPhoto.gui.render_backend import should_configure_global_desktop_opengl  # noqa: E402
+from iPhoto.gui.render_backend import (  # noqa: E402
+    selected_rhi_backend_name,
+    should_configure_global_desktop_opengl,
+)
 
 mark("module.imported")
 
@@ -458,20 +461,59 @@ def _configure_qt_opengl_defaults(library_root: Path | None = None) -> None:
 def _startup_feature_plan(
     platform: str | None = None,
 ) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Return features created before and after the main window is shown.
+    """Return feature completion work scheduled after the first paint.
 
-    On OpenGL-backed desktop platforms, inserting the detail page's
-    ``QRhiWidget`` children into an already visible top-level widget can make
-    Qt recreate the native window. That appears as a short-lived first window
-    followed by the real one. Keep the GPU-backed detail page in the pre-show
-    phase there, while retaining the faster first-frame path on macOS.
+    Detail's final QRhi hierarchy is prepared separately before ``show()`` on
+    every desktop platform.  Only its non-native feature completion remains in
+    this plan; platform-specific exceptions are intentionally forbidden.
     """
 
-    target_platform = sys.platform if platform is None else platform
-    deferred = ("detail",)
-    if target_platform in {"win32", "linux"}:
-        return (("detail",), ())
-    return ((), deferred)
+    del platform
+    return ((), ("detail",))
+
+
+def _prepare_top_level_rhi_surface(window: object, backend_name: str) -> str:
+    """Create the native top-level with the surface type required by QRhi.
+
+    Ui_MainWindow attaches the QRhi hierarchy before QMenuBar causes native
+    QWindow creation.  This function is a read-only contract check: changing,
+    destroying, or recreating QWidget's internal QWindow here would detach its
+    backing store and leave QRhiWidget without the window-associated QRhi.
+    """
+
+    targets_by_backend = {
+        "metal": (QSurface.SurfaceType.MetalSurface,),
+        "opengl": (
+            QSurface.SurfaceType.OpenGLSurface,
+            QSurface.SurfaceType.RasterGLSurface,
+        ),
+    }
+    targets = targets_by_backend.get(str(backend_name).strip().lower())
+    if targets is None:
+        raise RuntimeError(f"Unsupported startup QRhi backend: {backend_name}")
+    preferred_target = targets[0]
+
+    window_handle_accessor = getattr(window, "windowHandle", None)
+    if not callable(window_handle_accessor):
+        return preferred_target.name
+    handle = window_handle_accessor()
+    if handle is None:
+        # QMenuBar creates a native handle during setup on macOS, while other
+        # platforms may correctly defer it until show().  The attached QRhi
+        # hierarchy will select the surface type when Qt creates that handle.
+        return f"deferred:{preferred_target.name}"
+
+    is_visible = getattr(window, "isVisible", None)
+    if callable(is_visible) and is_visible():
+        raise RuntimeError("Top-level QRhi surface must be configured before show()")
+    actual_surface_type = handle.surfaceType()
+    if actual_surface_type not in targets:
+        raise RuntimeError(
+            "Top-level surface was created with "
+            f"{actual_surface_type.name}; expected one of "
+            f"{', '.join(target.name for target in targets)}"
+        )
+    return actual_surface_type.name
 
 
 def _startup_timing_plan(platform: str | None = None) -> _StartupTimingPlan:
@@ -711,7 +753,7 @@ def main(argv: list[str] | None = None) -> int:
 
     startup.phaseChanged.connect(_handle_startup_phase_changed)
 
-    pre_show_features, post_show_features = _startup_feature_plan()
+    _pre_show_features, post_show_features = _startup_feature_plan()
     startup_timing = _startup_timing_plan()
 
     def _preload_startup_modules() -> object:
@@ -735,63 +777,107 @@ def main(argv: list[str] | None = None) -> int:
     def _startup_imports_ready(generation: int) -> bool:
         return coordinator_runtime is not None or startup_imports.ready(generation)
 
-    def _ensure_pre_show_features(generation: int) -> StartupFailure | None:
-        for feature in pre_show_features:
-            job_name = f"feature.{feature}.pre_show"
-            thread_name = threading.current_thread().name
-            mark(
-                "startup.gui_job.started",
-                job=job_name,
-                generation=generation,
-                duration_ms=0.0,
-                budget_ms=100.0,
-                over_budget=False,
-                thread=thread_name,
-                result="running",
+    def _prepare_pre_show_native_hierarchy(
+        generation: int,
+    ) -> StartupFailure | None:
+        job_name = "feature.detail.native_hierarchy.pre_show"
+        thread_name = threading.current_thread().name
+        mark(
+            "startup.gui_job.started",
+            job=job_name,
+            generation=generation,
+            duration_ms=0.0,
+            budget_ms=100.0,
+            over_budget=False,
+            thread=thread_name,
+            result="running",
+        )
+        mark("detail.native_hierarchy.before_prepare", generation=generation)
+        started_ns = time.perf_counter_ns()
+        prepare_exception: Exception | None = None
+        surface_count = 0
+        graphics_backends: tuple[str, ...] = ()
+        top_level_surface_type = "unknown"
+        try:
+            selected_backend = selected_rhi_backend_name()
+            top_level_surface_type = _prepare_top_level_rhi_surface(
+                window,
+                selected_backend,
             )
-            started_ns = time.perf_counter_ns()
-            feature_exception: Exception | None = None
-            try:
-                if feature == "detail":
-                    mark("rhi_detail.before_create")
-                window.ui.ensure_feature(feature)
-                if feature == "detail":
-                    mark("rhi_detail.created")
-            except Exception as exc:  # Startup recovery boundary.
-                feature_exception = exc
-                _logger.exception("Pre-show feature %s failed", feature)
-            finally:
-                duration_ms = (time.perf_counter_ns() - started_ns) / 1_000_000.0
-                details = {
-                    "job": job_name,
-                    "generation": generation,
-                    "duration_ms": round(duration_ms, 3),
-                    "budget_ms": 100.0,
-                    "over_budget": duration_ms > 100.0,
-                    "thread": thread_name,
-                    "result": "error" if feature_exception is not None else "success",
-                }
-                mark("startup.gui_job.finished", **details)
-                if duration_ms > 100.0:
-                    mark("startup.gui_stall", **details)
-                    _logger.warning(
-                        "GUI startup job %s exceeded 100.0ms budget (%.1fms)",
-                        job_name,
-                        duration_ms,
-                    )
-            if feature_exception is not None:
-                return StartupFailure(
-                    phase=StartupPhase.APP_CREATED,
-                    message=str(feature_exception) or type(feature_exception).__name__,
-                    exception_type=type(feature_exception).__name__,
-                    recoverable=True,
-                    code=f"feature_{feature}_pre_show_failed",
-                    suggested_action="retry",
-                    operation=f"feature.{feature}.pre_show",
+            prepare = getattr(window.ui, "prepare_detail_native_hierarchy", None)
+            if not callable(prepare):
+                raise RuntimeError(
+                    "main window UI does not provide prepare_detail_native_hierarchy"
                 )
+            detail_page = prepare()
+            surfaces = tuple(detail_page.native_surfaces())
+            surface_count = len(surfaces)
+            graphics_backends = tuple(
+                sorted(
+                    {
+                        str(backend_name())
+                        for surface in surfaces
+                        if callable(
+                            backend_name := getattr(
+                                surface,
+                                "render_backend_name",
+                                None,
+                            )
+                        )
+                    }
+                )
+            )
+            mark(
+                "detail.native_hierarchy.prepared",
+                generation=generation,
+                surface_count=surface_count,
+                graphics_backends=graphics_backends,
+                top_level_surface_type=top_level_surface_type,
+            )
+        except Exception as exc:  # Startup recovery boundary.
+            prepare_exception = exc
+            _logger.exception("Pre-show Detail native hierarchy preparation failed")
+        finally:
+            measured_duration_ms = (
+                time.perf_counter_ns() - started_ns
+            ) / 1_000_000.0
+            prepared_duration_ms = float(
+                getattr(window.ui, "_detail_native_prepare_duration_ms", 0.0)
+            )
+            duration_ms = max(measured_duration_ms, prepared_duration_ms)
+            details = {
+                "job": job_name,
+                "generation": generation,
+                "duration_ms": round(duration_ms, 3),
+                "budget_ms": 100.0,
+                "over_budget": duration_ms > 100.0,
+                "thread": thread_name,
+                "result": "error" if prepare_exception is not None else "success",
+                "surface_count": surface_count,
+                "graphics_backends": graphics_backends,
+                "top_level_surface_type": top_level_surface_type,
+            }
+            mark("startup.gui_job.finished", **details)
+            if duration_ms > 100.0:
+                mark("startup.gui_stall", **details)
+                _logger.warning(
+                    "GUI startup job %s exceeded 100.0ms budget (%.1fms)",
+                    job_name,
+                    duration_ms,
+                )
+        if prepare_exception is not None:
+            return StartupFailure(
+                phase=StartupPhase.APP_CREATED,
+                message=str(prepare_exception) or type(prepare_exception).__name__,
+                exception_type=type(prepare_exception).__name__,
+                recoverable=True,
+                code="feature_detail_native_hierarchy_pre_show_failed",
+                suggested_action="retry",
+                operation=job_name,
+            )
         return None
 
-    pre_show_failure = _ensure_pre_show_features(startup.generation)
+    pre_show_failure = _prepare_pre_show_native_hierarchy(startup.generation)
 
     coordinator_runtime = None
     coordinator_started = False
@@ -1039,23 +1125,18 @@ def main(argv: list[str] | None = None) -> int:
             lambda: _start_startup_imports(generation),
         )
         for feature in post_show_features:
-            if feature == "detail":
-                prepare_surface = getattr(
-                    window.ui,
-                    "prepare_detail_surface",
-                    lambda: None,
-                )
-                _enqueue_startup_job(
-                    "feature.detail.surface",
-                    generation,
-                    prepare_surface,
-                    prerequisite=lambda: _startup_imports_ready(generation),
-                )
-
             def _create_feature(feature_name=feature) -> None:
                 mark("feature.before_create", feature=feature_name)
-                window.ui.ensure_feature(feature_name)
+                created = window.ui.ensure_feature(feature_name)
                 mark("feature.created", feature=feature_name)
+                if feature_name == "detail":
+                    native_surfaces = getattr(created, "native_surfaces", None)
+                    surfaces = tuple(native_surfaces()) if callable(native_surfaces) else ()
+                    mark(
+                        "detail.feature.completed",
+                        generation=generation,
+                        surface_count=len(surfaces),
+                    )
 
             _enqueue_startup_job(
                 f"feature.{feature}.post_show",
@@ -1099,7 +1180,7 @@ def main(argv: list[str] | None = None) -> int:
             return
         generation = startup.begin()
         _register_attempt_resources(generation)
-        pre_show_failure = _ensure_pre_show_features(generation)
+        pre_show_failure = _prepare_pre_show_native_hierarchy(generation)
         if pre_show_failure is not None:
             startup.fail(pre_show_failure)
             return

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -777,7 +777,7 @@ def main(argv: list[str] | None = None) -> int:
     def _startup_imports_ready(generation: int) -> bool:
         return coordinator_runtime is not None or startup_imports.ready(generation)
 
-    def _prepare_pre_show_native_hierarchy(
+    def _verify_prepared_native_hierarchy(
         generation: int,
     ) -> StartupFailure | None:
         job_name = "feature.detail.native_hierarchy.pre_show"
@@ -792,7 +792,7 @@ def main(argv: list[str] | None = None) -> int:
             thread=thread_name,
             result="running",
         )
-        mark("detail.native_hierarchy.before_prepare", generation=generation)
+        mark("detail.native_hierarchy.before_verify", generation=generation)
         started_ns = time.perf_counter_ns()
         prepare_exception: Exception | None = None
         surface_count = 0
@@ -804,12 +804,11 @@ def main(argv: list[str] | None = None) -> int:
                 window,
                 selected_backend,
             )
-            prepare = getattr(window.ui, "prepare_detail_native_hierarchy", None)
-            if not callable(prepare):
+            detail_page = getattr(window.ui, "_prepared_detail_page", None)
+            if detail_page is None:
                 raise RuntimeError(
-                    "main window UI does not provide prepare_detail_native_hierarchy"
+                    "main window UI did not prepare the Detail native hierarchy"
                 )
-            detail_page = prepare()
             surfaces = tuple(detail_page.native_surfaces())
             surface_count = len(surfaces)
             graphics_backends = tuple(
@@ -834,9 +833,9 @@ def main(argv: list[str] | None = None) -> int:
                 graphics_backends=graphics_backends,
                 top_level_surface_type=top_level_surface_type,
             )
-        except Exception as exc:  # Startup recovery boundary.
+        except Exception as exc:  # Non-recoverable shell verification boundary.
             prepare_exception = exc
-            _logger.exception("Pre-show Detail native hierarchy preparation failed")
+            _logger.exception("Pre-show Detail native hierarchy verification failed")
         finally:
             measured_duration_ms = (
                 time.perf_counter_ns() - started_ns
@@ -870,14 +869,21 @@ def main(argv: list[str] | None = None) -> int:
                 phase=StartupPhase.APP_CREATED,
                 message=str(prepare_exception) or type(prepare_exception).__name__,
                 exception_type=type(prepare_exception).__name__,
-                recoverable=True,
-                code="feature_detail_native_hierarchy_pre_show_failed",
-                suggested_action="retry",
+                recoverable=False,
+                code="shell_initialization_failed",
+                suggested_action="continue_without_library",
                 operation=job_name,
             )
         return None
 
-    pre_show_failure = _prepare_pre_show_native_hierarchy(startup.generation)
+    shell_verification_failure = _verify_prepared_native_hierarchy(
+        startup.generation
+    )
+    if shell_verification_failure is not None:
+        startup.fail(shell_verification_failure)
+        startup_jobs.close()
+        startup_imports.close()
+        return 1
 
     coordinator_runtime = None
     coordinator_started = False
@@ -1175,15 +1181,10 @@ def main(argv: list[str] | None = None) -> int:
         _initialize_features_after_show(generation)
 
     def _retry_startup() -> None:
-        nonlocal pre_show_failure
         if startup.phase is StartupPhase.CANCELLED:
             return
         generation = startup.begin()
         _register_attempt_resources(generation)
-        pre_show_failure = _prepare_pre_show_native_hierarchy(generation)
-        if pre_show_failure is not None:
-            startup.fail(pre_show_failure)
-            return
         startup.transition(StartupPhase.INTERACTIVE, reason="retry")
         _initialize_features_after_show(generation)
 
@@ -1213,13 +1214,10 @@ def main(argv: list[str] | None = None) -> int:
 
     startup.startupCompleted.connect(_schedule_benchmark_exit)
     startup.startupDegraded.connect(_schedule_benchmark_exit)
-    if pre_show_failure is None:
-        window.firstPainted.connect(startup.first_painted)
-        # Arm before show(): test doubles and a few embedded Qt hosts can paint
-        # synchronously from show(), and that event must not be lost.
-        startup.shell_shown(_continue_after_shell)
-    else:
-        startup.fail(pre_show_failure)
+    window.firstPainted.connect(startup.first_painted)
+    # Arm before show(): test doubles and a few embedded Qt hosts can paint
+    # synchronously from show(), and that event must not be lost.
+    startup.shell_shown(_continue_after_shell)
     mark("startup.show", generation=startup.generation)
     window.show()
     mark("main_window.show_called")

--- a/src/iPhoto/gui/ui/ui_main_window.py
+++ b/src/iPhoto/gui/ui/ui_main_window.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 import logging
+import time
 from enum import StrEnum
 from pathlib import Path
 
@@ -88,6 +89,8 @@ class Ui_MainWindow(QObject):
     def __init__(self) -> None:
         super().__init__()
         self._features: dict[FeatureKind, object] = {}
+        self._prepared_detail_page = None
+        self._detail_native_prepare_duration_ms = 0.0
         self._main_window: QMainWindow | None = None
         self._library = None
 
@@ -148,6 +151,41 @@ class Ui_MainWindow(QObject):
         self.title_separator.setFixedHeight(1)
         window_chrome_layout.addWidget(self.title_separator)
 
+        self.sidebar = AlbumSidebar(library, MainWindow)
+        self.gallery_page = GalleryPageWidget()
+        self.grid_view = self.gallery_page.grid_view
+
+        right_panel = QWidget()
+        right_panel.setObjectName("rightPanel")
+        _configure_opaque_widget_background(right_panel)
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(8, 8, 8, 8)
+
+        self.view_stack = QStackedWidget()
+        self.view_stack.setObjectName("mainViewStack")
+        _configure_opaque_widget_background(self.view_stack)
+
+        self.view_stack.addWidget(self.gallery_page)
+        self.view_stack.setCurrentWidget(self.gallery_page)
+        right_layout.addWidget(self.view_stack)
+
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.splitter.addWidget(self.sidebar)
+        self.splitter.addWidget(right_panel)
+        self.splitter.setStretchFactor(0, 0)
+        self.splitter.setStretchFactor(1, 1)
+        self.splitter.setCollapsible(0, True)
+        self.splitter.setCollapsible(1, False)
+
+        self.window_shell_layout.addWidget(self.splitter)
+
+        # QMenuBar forces macOS to create the top-level native QWindow.  The
+        # complete QRhi hierarchy must already be attached at that point so Qt
+        # creates the window with MetalSurface (or the selected desktop API)
+        # instead of permanently committing a RasterSurface first.
+        MainWindow.setCentralWidget(self.window_shell)
+        self.prepare_detail_native_hierarchy()
+
         self.main_header = MainHeaderWidget(self.window_shell, MainWindow)
         self.menu_bar_container = self.main_header
         self.menu_bar = self.main_header.menu_bar
@@ -186,42 +224,12 @@ class Ui_MainWindow(QObject):
         self.language_de = self.main_header.language_de
         self.language_zh_cn = self.main_header.language_zh_cn
 
-        self.window_shell_layout.addWidget(self.window_chrome)
-        self.window_shell_layout.addWidget(self.menu_bar_container)
-
-        self.sidebar = AlbumSidebar(library, MainWindow)
-        self.gallery_page = GalleryPageWidget()
-        self.grid_view = self.gallery_page.grid_view
-
-        right_panel = QWidget()
-        right_panel.setObjectName("rightPanel")
-        _configure_opaque_widget_background(right_panel)
-        right_layout = QVBoxLayout(right_panel)
-        right_layout.setContentsMargins(8, 8, 8, 8)
-
-        self.view_stack = QStackedWidget()
-        self.view_stack.setObjectName("mainViewStack")
-        _configure_opaque_widget_background(self.view_stack)
-
-        self.view_stack.addWidget(self.gallery_page)
-        self.view_stack.setCurrentWidget(self.gallery_page)
-        right_layout.addWidget(self.view_stack)
-
-        self.splitter = QSplitter(Qt.Orientation.Horizontal)
-        self.splitter.addWidget(self.sidebar)
-        self.splitter.addWidget(right_panel)
-        self.splitter.setStretchFactor(0, 0)
-        self.splitter.setStretchFactor(1, 1)
-        self.splitter.setCollapsible(0, True)
-        self.splitter.setCollapsible(1, False)
-
-        self.window_shell_layout.addWidget(self.splitter)
+        self.window_shell_layout.insertWidget(0, self.window_chrome)
+        self.window_shell_layout.insertWidget(1, self.menu_bar_container)
 
         self.status_bar = ChromeStatusBar(self.window_shell)
         self.window_shell_layout.addWidget(self.status_bar)
         self.progress_bar = self.status_bar.progress_bar
-
-        MainWindow.setCentralWidget(self.window_shell)
 
         self.notification_toast = NotificationToast(MainWindow)
 
@@ -248,11 +256,9 @@ class Ui_MainWindow(QObject):
         return created
 
     def _create_detail_feature(self) -> object:
-        from .widgets.detail_page import DetailPageWidget
-
         assert self._main_window is not None
-        shared_image_viewer = self.prepare_detail_surface()
-        self.detail_page = DetailPageWidget(self._main_window, image_viewer=shared_image_viewer)
+        self.detail_page = self.prepare_detail_native_hierarchy()
+        self.detail_page.complete_feature()
         for name in (
             "back_button", "info_button", "share_button", "favorite_button",
             "rotate_left_button", "edit_button", "zoom_widget", "zoom_slider",
@@ -265,23 +271,45 @@ class Ui_MainWindow(QObject):
             "player_container",
         ):
             setattr(self, name, getattr(self.detail_page, name))
-        self.image_viewer = shared_image_viewer
-        self.edit_image_viewer = shared_image_viewer
-        self.view_stack.addWidget(self.detail_page)
+        self.image_viewer = self.detail_page.image_viewer
+        self.edit_image_viewer = self.detail_page.image_viewer
         self.player_container.installEventFilter(self._main_window)
         self.retranslateUi(self._main_window)
         return self.detail_page
 
-    def prepare_detail_surface(self):
-        """Create only the single-window native/RHI surface host."""
+    def prepare_detail_native_hierarchy(self):
+        """Attach every Detail QRhi widget to its final top-level pre-show."""
 
-        existing = getattr(self, "_prepared_detail_surface", None)
+        existing = self._prepared_detail_page
         if existing is not None:
             return existing
-        from .widgets.gl_image_viewer import GLImageViewer
+        from .widgets.detail_page import DetailPageWidget
 
-        self._prepared_detail_surface = GLImageViewer()
-        return self._prepared_detail_surface
+        assert self._main_window is not None
+        current_page = self.view_stack.currentWidget()
+        detail_page = None
+        started_ns = time.perf_counter_ns()
+        try:
+            detail_page = DetailPageWidget(
+                self._main_window,
+                parent=self.view_stack,
+                staged=True,
+            )
+            self.view_stack.addWidget(detail_page)
+            if current_page is not None:
+                self.view_stack.setCurrentWidget(current_page)
+        except Exception:
+            if detail_page is not None:
+                self.view_stack.removeWidget(detail_page)
+                detail_page.deleteLater()
+            raise
+        finally:
+            self._detail_native_prepare_duration_ms = (
+                time.perf_counter_ns() - started_ns
+            ) / 1_000_000.0
+
+        self._prepared_detail_page = detail_page
+        return detail_page
 
     def ensure_detail_edit_bundle(self) -> object:
         """Publish the edit-only Detail controls on first edit use."""

--- a/src/iPhoto/gui/ui/widgets/detail_page.py
+++ b/src/iPhoto/gui/ui/widgets/detail_page.py
@@ -22,10 +22,7 @@ from PySide6.QtWidgets import (
 from ....gui.i18n import tr
 from ..icon import load_icon
 from ..palette import SIDEBAR_TEXT_COLOR, viewer_surface_color
-from .face_name_overlay import FaceNameOverlayWidget
-from .filmstrip_view import FilmstripView
 from .gl_image_viewer import GLImageViewer
-from .live_badge import LiveBadge
 from .main_window_metrics import (
     EDIT_DONE_BUTTON_BACKGROUND,
     EDIT_DONE_BUTTON_BACKGROUND_DISABLED,
@@ -38,7 +35,6 @@ from .main_window_metrics import (
     HEADER_ICON_GLYPH_SIZE,
 )
 from .video_area import VideoArea
-from .video_trim_bar import VideoTrimBar
 
 
 class DetailPageWidget(QWidget):
@@ -71,7 +67,10 @@ class DetailPageWidget(QWidget):
         self.player_stack = QStackedWidget(self)
         self._placeholder_default_text = self.default_placeholder_text()
         self.player_placeholder = QLabel(self._placeholder_default_text, self.player_stack)
-        self.image_viewer = image_viewer or GLImageViewer(self.player_stack)
+        self.image_viewer = image_viewer or GLImageViewer(
+            self.player_stack,
+            staged=staged,
+        )
         if self.image_viewer.parent() is not self.player_stack:
             self.image_viewer.setParent(self.player_stack)
         try:
@@ -116,6 +115,14 @@ class DetailPageWidget(QWidget):
         if self._feature_completed:
             return
 
+        from .face_name_overlay import FaceNameOverlayWidget
+        from .filmstrip_view import FilmstripView
+        from .live_badge import LiveBadge
+        from .video_trim_bar import VideoTrimBar
+
+        complete_image_viewer = getattr(self.image_viewer, "complete_runtime", None)
+        if callable(complete_image_viewer):
+            complete_image_viewer()
         complete_runtime = getattr(self.video_area, "complete_runtime", None)
         if callable(complete_runtime):
             complete_runtime()

--- a/src/iPhoto/gui/ui/widgets/detail_page.py
+++ b/src/iPhoto/gui/ui/widgets/detail_page.py
@@ -50,6 +50,7 @@ class DetailPageWidget(QWidget):
         parent: QWidget | None = None,
         *,
         image_viewer: GLImageViewer | None = None,
+        staged: bool = False,
     ) -> None:
         super().__init__(parent)
         self.setObjectName("detailPage")
@@ -63,43 +64,29 @@ class DetailPageWidget(QWidget):
         # ``hide_rhi_init_cover()`` and ``resizeEvent`` always find the attr.
         self._rhi_init_cover: QWidget | None = None
         self._edit_bundle_created = False
+        self._feature_completed = False
         self._main_window = main_window
-
-        # Header widgets -----------------------------------------------------
-        self.back_button = QToolButton(self)
-        self.info_button = QToolButton(self)
-        self.share_button = QToolButton(self)
-        self.favorite_button = QToolButton(self)
-        self.favorite_button.setEnabled(False)
-        self.rotate_left_button = QToolButton(self)
-        self.edit_button = QPushButton(tr("DetailPage", "Edit"), self)
-        self.edit_button.setEnabled(False)
-
-        self.zoom_widget = QWidget(self)
-        self.zoom_slider = QSlider(Qt.Orientation.Horizontal, self.zoom_widget)
-        self.zoom_in_button = QToolButton(self.zoom_widget)
-        self.zoom_out_button = QToolButton(self.zoom_widget)
-
-        self.location_label = QLabel(self)
-        self.timestamp_label = QLabel(self)
 
         # Viewer widgets -----------------------------------------------------
         self.player_stack = QStackedWidget(self)
         self._placeholder_default_text = self.default_placeholder_text()
         self.player_placeholder = QLabel(self._placeholder_default_text, self.player_stack)
-        self.image_viewer = image_viewer or GLImageViewer()
-        if self.image_viewer.parent() not in (None, self.player_stack):
-            self.image_viewer.setParent(None)
-        self.video_area = VideoArea()
-        self.player_bar = self.video_area.player_bar
-        self.video_trim_bar = VideoTrimBar()
-        self.video_trim_bar.hide()
-        self.face_name_overlay = FaceNameOverlayWidget()
-
-        self.filmstrip_view = FilmstripView()
-
-        self.live_badge = LiveBadge(main_window)
-        self.live_badge.hide()
+        self.image_viewer = image_viewer or GLImageViewer(self.player_stack)
+        if self.image_viewer.parent() is not self.player_stack:
+            self.image_viewer.setParent(self.player_stack)
+        try:
+            self.video_area = VideoArea(self.player_stack, staged=True)
+        except TypeError as exc:
+            # Lightweight embedders and controller tests may replace
+            # VideoArea with the historical parent-only constructor.
+            if "staged" not in str(exc):
+                raise
+            self.video_area = VideoArea(self.player_stack)
+        self.player_bar = None
+        self.video_trim_bar = None
+        self.face_name_overlay = None
+        self.filmstrip_view = None
+        self.live_badge = None
         self.badge_host: QWidget | None = None
 
         # References controllers rely on when shuffling widgets.
@@ -114,15 +101,73 @@ class DetailPageWidget(QWidget):
         self.player_container: QWidget | None = None
         self.player_column: QWidget | None = None
 
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        self._root_layout = QVBoxLayout(self)
+        self._root_layout.setContentsMargins(0, 0, 0, 0)
+        self._root_layout.setSpacing(6)
 
-        self._build_header(main_window, layout)
         self._build_player_area()
-        self._build_player_container(layout)
-        layout.addWidget(self.filmstrip_view)
+        self._build_player_container(self._root_layout)
+        if not staged:
+            self.complete_feature()
+
+    def complete_feature(self) -> None:
+        """Complete non-native Detail UI without moving prepared QRhi widgets."""
+
+        if self._feature_completed:
+            return
+
+        complete_runtime = getattr(self.video_area, "complete_runtime", None)
+        if callable(complete_runtime):
+            complete_runtime()
+        self.player_bar = self.video_area.player_bar
+
+        # Header widgets -----------------------------------------------------
+        self.back_button = QToolButton(self)
+        self.info_button = QToolButton(self)
+        self.share_button = QToolButton(self)
+        self.favorite_button = QToolButton(self)
+        self.favorite_button.setEnabled(False)
+        self.rotate_left_button = QToolButton(self)
+        self.edit_button = QPushButton(tr("DetailPage", "Edit"), self)
+        self.edit_button.setEnabled(False)
+        self.zoom_widget = QWidget(self)
+        self.zoom_slider = QSlider(Qt.Orientation.Horizontal, self.zoom_widget)
+        self.zoom_in_button = QToolButton(self.zoom_widget)
+        self.zoom_out_button = QToolButton(self.zoom_widget)
+        self.location_label = QLabel(self)
+        self.timestamp_label = QLabel(self)
+
+        self.video_trim_bar = VideoTrimBar(self)
+        self.video_trim_bar.hide()
+        self._player_column_layout.addWidget(self.video_trim_bar)
+
+        self.face_name_overlay = FaceNameOverlayWidget(self.player_container)
+        self.face_name_overlay.set_viewer(self.image_viewer)
+        player_layout = self.player_container.layout()
+        if player_layout is not None:
+            player_layout.addWidget(self.face_name_overlay, 0, 0)
+        self.face_name_overlay.hide()
+
+        self.live_badge = LiveBadge(self._main_window)
+        self.live_badge.setParent(self.player_container)
+        self.live_badge.hide()
+        self.badge_host = self.player_container
+
+        self.filmstrip_view = FilmstripView(self)
+        self._build_header(self._main_window, self._root_layout)
+        self._root_layout.addWidget(self.filmstrip_view)
+        self._feature_completed = True
+        self._raise_player_overlays()
         self.retranslate_ui()
+
+    def native_surfaces(self) -> tuple[QWidget, QWidget, QWidget]:
+        """Return the QRhi widgets whose final hierarchy is prepared pre-show."""
+
+        return (
+            self.image_viewer,
+            self.video_area.renderer,
+            self.video_area.edit_viewer,
+        )
 
     @classmethod
     def default_placeholder_text(cls) -> str:
@@ -179,7 +224,8 @@ class DetailPageWidget(QWidget):
         ):
             self.player_placeholder.setText(default_placeholder_text)
         self._placeholder_default_text = default_placeholder_text
-        self.player_bar.retranslate_ui()
+        if self.player_bar is not None:
+            self.player_bar.retranslate_ui()
         for child_name in ("video_trim_bar", "edit_sidebar", "face_name_overlay"):
             child = getattr(self, child_name, None)
             method = getattr(child, "retranslate_ui", None)
@@ -360,7 +406,7 @@ class DetailPageWidget(QWidget):
         detail_chrome_layout.addWidget(header_separator)
         self.detail_header_separator = header_separator
 
-        parent_layout.addWidget(detail_chrome_container)
+        parent_layout.insertWidget(0, detail_chrome_container)
         self.detail_chrome_container = detail_chrome_container
 
     def _build_player_area(self) -> None:
@@ -374,8 +420,6 @@ class DetailPageWidget(QWidget):
         self.player_placeholder.setMinimumHeight(320)
 
         self.player_stack.addWidget(self.player_placeholder)
-        if self.image_viewer.parent() is not self.player_stack:
-            self.image_viewer.setParent(self.player_stack)
         self.player_stack.addWidget(self.image_viewer)
         self.player_stack.addWidget(self.video_area)
         self.player_stack.setCurrentWidget(self.player_placeholder)
@@ -405,10 +449,6 @@ class DetailPageWidget(QWidget):
         player_layout.setContentsMargins(0, 0, 0, 0)
         player_layout.setSpacing(0)
         player_layout.addWidget(self.player_stack, 0, 0)
-        self.face_name_overlay.setParent(player_container)
-        self.face_name_overlay.set_viewer(self.image_viewer)
-        player_layout.addWidget(self.face_name_overlay, 0, 0)
-        self.face_name_overlay.hide()
         self.player_container = player_container
 
         # Opaque cover that hides the QRhiWidget area until its first frame
@@ -424,9 +464,6 @@ class DetailPageWidget(QWidget):
         player_layout.addWidget(self._rhi_init_cover, 0, 0)
         self._rhi_init_cover.raise_()
 
-        self.live_badge.setParent(player_container)
-        self.badge_host = player_container
-        self._raise_player_overlays()
 
     def _build_player_container(self, parent_layout: QVBoxLayout) -> None:
         """Install the playback host without constructing optional edit chrome."""
@@ -448,7 +485,7 @@ class DetailPageWidget(QWidget):
         player_column_layout.setContentsMargins(0, 0, 0, 0)
         player_column_layout.setSpacing(0)
         player_column_layout.addWidget(self.player_container, 1)
-        player_column_layout.addWidget(self.video_trim_bar)
+        self._player_column_layout = player_column_layout
 
         edit_body_layout.addWidget(self.player_column, 1)
         edit_layout.addWidget(edit_body, 1)
@@ -460,6 +497,7 @@ class DetailPageWidget(QWidget):
     def ensure_edit_bundle(self) -> None:
         """Create edit-only controls immediately before the first edit session."""
 
+        self.complete_feature()
         if self._edit_bundle_created:
             return
         from .edit_sidebar import EditSidebar
@@ -654,15 +692,19 @@ class DetailPageWidget(QWidget):
         cover.setStyleSheet("background-color: palette(window);")
 
     def _raise_player_overlays(self) -> None:
-        refresh_overlay = getattr(self.face_name_overlay, "refresh_view_state", None)
+        face_name_overlay = self.face_name_overlay
+        live_badge = self.live_badge
+        if face_name_overlay is None or live_badge is None:
+            return
+        refresh_overlay = getattr(face_name_overlay, "refresh_view_state", None)
         if callable(refresh_overlay):
             refresh_overlay()
-        raise_overlay_controls = getattr(self.face_name_overlay, "raise_interactive_controls", None)
+        raise_overlay_controls = getattr(face_name_overlay, "raise_interactive_controls", None)
         if callable(raise_overlay_controls):
             raise_overlay_controls()
         else:
-            self.face_name_overlay.raise_()
-        self.live_badge.raise_()
+            face_name_overlay.raise_()
+        live_badge.raise_()
 
 
 __all__ = ["DetailPageWidget"]

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -29,32 +29,86 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QRhiWidget
 
+from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
+
+from ..render_backend import is_opengl_api, qrhi_api_name, select_qrhi_widget_api
+
 QVideoFrame = None  # type: ignore[assignment, misc]
 QVideoFrameFormat = None  # type: ignore[assignment, misc]
-
-from iPhoto.gui.detail_decode_backend import DecodedSurface
-from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
-from iPhoto.gui.detail_surface_residency import (
-    SurfaceByteBreakdown,
-    SurfaceResidencyTracker,
-    surface_resource_id,
-)
-
-from ..gl_crop_controller import CropInteractionController
-from ..render_backend import is_opengl_api, qrhi_api_name, select_qrhi_widget_api
-from ..rhi_image_renderer import RhiImageRenderer
-from ..view_transform_controller import ViewTransformController
-from . import crop_viewport, geometry
-from .adjustment_applicator import AdjustmentApplicator
-from .components import LoadingOverlay
-from .fullscreen_handler import FullscreenHandler
-from .input_handler import InputEventHandler
-from .offscreen import OffscreenRenderer
-from .resources import TextureResourceManager
-from .utils import normalise_colour
-from .zoom_controller import ZoomController
+DecodedSurface = None
+SurfaceByteBreakdown = None
+SurfaceResidencyTracker = None
+surface_resource_id = None
+CropInteractionController = None
+RhiImageRenderer = None
+ViewTransformController = None
+crop_viewport = None
+geometry = None
+AdjustmentApplicator = None
+LoadingOverlay = None
+FullscreenHandler = None
+InputEventHandler = None
+OffscreenRenderer = None
+TextureResourceManager = None
+normalise_colour = None
+ZoomController = None
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _load_viewer_runtime_dependencies() -> None:
+    """Load NumPy-backed viewer services only after the first shell paint."""
+
+    global AdjustmentApplicator, CropInteractionController, DecodedSurface
+    global FullscreenHandler, InputEventHandler, LoadingOverlay, OffscreenRenderer
+    global RhiImageRenderer, SurfaceByteBreakdown, SurfaceResidencyTracker
+    global TextureResourceManager, ViewTransformController, ZoomController
+    global crop_viewport, geometry, normalise_colour, surface_resource_id
+    if TextureResourceManager is not None:
+        return
+
+    from iPhoto.gui.detail_decode_backend import DecodedSurface as _DecodedSurface
+    from iPhoto.gui.detail_surface_residency import (
+        SurfaceByteBreakdown as _SurfaceByteBreakdown,
+    )
+    from iPhoto.gui.detail_surface_residency import (
+        SurfaceResidencyTracker as _SurfaceResidencyTracker,
+    )
+    from iPhoto.gui.detail_surface_residency import (
+        surface_resource_id as _surface_resource_id,
+    )
+
+    from ..gl_crop_controller import CropInteractionController as _CropInteractionController
+    from ..rhi_image_renderer import RhiImageRenderer as _RhiImageRenderer
+    from ..view_transform_controller import ViewTransformController as _ViewTransformController
+    from . import crop_viewport as _crop_viewport
+    from . import geometry as _geometry
+    from .adjustment_applicator import AdjustmentApplicator as _AdjustmentApplicator
+    from .components import LoadingOverlay as _LoadingOverlay
+    from .fullscreen_handler import FullscreenHandler as _FullscreenHandler
+    from .input_handler import InputEventHandler as _InputEventHandler
+    from .offscreen import OffscreenRenderer as _OffscreenRenderer
+    from .resources import TextureResourceManager as _TextureResourceManager
+    from .utils import normalise_colour as _normalise_colour
+    from .zoom_controller import ZoomController as _ZoomController
+
+    DecodedSurface = _DecodedSurface
+    SurfaceByteBreakdown = _SurfaceByteBreakdown
+    SurfaceResidencyTracker = _SurfaceResidencyTracker
+    surface_resource_id = _surface_resource_id
+    CropInteractionController = _CropInteractionController
+    RhiImageRenderer = _RhiImageRenderer
+    ViewTransformController = _ViewTransformController
+    crop_viewport = _crop_viewport
+    geometry = _geometry
+    AdjustmentApplicator = _AdjustmentApplicator
+    LoadingOverlay = _LoadingOverlay
+    FullscreenHandler = _FullscreenHandler
+    InputEventHandler = _InputEventHandler
+    OffscreenRenderer = _OffscreenRenderer
+    TextureResourceManager = _TextureResourceManager
+    normalise_colour = _normalise_colour
+    ZoomController = _ZoomController
 
 
 def _load_video_frame_types() -> None:
@@ -66,6 +120,8 @@ def _load_video_frame_types() -> None:
     try:
         from PySide6.QtMultimedia import (
             QVideoFrame as _QVideoFrame,
+        )
+        from PySide6.QtMultimedia import (
             QVideoFrameFormat as _QVideoFrameFormat,
         )
     except (ModuleNotFoundError, ImportError):  # pragma: no cover
@@ -155,7 +211,12 @@ class GLImageViewer(QRhiWidget):
     videoFramePresented = Signal()
     """Emitted after a newly uploaded video frame has been drawn."""
 
-    def __init__(self, parent: QRhiWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QRhiWidget | None = None,
+        *,
+        staged: bool = False,
+    ) -> None:
         super().__init__(parent)
         self.setMouseTracking(True)
 
@@ -212,6 +273,29 @@ class GLImageViewer(QRhiWidget):
         self._diag_video_render_count = 0
         self._adjustments: dict[str, Any] = {}
         self._eyedropper_active = False
+        self._auto_crop_view_locked = False
+        self._auto_crop_center_locked = False
+        self._time_base = time.monotonic()
+        self._runtime_ready = False
+        self._texture_manager = None
+        self._adjustment_applicator = None
+        self._fullscreen_handler = None
+        self._loading_overlay = None
+        self._transform_controller = None
+        self._zoom_ctrl = None
+        self._crop_controller = None
+        self._input_handler = None
+        self._pending_surface_color_override: str | None = None
+
+        if not staged:
+            self.complete_runtime()
+
+    def complete_runtime(self) -> None:
+        """Create NumPy-backed viewer services without replacing the QRhi widget."""
+
+        if self._runtime_ready:
+            return
+        _load_viewer_runtime_dependencies()
 
         # Texture resource manager
         self._texture_manager = TextureResourceManager(
@@ -234,10 +318,11 @@ class GLImageViewer(QRhiWidget):
             set_stylesheet=self.setStyleSheet,
             request_update=self.update,
         )
+        if self._pending_surface_color_override is not None:
+            self._fullscreen_handler.set_surface_color_override(
+                self._pending_surface_color_override
+            )
         self._fullscreen_handler._apply()
-
-        # ``_time_base`` anchors the monotonic clock used by the shader grain generator.
-        self._time_base = time.monotonic()
 
         # Loading overlay component
         self._loading_overlay = LoadingOverlay(self)
@@ -272,8 +357,6 @@ class GLImageViewer(QRhiWidget):
             on_interaction_started=self.cropInteractionStarted.emit,
             on_interaction_finished=self.cropInteractionFinished.emit,
         )
-        self._auto_crop_view_locked: bool = False
-        self._auto_crop_center_locked: bool = False
         self._update_crop_perspective_state()
 
         # Input event handler
@@ -285,6 +368,7 @@ class GLImageViewer(QRhiWidget):
             on_fullscreen_toggle=self.fullscreenToggleRequested.emit,
             on_cancel_auto_crop_lock=self._cancel_auto_crop_lock,
         )
+        self._runtime_ready = True
 
     def render_backend_name(self) -> str:
         """Return the active QRhi backend name for diagnostics/tests."""
@@ -1056,6 +1140,9 @@ class GLImageViewer(QRhiWidget):
 
     def set_surface_color_override(self, colour: str | None) -> None:
         """Override the viewer backdrop with *colour* or restore the default."""
+        self._pending_surface_color_override = colour
+        if not self._runtime_ready:
+            return
         self._fullscreen_handler.set_surface_color_override(colour)
 
     def set_crop_framing_enabled(self, enabled: bool) -> None:
@@ -1324,6 +1411,7 @@ class GLImageViewer(QRhiWidget):
 
     def initialize(self, cb) -> None:  # type: ignore[override]
         """QRhiWidget override: initialise renderer resources once."""
+        self.complete_runtime()
         if self._gl_initialized:
             return
         rhi = self.rhi()
@@ -1371,6 +1459,8 @@ class GLImageViewer(QRhiWidget):
     def releaseResources(self) -> None:  # type: ignore[override]
         """QRhiWidget override: release renderer resources."""
         self._gl_initialized = False
+        if not self._runtime_ready:
+            return
         if self._renderer is not None:
             rhi = self.rhi()
             if self._uses_raw_gl and rhi is not None:
@@ -1388,6 +1478,7 @@ class GLImageViewer(QRhiWidget):
 
     def render(self, cb) -> None:  # type: ignore[override]
         """QRhiWidget override: render the current image/video frame."""
+        self.complete_runtime()
         if not self._uses_raw_gl:
             self._render_rhi(cb)
             return
@@ -1992,6 +2083,8 @@ class GLImageViewer(QRhiWidget):
 
     def resizeEvent(self, event) -> None:  # type: ignore[override]
         super().resizeEvent(event)
+        if not self._runtime_ready:
+            return
         self._loading_overlay.update_geometry(self.size())
         if self._auto_crop_view_locked and not self._crop_controller.is_active():
             self._reapply_locked_crop_view()

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -29,11 +29,8 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QRhiWidget
 
-try:  # pragma: no cover - optional Qt module
-    from PySide6.QtMultimedia import QVideoFrame, QVideoFrameFormat
-except (ModuleNotFoundError, ImportError):  # pragma: no cover
-    QVideoFrame = None  # type: ignore[assignment, misc]
-    QVideoFrameFormat = None  # type: ignore[assignment, misc]
+QVideoFrame = None  # type: ignore[assignment, misc]
+QVideoFrameFormat = None  # type: ignore[assignment, misc]
 
 from iPhoto.gui.detail_decode_backend import DecodedSurface
 from iPhoto.gui.detail_profile import emit_detail_event, log_detail_profile
@@ -58,6 +55,23 @@ from .utils import normalise_colour
 from .zoom_controller import ZoomController
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _load_video_frame_types() -> None:
+    """Load QtMultimedia frame types only when a decoded frame arrives."""
+
+    global QVideoFrame, QVideoFrameFormat
+    if QVideoFrame is not None and QVideoFrameFormat is not None:
+        return
+    try:
+        from PySide6.QtMultimedia import (
+            QVideoFrame as _QVideoFrame,
+            QVideoFrameFormat as _QVideoFrameFormat,
+        )
+    except (ModuleNotFoundError, ImportError):  # pragma: no cover
+        return
+    QVideoFrame = _QVideoFrame
+    QVideoFrameFormat = _QVideoFrameFormat
 
 # Crop preview must not reuse the persisted [0, 1] crop mask.  Straightened or
 # perspective-corrected source pixels can project outside that logical square;
@@ -628,6 +642,7 @@ class GLImageViewer(QRhiWidget):
     ) -> None:
         """Display *frame* directly through the OpenGL shader pipeline."""
 
+        _load_video_frame_types()
         if QVideoFrame is None or frame is None or not frame.isValid():
             return
 

--- a/src/iPhoto/gui/ui/widgets/rhi_image_renderer.py
+++ b/src/iPhoto/gui/ui/widgets/rhi_image_renderer.py
@@ -40,11 +40,8 @@ from PySide6.QtGui import (
     QShader,
 )
 
-try:  # pragma: no cover - optional Qt module
-    from PySide6.QtMultimedia import QVideoFrame, QVideoFrameFormat
-except (ModuleNotFoundError, ImportError):  # pragma: no cover
-    QVideoFrame = None  # type: ignore[assignment, misc]
-    QVideoFrameFormat = None  # type: ignore[assignment, misc]
+QVideoFrame = None  # type: ignore[assignment, misc]
+QVideoFrameFormat = None  # type: ignore[assignment, misc]
 
 from ....core.selective_color_resolver import NUM_RANGES, SAT_GATE_HI, SAT_GATE_LO
 from ....gui.detail_profile import emit_detail_event
@@ -52,6 +49,23 @@ from ....gui.detail_profile import emit_detail_event
 from .perspective_math import build_perspective_matrix
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _load_video_frame_types() -> None:
+    """Load QtMultimedia frame types only when playback submits a frame."""
+
+    global QVideoFrame, QVideoFrameFormat
+    if QVideoFrame is not None and QVideoFrameFormat is not None:
+        return
+    try:
+        from PySide6.QtMultimedia import (
+            QVideoFrame as _QVideoFrame,
+            QVideoFrameFormat as _QVideoFrameFormat,
+        )
+    except (ModuleNotFoundError, ImportError):  # pragma: no cover
+        return
+    QVideoFrame = _QVideoFrame
+    QVideoFrameFormat = _QVideoFrameFormat
 
 _SHADER_DIR = Path(__file__).resolve().parent
 _IMAGE_VERT_QSB = _SHADER_DIR / "image_viewer_rhi.vert.qsb"
@@ -94,6 +108,7 @@ def _qimage_to_rgba(image: QImage) -> QImage:
 def _classify_video_frame_format(
     fmt: "QVideoFrameFormat | None",
 ) -> tuple[int, int, int, int]:
+    _load_video_frame_types()
     if fmt is None or QVideoFrameFormat is None:
         return (_VIDEO_FMT_NONE, _CS_BT709, _TF_SDR, _RANGE_LIMITED)
 
@@ -436,6 +451,7 @@ class RhiImageRenderer:
             emit_detail_event("gpu_evict", generation=0, key=str(key), bytes=size, pressure=True)
 
     def upload_video_frame(self, frame: "QVideoFrame") -> tuple[int, int]:
+        _load_video_frame_types()
         if QVideoFrame is None or QVideoFrameFormat is None:
             raise RuntimeError("PySide6.QtMultimedia is required for video frame upload")
         if frame is None or not frame.isValid():

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -35,18 +35,13 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-try:  # pragma: no cover - optional Qt module
-    from PySide6.QtMultimedia import (
-        QAudioOutput,
-        QMediaPlayer,
-        QVideoFrame,
-        QVideoSink,
-    )
-except (ModuleNotFoundError, ImportError):  # pragma: no cover - handled by main window guard
-    QMediaPlayer = None
-    QAudioOutput = None
-    QVideoFrame = None  # type: ignore[assignment, misc]
-    QVideoSink = None  # type: ignore[assignment, misc]
+# QtMultimedia is deliberately imported by ``complete_runtime()``.  The staged
+# startup path must be able to establish the final QRhiWidget hierarchy without
+# also starting the platform media backend before the main window is shown.
+QMediaPlayer = None
+QAudioOutput = None
+QVideoFrame = None  # type: ignore[assignment, misc]
+QVideoSink = None  # type: ignore[assignment, misc]
 
 from ....config import (
     PLAYER_CONTROLS_HIDE_DELAY_MS,
@@ -61,14 +56,11 @@ from ....gui.detail_pipeline import (
     VideoPresentationState,
 )
 from ....gui.detail_profile import emit_detail_event, log_detail_profile
-from ....utils.ffmpeg import (  # noqa: F401 - V1 monkeypatch/test compatibility
-    get_linux_180_prerotate_hint,
-    probe_video_rotation,
-)
 from ..palette import viewer_surface_color
 from .gl_image_viewer import GLImageViewer
-from .player_bar import PlayerBar
 from .video_renderer_widget import VideoRendererWidget, _resolve_frame_rotation_cw
+
+PlayerBar = None
 
 _log = logging.getLogger(__name__)
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
@@ -76,6 +68,57 @@ _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 def _startup_hang_diag_enabled() -> bool:
     return os.environ.get("IPHOTO_STARTUP_HANG_DIAG", "").strip().lower() in _TRUE_ENV_VALUES
+
+
+def _load_qt_multimedia_runtime() -> None:
+    """Load optional playback classes without replacing test-provided seams."""
+
+    global QAudioOutput, QMediaPlayer, QVideoFrame, QVideoSink
+    if QMediaPlayer is None or QAudioOutput is None or QVideoSink is None:
+        try:
+            from PySide6.QtMultimedia import (
+                QAudioOutput as _QAudioOutput,
+                QMediaPlayer as _QMediaPlayer,
+                QVideoFrame as _QVideoFrame,
+                QVideoSink as _QVideoSink,
+            )
+        except (ModuleNotFoundError, ImportError):
+            return
+        if QMediaPlayer is None:
+            QMediaPlayer = _QMediaPlayer
+        if QAudioOutput is None:
+            QAudioOutput = _QAudioOutput
+        if QVideoFrame is None:
+            QVideoFrame = _QVideoFrame
+        if QVideoSink is None:
+            QVideoSink = _QVideoSink
+
+
+def _load_player_bar_class():
+    global PlayerBar
+    if PlayerBar is None:
+        from .player_bar import PlayerBar as _PlayerBar
+
+        PlayerBar = _PlayerBar
+    return PlayerBar
+
+
+def probe_video_rotation(*args, **kwargs):
+    """Lazy compatibility seam for tests and older callers."""
+
+    from ....utils.ffmpeg import probe_video_rotation as _probe_video_rotation
+
+    return _probe_video_rotation(*args, **kwargs)
+
+
+def get_linux_180_prerotate_hint(*args, **kwargs):
+    """Lazy compatibility seam for tests and older callers."""
+
+    from ....utils.ffmpeg import (
+        get_linux_180_prerotate_hint as _get_linux_180_prerotate_hint,
+    )
+
+    return _get_linux_180_prerotate_hint(*args, **kwargs)
 
 
 class VideoArea(QWidget):
@@ -111,7 +154,12 @@ class VideoArea(QWidget):
     displaySizeChanged = Signal(QSizeF)
     SHORTCUT_VOLUME_STEP = 5
 
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        *,
+        staged: bool = False,
+    ) -> None:
         super().__init__(parent)
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         # Prevent the WA_TranslucentBackground cascade from the main window
@@ -119,11 +167,6 @@ class VideoArea(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
         self.setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent, True)
         self.setMouseTracking(True)
-
-        if QMediaPlayer is None or QVideoSink is None:
-            raise RuntimeError(
-                "PySide6.QtMultimedia is required for video playback."
-            )
 
         # --- Video Renderer Setup ---
         surface_color = viewer_surface_color(self)
@@ -194,8 +237,46 @@ class VideoArea(QWidget):
         self._renderer_zoom: float = 1.0
         self._edit_viewer_zoom: float = 1.0
 
+        # Playback-only objects are created after the first main-window paint
+        # on the staged startup path.  The QRhi widgets above already have
+        # their final parents and must never be reparented during completion.
+        self._runtime_ready = False
+        self._player = None
+        self._audio_output = None
+        self._video_sink = None
+        self._player_bar = None
+        self._fade_anim = None
+        self._hide_timer = None
+        self._overlay_margin = 48
+        self._controls_visible = False
+        self._target_opacity = 0.0
+        self._host_widget: QWidget | None = self._renderer
+        self._window_host: QWidget | None = None
+        self._controls_enabled = True
+
         self._apply_surface(surface_color)
         # --- End Video Renderer Setup ---
+
+        self._wire_edit_viewer()
+        self._renderer.nativeSizeChanged.connect(self.displaySizeChanged.emit)
+        self._renderer.videoFramePresented.connect(self._on_gpu_video_frame_presented)
+        self._edit_viewer.videoFramePresented.connect(self._on_gpu_video_frame_presented)
+
+        if not staged:
+            self.complete_runtime()
+
+    def complete_runtime(self) -> None:
+        """Create playback services while preserving the prepared surfaces."""
+
+        if self._runtime_ready:
+            return
+
+        _load_qt_multimedia_runtime()
+        player_bar_class = _load_player_bar_class()
+        if QMediaPlayer is None or QAudioOutput is None or QVideoSink is None:
+            raise RuntimeError(
+                "PySide6.QtMultimedia is required for video playback."
+            )
 
         # --- Media Player Setup ---
         self._player = QMediaPlayer(self)
@@ -215,16 +296,9 @@ class VideoArea(QWidget):
         self._player.errorOccurred.connect(self._on_error_occurred)
         # --- End Media Player Setup ---
 
-        self._overlay_margin = 48
-        self._player_bar = PlayerBar(self)
+        self._player_bar = player_bar_class(self)
         self._player_bar.hide()
         self._player_bar.setMouseTracking(True)
-
-        self._controls_visible = False
-        self._target_opacity = 0.0
-        self._host_widget: QWidget | None = self._renderer
-        self._window_host: QWidget | None = None
-        self._controls_enabled = True
 
         effect = QGraphicsOpacityEffect(self._player_bar)
         effect.setOpacity(0.0)
@@ -241,10 +315,7 @@ class VideoArea(QWidget):
 
         self._install_activity_filters()
         self._wire_player_bar()
-        self._wire_edit_viewer()
-        self._renderer.nativeSizeChanged.connect(self.displaySizeChanged.emit)
-        self._renderer.videoFramePresented.connect(self._on_gpu_video_frame_presented)
-        self._edit_viewer.videoFramePresented.connect(self._on_gpu_video_frame_presented)
+        self._runtime_ready = True
 
     # ------------------------------------------------------------------
     # Public API
@@ -259,6 +330,8 @@ class VideoArea(QWidget):
     def player_bar(self) -> PlayerBar:
         """Return the floating :class:`PlayerBar`."""
 
+        if self._player_bar is None:
+            raise RuntimeError("VideoArea playback runtime has not been completed")
         return self._player_bar
 
     @property
@@ -593,7 +666,7 @@ class VideoArea(QWidget):
     def show_controls(self, *, animate: bool = True) -> None:
         """Reveal the playback controls and restart the hide timer."""
 
-        if not self._controls_enabled:
+        if not self._runtime_ready or not self._controls_enabled:
             return
         self._hide_timer.stop()
         if not self._controls_visible:
@@ -611,6 +684,8 @@ class VideoArea(QWidget):
     def hide_controls(self, *, animate: bool = True) -> None:
         """Fade the playback controls out."""
 
+        if not self._runtime_ready:
+            return
         if not self._controls_visible and self._current_opacity() <= 0.0:
             return
         self._hide_timer.stop()
@@ -624,7 +699,7 @@ class VideoArea(QWidget):
     def note_activity(self) -> None:
         """Treat external events as user activity to keep controls visible."""
 
-        if not self._controls_enabled:
+        if not self._runtime_ready or not self._controls_enabled:
             return
         if self._controls_visible:
             self._restart_hide_timer()
@@ -1323,7 +1398,7 @@ class VideoArea(QWidget):
 
     def leaveEvent(self, event) -> None:  # pragma: no cover - GUI behaviour
         super().leaveEvent(event)
-        if not self._player_bar.underMouse():
+        if self._player_bar is not None and not self._player_bar.underMouse():
             self.hide_controls()
 
     def mouseMoveEvent(self, event) -> None:  # pragma: no cover - GUI behaviour
@@ -1357,7 +1432,7 @@ class VideoArea(QWidget):
         elsewhere in the window.  Space, M, and other transport shortcuts are
         handled globally by ``AppShortcutManager``.
         """
-        if self._edit_mode_active:
+        if not self._runtime_ready or self._edit_mode_active:
             super().keyPressEvent(event)
             return
 
@@ -1382,6 +1457,8 @@ class VideoArea(QWidget):
         self.hide_controls(animate=False)
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:  # pragma: no cover - GUI behaviour
+        if not self._runtime_ready:
+            return super().eventFilter(watched, event)
         if event.type() in {
             QEvent.Type.MouseMove,
             QEvent.Type.HoverMove,
@@ -1442,7 +1519,7 @@ class VideoArea(QWidget):
             self.zoomChanged.emit(factor)
 
     def _on_mouse_activity(self) -> None:
-        if not self._controls_enabled:
+        if not self._runtime_ready or not self._controls_enabled:
             return
         self.mouseActive.emit()
         if self._controls_visible:
@@ -1492,7 +1569,7 @@ class VideoArea(QWidget):
             self._player_bar.hide()
 
     def _update_bar_geometry(self) -> None:
-        if not self.isVisible():
+        if self._player_bar is None or not self.isVisible():
             return
         rect = self.rect()
         available_width = max(0, rect.width() - (2 * self._overlay_margin))

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -36,21 +36,12 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-# QtMultimedia is deliberately imported by ``complete_runtime()``.  The staged
-# startup path must be able to establish the final QRhiWidget hierarchy without
-# also starting the platform media backend before the main window is shown.
-QMediaPlayer = None
-QAudioOutput = None
-QVideoFrame = None  # type: ignore[assignment, misc]
-QVideoSink = None  # type: ignore[assignment, misc]
-
 from ....config import (
     PLAYER_CONTROLS_HIDE_DELAY_MS,
     PLAYER_FADE_IN_MS,
     PLAYER_FADE_OUT_MS,
     VIDEO_COMPLETE_HOLD_BACKSTEP_MS,
 )
-from ....core.adjustment_mapping import normalise_video_trim, video_requires_adjusted_preview
 from ....gui.detail_pipeline import (
     AssetSourceIdentity,
     DetailRenderTransaction,
@@ -61,7 +52,16 @@ from ..palette import viewer_surface_color
 from .gl_image_viewer import GLImageViewer
 from .video_renderer_widget import VideoRendererWidget, _resolve_frame_rotation_cw
 
+# QtMultimedia is deliberately imported by ``complete_runtime()``.  The staged
+# startup path must be able to establish the final QRhiWidget hierarchy without
+# also starting the platform media backend before the main window is shown.
+QMediaPlayer = None
+QAudioOutput = None
+QVideoFrame = None  # type: ignore[assignment, misc]
+QVideoSink = None  # type: ignore[assignment, misc]
 PlayerBar = None
+normalise_video_trim = None
+video_requires_adjusted_preview = None
 
 _log = logging.getLogger(__name__)
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
@@ -79,8 +79,14 @@ def _load_qt_multimedia_runtime() -> None:
         try:
             from PySide6.QtMultimedia import (
                 QAudioOutput as _QAudioOutput,
+            )
+            from PySide6.QtMultimedia import (
                 QMediaPlayer as _QMediaPlayer,
+            )
+            from PySide6.QtMultimedia import (
                 QVideoFrame as _QVideoFrame,
+            )
+            from PySide6.QtMultimedia import (
                 QVideoSink as _QVideoSink,
             )
         except (ModuleNotFoundError, ImportError):
@@ -102,6 +108,21 @@ def _load_player_bar_class():
 
         PlayerBar = _PlayerBar
     return PlayerBar
+
+
+def _load_video_adjustment_helpers() -> None:
+    global normalise_video_trim, video_requires_adjusted_preview
+    if normalise_video_trim is not None and video_requires_adjusted_preview is not None:
+        return
+    from ....core.adjustment_mapping import (
+        normalise_video_trim as _normalise_video_trim,
+    )
+    from ....core.adjustment_mapping import (
+        video_requires_adjusted_preview as _video_requires_adjusted_preview,
+    )
+
+    normalise_video_trim = _normalise_video_trim
+    video_requires_adjusted_preview = _video_requires_adjusted_preview
 
 
 def probe_video_rotation(*args, **kwargs):
@@ -182,7 +203,7 @@ class VideoArea(QWidget):
         # Accept focus so keyboard navigation targets the video surface
         # without requiring the user to click a non-interactive element.
         self._renderer.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-        self._edit_viewer = GLImageViewer(self._surface_stack)
+        self._edit_viewer = GLImageViewer(self._surface_stack, staged=staged)
         self._edit_viewer.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         # In detail playback, crop framing is disabled but the crop region fills
         # the canvas (strength=1.0) so that crop-edited videos look the same as
@@ -275,6 +296,11 @@ class VideoArea(QWidget):
         if self._runtime_ready:
             return
 
+        complete_edit_viewer = getattr(self._edit_viewer, "complete_runtime", None)
+        if callable(complete_edit_viewer):
+            complete_edit_viewer()
+
+        _load_video_adjustment_helpers()
         _load_qt_multimedia_runtime()
         player_bar_class = _load_player_bar_class()
         if QMediaPlayer is None or QAudioOutput is None or QVideoSink is None:

--- a/src/iPhoto/gui/ui/widgets/video_renderer_widget.py
+++ b/src/iPhoto/gui/ui/widgets/video_renderer_widget.py
@@ -48,16 +48,29 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QRhiWidget, QWidget
 
-try:
-    from PySide6.QtMultimedia import QVideoFrame, QVideoFrameFormat, QVideoSink
-except (ModuleNotFoundError, ImportError):  # pragma: no cover
-    QVideoFrame = None  # type: ignore[assignment, misc]
-    QVideoFrameFormat = None  # type: ignore[assignment, misc]
-    QVideoSink = None  # type: ignore[assignment, misc]
+QVideoFrame = None  # type: ignore[assignment, misc]
+QVideoFrameFormat = None  # type: ignore[assignment, misc]
 
 from .render_backend import qrhi_api_name, select_qrhi_widget_api
 
 _log = logging.getLogger(__name__)
+
+
+def _load_video_frame_types() -> None:
+    """Load QtMultimedia frame types only when playback begins."""
+
+    global QVideoFrame, QVideoFrameFormat
+    if QVideoFrame is not None and QVideoFrameFormat is not None:
+        return
+    try:
+        from PySide6.QtMultimedia import (
+            QVideoFrame as _QVideoFrame,
+            QVideoFrameFormat as _QVideoFrameFormat,
+        )
+    except (ModuleNotFoundError, ImportError):  # pragma: no cover
+        return
+    QVideoFrame = _QVideoFrame
+    QVideoFrameFormat = _QVideoFrameFormat
 
 # Shader .qsb files live next to this module.
 _SHADER_DIR = Path(__file__).resolve().parent
@@ -214,6 +227,7 @@ def _resolve_frame_rotation_cw(
 def _classify_frame_format(fmt: "QVideoFrameFormat") -> tuple[int, int, int, int]:
     """Return (format, colorspace, transfer, range) shader enum values for *fmt*."""
 
+    _load_video_frame_types()
     if QVideoFrameFormat is None:
         return _FMT_RGBA, _CS_BT709, _TF_SDR, _RANGE_LIMITED
 
@@ -426,6 +440,7 @@ class VideoRendererWidget(QRhiWidget):
 
     def update_frame(self, frame: "QVideoFrame") -> None:
         """Accept a new video frame and schedule a repaint."""
+        _load_video_frame_types()
         if frame is None or not frame.isValid():
             return
         self._current_frame = frame
@@ -808,6 +823,7 @@ class VideoRendererWidget(QRhiWidget):
         Returns ``True`` if the upload succeeded.  A return of ``False``
         means the frame should be retried on the next render cycle.
         """
+        _load_video_frame_types()
         frame = self._current_frame
         if frame is None:
             return False

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -6,12 +6,13 @@ from types import SimpleNamespace
 
 import pytest
 from PySide6.QtCore import QCoreApplication, QEvent, Qt
-from PySide6.QtGui import QCloseEvent
+from PySide6.QtGui import QCloseEvent, QSurface
 
 from iPhoto.gui.main import (
     _bootstrap_macos_external_tool_path,
     _configure_qt_opengl_defaults,
     _prepare_qt_runtime_for_maps,
+    _prepare_top_level_rhi_surface,
     _startup_feature_plan,
     _startup_timing_plan,
     _StartupInputGuard,
@@ -275,12 +276,12 @@ def test_prepare_qt_runtime_for_maps_allows_packaged_linux_wayland_opt_out(monke
 @pytest.mark.parametrize(
     ("platform", "expected"),
     (
-        ("win32", (("detail",), ())),
+        ("win32", ((), ("detail",))),
         ("darwin", ((), ("detail",))),
-        ("linux", (("detail",), ())),
+        ("linux", ((), ("detail",))),
     ),
 )
-def test_startup_feature_plan_keeps_opengl_rhi_detail_before_show(
+def test_startup_feature_plan_completes_detail_after_show_on_every_platform(
     platform: str,
     expected: tuple[tuple[str, ...], tuple[str, ...]],
 ) -> None:
@@ -300,6 +301,58 @@ def test_startup_timing_plan_has_no_fixed_platform_delay(
     expected: tuple[int, int, int],
 ) -> None:
     assert tuple(_startup_timing_plan(platform)) == expected
+
+
+@pytest.mark.parametrize(
+    ("backend", "surface_type"),
+    (
+        ("metal", QSurface.SurfaceType.MetalSurface),
+        ("opengl", QSurface.SurfaceType.OpenGLSurface),
+    ),
+)
+def test_prepare_top_level_rhi_surface_only_verifies_precreated_handle(
+    backend: str,
+    surface_type: QSurface.SurfaceType,
+) -> None:
+    class _FakeHandle:
+        def surfaceType(self):  # noqa: N802 - Qt API
+            return surface_type
+
+    class _FakeWindow:
+        def windowHandle(self):  # noqa: N802 - Qt API
+            return _FakeHandle()
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API
+            return False
+
+    assert _prepare_top_level_rhi_surface(_FakeWindow(), backend) == surface_type.name
+
+
+def test_prepare_top_level_rhi_surface_rejects_late_raster_handle() -> None:
+    class _RasterHandle:
+        def surfaceType(self):  # noqa: N802 - Qt API
+            return QSurface.SurfaceType.RasterSurface
+
+    class _FakeWindow:
+        def windowHandle(self):  # noqa: N802 - Qt API
+            return _RasterHandle()
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API
+            return False
+
+    with pytest.raises(RuntimeError, match="RasterSurface; expected one of MetalSurface"):
+        _prepare_top_level_rhi_surface(_FakeWindow(), "metal")
+
+
+def test_prepare_top_level_rhi_surface_allows_platform_deferred_handle() -> None:
+    class _FakeWindow:
+        def windowHandle(self):  # noqa: N802 - Qt API
+            return None
+
+    assert (
+        _prepare_top_level_rhi_surface(_FakeWindow(), "opengl")
+        == "deferred:OpenGLSurface"
+    )
 
 
 def test_startup_input_guard_filters_only_window_startup_input() -> None:
@@ -472,6 +525,16 @@ def test_main_creates_required_features_in_platform_safe_order(
 
     startup_ready_signal = _FakeSignal()
 
+    class _FakeSurface:
+        def render_backend_name(self) -> str:
+            return "test"
+
+    class _FakeDetailPage:
+        def native_surfaces(self):
+            return (_FakeSurface(), _FakeSurface(), _FakeSurface())
+
+    detail_page = _FakeDetailPage()
+
     class _FakeUi:
         sidebar = type(
             "FakeSidebar",
@@ -484,8 +547,13 @@ def test_main_creates_required_features_in_platform_safe_order(
             },
         )()
 
-        def ensure_feature(self, feature: str) -> None:
+        def prepare_detail_native_hierarchy(self):
+            call_order.append("prepare:detail")
+            return detail_page
+
+        def ensure_feature(self, feature: str):
             call_order.append(f"feature:{feature}")
+            return detail_page
 
     class _FakeWindow:
         def __init__(self, _context) -> None:
@@ -646,25 +714,18 @@ def test_main_creates_required_features_in_platform_safe_order(
     assert main([]) == 0
 
     detail_index = call_order.index("feature:detail")
+    prepare_index = call_order.index("prepare:detail")
     show_index = call_order.index("show")
     coordinator_index = call_order.index("coordinator:create")
 
-    if platform in {"win32", "linux"}:
-        assert detail_index < show_index
-        assert "rhi_detail.before_create" in profile_marks
-        assert "rhi_detail.created" in profile_marks
-    else:
-        assert show_index < detail_index
-        assert "rhi_detail.before_create" not in profile_marks
-        assert "rhi_detail.created" not in profile_marks
+    assert prepare_index < show_index < detail_index < coordinator_index
+    assert "detail.native_hierarchy.before_prepare" in profile_marks
+    assert "detail.native_hierarchy.prepared" in profile_marks
+    assert "detail.feature.completed" in profile_marks
     assert "windows_detail.before_create" not in profile_marks
     assert "windows_detail.created" not in profile_marks
     assert "feature:preview" not in call_order
     assert "feature:people" not in call_order
-    if platform == "darwin":
-        assert show_index < detail_index < coordinator_index
-    else:
-        assert detail_index < show_index < coordinator_index
     # The shell becomes interactive immediately after the first-paint/watchdog
     # boundary; library probing and hidden feature creation must not retain the
     # global input filter.
@@ -736,7 +797,7 @@ def test_main_defers_pending_map_extension_until_map_feature(monkeypatch) -> Non
     )
     monkeypatch.setattr(
         "iPhoto.gui.main._startup_feature_plan",
-        lambda: (("detail",), ()),
+        lambda: ((), ()),
     )
     monkeypatch.setattr("iPhoto.gui.main.QApplication", _FakeApp)
     monkeypatch.setattr("iPhoto.gui.main.QPalette", _FakePalette)
@@ -770,6 +831,14 @@ def test_main_defers_pending_map_extension_until_map_feature(monkeypatch) -> Non
                 def ensure_feature(self, feature: str) -> None:
                     call_order.append(("ensure_feature", feature))
 
+                def prepare_detail_native_hierarchy(self):
+                    call_order.append(("prepare_detail_native_hierarchy", None))
+                    return type(
+                        "FakeDetailPage",
+                        (),
+                        {"native_surfaces": lambda self: ()},
+                    )()
+
             self.ui = _FakeUi()
             self.firstPainted = type("FakeSignal", (), {"connect": lambda *a, **k: None})()
 
@@ -798,5 +867,5 @@ def test_main_defers_pending_map_extension_until_map_feature(monkeypatch) -> Non
 
     assert call_order[0][0] == "prefer"
     assert not any(name == "apply_pending" for name, _value in call_order)
-    assert ("ensure_feature", "detail") in call_order
+    assert ("prepare_detail_native_hierarchy", None) in call_order
     assert call_order[1][0] == "prepare_maps"

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -547,6 +547,9 @@ def test_main_creates_required_features_in_platform_safe_order(
             },
         )()
 
+        def __init__(self) -> None:
+            self._prepared_detail_page = self.prepare_detail_native_hierarchy()
+
         def prepare_detail_native_hierarchy(self):
             call_order.append("prepare:detail")
             return detail_page
@@ -719,7 +722,7 @@ def test_main_creates_required_features_in_platform_safe_order(
     coordinator_index = call_order.index("coordinator:create")
 
     assert prepare_index < show_index < detail_index < coordinator_index
-    assert "detail.native_hierarchy.before_prepare" in profile_marks
+    assert "detail.native_hierarchy.before_verify" in profile_marks
     assert "detail.native_hierarchy.prepared" in profile_marks
     assert "detail.feature.completed" in profile_marks
     assert "windows_detail.before_create" not in profile_marks
@@ -827,6 +830,9 @@ def test_main_defers_pending_map_extension_until_map_feature(monkeypatch) -> Non
                     (),
                     {"select_all_photos": lambda *args, **kwargs: None},
                 )()
+
+                def __init__(self) -> None:
+                    self._prepared_detail_page = self.prepare_detail_native_hierarchy()
 
                 def ensure_feature(self, feature: str) -> None:
                     call_order.append(("ensure_feature", feature))

--- a/tests/gui/test_startup_import_boundary.py
+++ b/tests/gui/test_startup_import_boundary.py
@@ -66,3 +66,39 @@ if loaded:
         check=False,
     )
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_detail_surface_modules_do_not_start_qt_multimedia() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(project_root / "src")
+    script = """
+import sys
+import iPhoto.gui.ui.widgets.detail_page
+blocked = ('PySide6.QtMultimedia',)
+loaded = [name for name in blocked if name in sys.modules]
+if loaded:
+    raise SystemExit(','.join(loaded))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_detail_hierarchy_precedes_native_menu_bar_creation() -> None:
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src/iPhoto/gui/ui/ui_main_window.py"
+    ).read_text(encoding="utf-8")
+
+    prepare_call = source.index("self.prepare_detail_native_hierarchy()")
+    menu_bar_creation = source.index(
+        "self.main_header = MainHeaderWidget(self.window_shell, MainWindow)"
+    )
+    assert prepare_call < menu_bar_creation

--- a/tests/gui/test_startup_import_boundary.py
+++ b/tests/gui/test_startup_import_boundary.py
@@ -68,20 +68,23 @@ if loaded:
     assert result.returncode == 0, result.stderr or result.stdout
 
 
-def test_detail_surface_modules_keep_post_paint_dependencies_unloaded() -> None:
+def test_detail_runtime_stays_deferred_through_first_shell_paint() -> None:
     project_root = Path(__file__).resolve().parents[2]
     env = dict(os.environ)
     env["PYTHONPATH"] = str(project_root / "src")
     env["QT_QPA_PLATFORM"] = "offscreen"
     script = """
 import sys
-from PySide6.QtWidgets import QApplication, QMainWindow, QStackedWidget
+from PySide6.QtWidgets import QApplication, QMainWindow, QStackedWidget, QWidget
 from iPhoto.gui.ui.widgets.detail_page import DetailPageWidget
 
 app = QApplication.instance() or QApplication([])
 window = QMainWindow()
 stack = QStackedWidget(window)
 window.setCentralWidget(stack)
+gallery = QWidget(stack)
+stack.addWidget(gallery)
+stack.setCurrentWidget(gallery)
 detail = DetailPageWidget(window, parent=stack, staged=True)
 stack.addWidget(detail)
 blocked = (
@@ -91,7 +94,27 @@ blocked = (
 )
 loaded = [name for name in blocked if name in sys.modules]
 if loaded:
-    raise SystemExit(','.join(loaded))
+    raise SystemExit('construct:' + ','.join(loaded))
+if detail.image_viewer._runtime_ready:
+    raise SystemExit('construct:image-runtime-ready')
+
+window.show()
+app.processEvents()
+
+loaded = [name for name in blocked if name in sys.modules]
+if loaded:
+    raise SystemExit('first-paint:' + ','.join(loaded))
+if detail.image_viewer._runtime_ready:
+    raise SystemExit('first-paint:image-runtime-ready')
+
+detail.complete_feature()
+app.processEvents()
+
+missing = [name for name in blocked if name not in sys.modules]
+if missing:
+    raise SystemExit('complete:missing:' + ','.join(missing))
+if not detail.image_viewer._runtime_ready:
+    raise SystemExit('complete:image-runtime-not-ready')
 """
     result = subprocess.run(
         [sys.executable, "-c", script],

--- a/tests/gui/test_startup_import_boundary.py
+++ b/tests/gui/test_startup_import_boundary.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_gui_entry_import_keeps_heavy_features_unloaded() -> None:
@@ -68,14 +68,27 @@ if loaded:
     assert result.returncode == 0, result.stderr or result.stdout
 
 
-def test_detail_surface_modules_do_not_start_qt_multimedia() -> None:
+def test_detail_surface_modules_keep_post_paint_dependencies_unloaded() -> None:
     project_root = Path(__file__).resolve().parents[2]
     env = dict(os.environ)
     env["PYTHONPATH"] = str(project_root / "src")
+    env["QT_QPA_PLATFORM"] = "offscreen"
     script = """
 import sys
-import iPhoto.gui.ui.widgets.detail_page
-blocked = ('PySide6.QtMultimedia',)
+from PySide6.QtWidgets import QApplication, QMainWindow, QStackedWidget
+from iPhoto.gui.ui.widgets.detail_page import DetailPageWidget
+
+app = QApplication.instance() or QApplication([])
+window = QMainWindow()
+stack = QStackedWidget(window)
+window.setCentralWidget(stack)
+detail = DetailPageWidget(window, parent=stack, staged=True)
+stack.addWidget(detail)
+blocked = (
+    'numpy',
+    'iPhoto.people.repository',
+    'PySide6.QtMultimedia',
+)
 loaded = [name for name in blocked if name in sys.modules]
 if loaded:
     raise SystemExit(','.join(loaded))
@@ -102,3 +115,15 @@ def test_detail_hierarchy_precedes_native_menu_bar_creation() -> None:
         "self.main_header = MainHeaderWidget(self.window_shell, MainWindow)"
     )
     assert prepare_call < menu_bar_creation
+
+
+def test_native_hierarchy_uses_single_terminal_shell_failure_model() -> None:
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src/iPhoto/gui/main.py"
+    ).read_text(encoding="utf-8")
+
+    assert "feature_detail_native_hierarchy_pre_show_failed" not in source
+    assert "_prepare_pre_show_native_hierarchy" not in source
+    assert 'code="shell_initialization_failed"' in source
+    assert 'getattr(window.ui, "_prepared_detail_page", None)' in source

--- a/tests/test_ui_main_window_map_stack.py
+++ b/tests/test_ui_main_window_map_stack.py
@@ -7,9 +7,15 @@ import pytest
 pytest.importorskip("PySide6", reason="PySide6 is required for UI stack tests", exc_type=ImportError)
 pytest.importorskip("PySide6.QtWidgets", reason="Qt widgets are required for UI stack tests", exc_type=ImportError)
 
-from PySide6.QtWidgets import QApplication, QWidget, QStackedLayout, QStackedWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QWidget,
+    QStackedLayout,
+    QStackedWidget,
+)
 
-from iPhoto.gui.ui.ui_main_window import _configure_main_view_stack
+from iPhoto.gui.ui.ui_main_window import Ui_MainWindow, _configure_main_view_stack
 
 
 @pytest.fixture
@@ -65,3 +71,51 @@ def test_configure_main_view_stack_leaves_python_backends_unchanged(qapp: QAppli
 
     assert isinstance(stack.layout(), QStackedLayout)
     assert stack.layout().stackingMode() == QStackedLayout.StackOne
+
+
+def test_detail_prepare_and_feature_publication_are_idempotent(
+    qapp: QApplication,
+    monkeypatch,
+) -> None:
+    del qapp
+
+    class _FakeDetailPage(QWidget):
+        def __init__(self, _main_window, parent=None, *, staged=False) -> None:
+            super().__init__(parent)
+            self.staged = staged
+            self.complete_calls = 0
+
+        def complete_feature(self) -> None:
+            self.complete_calls += 1
+
+    monkeypatch.setattr(
+        "iPhoto.gui.ui.widgets.detail_page.DetailPageWidget",
+        _FakeDetailPage,
+    )
+    main_window = QMainWindow()
+    stack = QStackedWidget(main_window)
+    gallery = QWidget(stack)
+    stack.addWidget(gallery)
+    stack.setCurrentWidget(gallery)
+    main_window.setCentralWidget(stack)
+    ui = Ui_MainWindow()
+    ui._main_window = main_window
+    ui.view_stack = stack
+    published = []
+    ui.featureCreated.connect(lambda feature, page: published.append((feature, page)))
+
+    prepared = ui.prepare_detail_native_hierarchy()
+    assert ui.prepare_detail_native_hierarchy() is prepared
+    assert prepared.staged is True
+    assert stack.currentWidget() is gallery
+
+    def _complete_detail():
+        prepared.complete_feature()
+        return prepared
+
+    monkeypatch.setattr(ui, "_create_detail_feature", _complete_detail)
+    completed = ui.ensure_feature("detail")
+    assert ui.ensure_feature("detail") is completed
+    assert completed is prepared
+    assert prepared.complete_calls == 1
+    assert published == [("detail", completed)]

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from PySide6.QtCore import QPointF, QRectF, QSize, QSizeF, Qt
 from PySide6.QtGui import QColor, QImage, QKeyEvent, QRhiCommandBuffer, QShowEvent
 from PySide6.QtMultimedia import QMediaPlayer, QVideoFrame, QVideoFrameFormat
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QMainWindow, QStackedWidget, QWidget
 
 from iPhoto.config import VIDEO_COMPLETE_HOLD_BACKSTEP_MS
 import iPhoto.gui.ui.widgets.video_area as video_area_module
@@ -637,6 +637,51 @@ class TestVideoArea:
         va = VideoArea()
         assert va._renderer.parent() is va._surface_stack
         assert va._surface_stack.parent() is va
+
+    def test_staged_runtime_preserves_surface_hierarchy(self, qapp):
+        """Completing playback must not move either prepared QRhi widget."""
+
+        main_window = QMainWindow()
+        host = QWidget(main_window)
+        main_window.setCentralWidget(host)
+        va = VideoArea(host, staged=True)
+        va._test_main_window = main_window
+        surfaces = (va.renderer, va.edit_viewer)
+        parents_before = tuple(surface.parent() for surface in surfaces)
+        windows_before = tuple(surface.window() for surface in surfaces)
+
+        assert va._runtime_ready is False
+        va.complete_runtime()
+        player = va._player
+        va.complete_runtime()
+
+        assert va._runtime_ready is True
+        assert va._player is player
+        assert tuple(surface.parent() for surface in surfaces) == parents_before
+        assert tuple(surface.window() for surface in surfaces) == windows_before
+        assert all(surface.window() is main_window for surface in surfaces)
+
+    def test_staged_detail_preserves_all_three_surface_parents(self, qapp):
+        """Detail completion adds chrome without reparenting native surfaces."""
+
+        from iPhoto.gui.ui.widgets.detail_page import DetailPageWidget
+
+        main_window = QMainWindow()
+        stack = QStackedWidget(main_window)
+        main_window.setCentralWidget(stack)
+        detail = DetailPageWidget(main_window, parent=stack, staged=True)
+        stack.addWidget(detail)
+        surfaces = detail.native_surfaces()
+        parents_before = tuple(surface.parent() for surface in surfaces)
+        windows_before = tuple(surface.window() for surface in surfaces)
+
+        assert all(not surface.isWindow() for surface in surfaces)
+        assert all(surface.window() is main_window for surface in surfaces)
+        detail.complete_feature()
+        detail.complete_feature()
+
+        assert tuple(surface.parent() for surface in surfaces) == parents_before
+        assert tuple(surface.window() for surface in surfaces) == windows_before
 
     def test_has_video_sink(self, qapp):
         """VideoArea should use QVideoSink, not QGraphicsVideoItem."""


### PR DESCRIPTION
## Summary

- establish the final Detail QRhi widget hierarchy before any native top-level window is created
- construct the staged Detail surface shell before `QMenuBar`, preventing macOS from committing the main window as `RasterSurface`
- defer Detail chrome, QtMultimedia, playback controls, and coordinator wiring until after first paint without reparenting QRhi widgets
- enforce the same lifecycle on macOS, Windows, and Linux, with Metal/OpenGL surface validation and startup diagnostics
- document the cross-platform startup contract and add hierarchy/import/idempotency regression coverage

## Validation

- `python -m pytest tests/gui -q` — 686 passed, 1 skipped (Windows WIC only)
- focused Detail/VideoArea/RHI suite — 192 passed
- `python tools/check_architecture.py` — passed
- macOS Metal startup smoke: no `QMetalSwapChain`, swapchain creation, or `QRhiWidget: No QRhi` errors
- Gallery → Detail diagnostic produced image, Live Motion, and video `presented` events
