### PR TITLE
Fix Filmstrip multi-surface thumbnail demand

### DIFF
--- a/demo/shadowbar.py
+++ b/demo/shadowbar.py
@@ -1,0 +1,590 @@
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+from PySide6.QtCore import QRectF, QSize, Qt
+from PySide6.QtGui import (
+    QColor,
+    QFont,
+    QImage,
+    QLinearGradient,
+    QPainter,
+    QPainterPath,
+    QPen,
+)
+from PySide6.QtOpenGLWidgets import QOpenGLWidget
+from PySide6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QSizePolicy,
+    QSlider,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+# ============================================================
+# 只改这一行：替换成你要测试的真实照片地址
+# ============================================================
+PHOTO_PATH = r""   # 例如：r"D:\Photos\IMG_4902.jpg"
+
+
+# ============================================================
+# 来自 iPhotron 当前 DetailPage / Filmstrip 的关键几何参数
+# ============================================================
+HEADER_BUTTON_SIZE = QSize(36, 38)
+HEADER_ICON_GLYPH_SIZE = QSize(24, 24)
+HEADER_MARGIN_X = 12
+HEADER_SPACING = 8
+ZOOM_SLIDER_WIDTH = 90
+
+FILMSTRIP_BASE_HEIGHT = 120
+FILMSTRIP_HEIGHT = FILMSTRIP_BASE_HEIGHT + 12   # iPhotron 当前是 132 px
+PLAYER_FILMSTRIP_GAP = 6
+
+# 新阴影：完全 overlay，不占 layout 高度
+SHADOW_HEIGHT = 28
+
+
+class ShadowOverlay(QWidget):
+    """
+    顶部 toolbar 下方的 macOS Photos 风格阴影。
+
+    关键点：
+    - 它和 header / OpenGL viewport 是 sibling。
+    - geometry 放在 viewport 的最顶端。
+    - 它不占任何 layout 高度。
+    - 鼠标事件直接穿透给 OpenGL viewport。
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
+    def paintEvent(self, event) -> None:  # noqa: N802
+        p = QPainter(self)
+
+        # 顶部 1 px 分隔线：比现在 detailHeaderSeparator 更克制
+        p.fillRect(0, 0, self.width(), 1, QColor(0, 0, 0, 30))
+
+        # 阴影仅向下衰减，不向 toolbar 上方扩散
+        g = QLinearGradient(0, 1, 0, self.height())
+        g.setColorAt(0.00, QColor(0, 0, 0, 46))
+        g.setColorAt(0.08, QColor(0, 0, 0, 35))
+        g.setColorAt(0.22, QColor(0, 0, 0, 22))
+        g.setColorAt(0.42, QColor(0, 0, 0, 11))
+        g.setColorAt(0.68, QColor(0, 0, 0, 4))
+        g.setColorAt(1.00, QColor(0, 0, 0, 0))
+        p.fillRect(self.rect().adjusted(0, 1, 0, 0), g)
+
+
+class PhotoGLViewport(QOpenGLWidget):
+    """
+    单文件 demo 用的 OpenGL viewport。
+
+    iPhotron 当前 GLImageViewer 已经迁移到 QRhiWidget，但这个 demo 使用
+    QOpenGLWidget 只是为了把“shadow sibling 覆盖 GPU viewport”这件事
+    独立跑出来。sibling overlay 的几何关系与接入真实 GLImageViewer 相同。
+    """
+
+    def __init__(self, photo_path: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent, True)
+        self.setAutoFillBackground(False)
+
+        self._image = QImage(photo_path) if photo_path else QImage()
+        self._zoom = 1.0
+
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Expanding,
+        )
+
+    def set_zoom_percent(self, value: int) -> None:
+        self._zoom = max(0.1, min(4.0, value / 100.0))
+        self.update()
+
+    def initializeGL(self) -> None:  # noqa: N802
+        pass
+
+    def resizeGL(self, w: int, h: int) -> None:  # noqa: N802
+        pass
+
+    def paintGL(self) -> None:  # noqa: N802
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, True)
+
+        # 与 iPhotron viewer_surface_color 的思想一致：
+        # viewer 背景取 palette(window)，而不是写死纯黑。
+        surface = self.palette().color(self.backgroundRole())
+        if not surface.isValid():
+            surface = self.palette().window().color()
+        p.fillRect(self.rect(), surface)
+
+        if self._image.isNull():
+            self._paint_fallback(p)
+            return
+
+        iw = self._image.width()
+        ih = self._image.height()
+        if iw <= 0 or ih <= 0:
+            return
+
+        vw = max(1, self.width())
+        vh = max(1, self.height())
+
+        fit = min(vw / iw, vh / ih)
+        scale = fit * self._zoom
+
+        dw = iw * scale
+        dh = ih * scale
+        x = (vw - dw) / 2.0
+        y = (vh - dh) / 2.0
+
+        p.drawImage(
+            QRectF(x, y, dw, dh),
+            self._image,
+            QRectF(0, 0, iw, ih),
+        )
+
+    def _paint_fallback(self, p: QPainter) -> None:
+        """PHOTO_PATH 为空时仍能直接启动，便于先看 shadow 几何。"""
+        w = self.width()
+        h = self.height()
+
+        g = QLinearGradient(0, 0, w, h)
+        g.setColorAt(0.0, QColor("#d5d8dc"))
+        g.setColorAt(0.48, QColor("#8b939b"))
+        g.setColorAt(1.0, QColor("#353a40"))
+        p.fillRect(self.rect(), g)
+
+        p.setPen(QColor(255, 255, 255, 215))
+        f = p.font()
+        f.setPointSize(16)
+        f.setWeight(QFont.Weight.Medium)
+        p.setFont(f)
+        p.drawText(
+            self.rect(),
+            Qt.AlignmentFlag.AlignCenter,
+            "把文件顶部 PHOTO_PATH 换成真实照片地址",
+        )
+
+
+class FlatIconButton(QToolButton):
+    """单文件替代项目 SVG 资源，保持 iPhotron 36x38 的真实 hit target。"""
+
+    def __init__(
+        self,
+        glyph: str,
+        *,
+        blue: bool = False,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setText(glyph)
+        self.setFixedSize(HEADER_BUTTON_SIZE)
+        self.setAutoRaise(True)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        f = self.font()
+        f.setPointSize(16)
+        self.setFont(f)
+
+        fg = "#1677ff" if blue else "#202124"
+        self.setStyleSheet(
+            f"""
+            QToolButton {{
+                border: none;
+                background: transparent;
+                color: {fg};
+                border-radius: 8px;
+                padding: 0px;
+            }}
+            QToolButton:hover {{
+                background: rgba(0, 0, 0, 18);
+            }}
+            QToolButton:pressed {{
+                background: rgba(0, 0, 0, 28);
+            }}
+            """
+        )
+
+
+class PlaybackHeader(QWidget):
+    """
+    按当前 iPhotron DetailPageWidget._build_header() 的布局复刻：
+    - margins = (12, 0, 12, 0)
+    - spacing = 8
+    - HEADER_BUTTON_SIZE = 36 x 38
+    - zoom slider = 90
+    - 中央 location / timestamp
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAutoFillBackground(True)
+
+        row = QHBoxLayout(self)
+        row.setContentsMargins(HEADER_MARGIN_X, 0, HEADER_MARGIN_X, 0)
+        row.setSpacing(HEADER_SPACING)
+
+        self.back_button = FlatIconButton("‹", parent=self)
+        row.addWidget(self.back_button)
+
+        # ----------------------- zoom widget -----------------------
+        self.zoom_widget = QWidget(self)
+        zoom = QHBoxLayout(self.zoom_widget)
+        zoom.setContentsMargins(0, 0, 0, 0)
+        zoom.setSpacing(4)
+
+        small = QSize(
+            HEADER_BUTTON_SIZE.width() // 2,
+            HEADER_BUTTON_SIZE.height() // 2,
+        )
+
+        self.zoom_out_button = FlatIconButton("−", parent=self.zoom_widget)
+        self.zoom_out_button.setFixedSize(small)
+        self.zoom_out_button.setStyleSheet(
+            """
+            QToolButton {
+                border: none;
+                background: transparent;
+                color: #303030;
+                padding: 0px;
+                font-size: 15px;
+            }
+            QToolButton:hover { background: rgba(0,0,0,14); border-radius: 5px; }
+            """
+        )
+        zoom.addWidget(self.zoom_out_button)
+
+        self.zoom_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.zoom_widget,
+        )
+        self.zoom_slider.setRange(10, 400)
+        self.zoom_slider.setSingleStep(5)
+        self.zoom_slider.setPageStep(25)
+        self.zoom_slider.setValue(100)
+        self.zoom_slider.setFixedWidth(ZOOM_SLIDER_WIDTH)
+        self.zoom_slider.setStyleSheet(
+            """
+            QSlider::groove:horizontal {
+                height: 3px;
+                border-radius: 1px;
+                background: rgba(0, 0, 0, 28);
+            }
+            QSlider::sub-page:horizontal {
+                height: 3px;
+                border-radius: 1px;
+                background: rgba(0, 0, 0, 45);
+            }
+            QSlider::handle:horizontal {
+                width: 14px;
+                height: 14px;
+                margin: -6px 0;
+                border-radius: 7px;
+                border: 1px solid rgba(0, 0, 0, 55);
+                background: white;
+            }
+            """
+        )
+        zoom.addWidget(self.zoom_slider)
+
+        self.zoom_in_button = FlatIconButton("+", parent=self.zoom_widget)
+        self.zoom_in_button.setFixedSize(small)
+        self.zoom_in_button.setStyleSheet(self.zoom_out_button.styleSheet())
+        zoom.addWidget(self.zoom_in_button)
+
+        zoom_width = (
+            small.width() * 2
+            + ZOOM_SLIDER_WIDTH
+            + zoom.spacing() * 2
+        )
+        self.zoom_widget.setMinimumWidth(zoom_width)
+        self.zoom_widget.setSizePolicy(
+            QSizePolicy.Policy.Fixed,
+            QSizePolicy.Policy.Fixed,
+        )
+        row.addWidget(self.zoom_widget)
+
+        # ----------------------- center info -----------------------
+        info_container = QWidget(self)
+        info = QVBoxLayout(info_container)
+        info.setContentsMargins(0, 0, 0, 0)
+        info.setSpacing(0)
+        info.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self.location_label = QLabel("Edinburgh - Queen Street", info_container)
+        lf = self.font()
+        lf.setPointSize(max(lf.pointSize() + 2, 12))
+        lf.setBold(True)
+        self.location_label.setFont(lf)
+        self.location_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.location_label.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Preferred,
+        )
+
+        self.timestamp_label = QLabel(
+            "2025年9月21日 19:49:05    ·    1,918 / 1,931",
+            info_container,
+        )
+        tf = self.font()
+        tf.setPointSize(max(tf.pointSize() + 1, 10))
+        self.timestamp_label.setFont(tf)
+        self.timestamp_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.timestamp_label.setStyleSheet("color: rgba(0, 0, 0, 115);")
+
+        info.addWidget(self.location_label)
+        info.addWidget(self.timestamp_label)
+        row.addWidget(info_container, 1)
+
+        # ----------------------- actions -----------------------
+        actions = QWidget(self)
+        actions_layout = QHBoxLayout(actions)
+        actions_layout.setContentsMargins(0, 0, 0, 0)
+        actions_layout.setSpacing(8)
+
+        self.info_button = FlatIconButton("ⓘ", blue=True, parent=actions)
+        self.share_button = FlatIconButton("⇧", parent=actions)
+        self.favorite_button = FlatIconButton("♡", parent=actions)
+        self.rotate_button = FlatIconButton("↶", parent=actions)
+
+        for b in (
+            self.info_button,
+            self.share_button,
+            self.favorite_button,
+            self.rotate_button,
+        ):
+            actions_layout.addWidget(b)
+
+        self.edit_button = QPushButton("编辑", actions)
+        self.edit_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.edit_button.setFixedHeight(30)
+        self.edit_button.setStyleSheet(
+            """
+            QPushButton {
+                background-color: palette(window);
+                border: 1px solid rgba(0, 0, 0, 30);
+                border-radius: 8px;
+                color: #000000;
+                font-weight: 600;
+                padding-left: 20px;
+                padding-right: 20px;
+            }
+            QPushButton:hover { background-color: rgba(0,0,0,12); }
+            QPushButton:pressed { background-color: rgba(0,0,0,20); }
+            """
+        )
+        actions_layout.addWidget(self.edit_button)
+
+        row.addWidget(actions)
+
+        # 按 38px hit target，留一点上下空气；视觉接近真实 DetailPage header。
+        self.setMinimumHeight(50)
+        self.setMaximumHeight(50)
+
+
+class Filmstrip(QWidget):
+    """
+    单文件版 filmstrip。
+    高度严格复用当前 iPhotron FilmstripView 的 120 + 12 = 132 px。
+    """
+
+    def __init__(self, photo_path: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._image = QImage(photo_path) if photo_path else QImage()
+        self.setFixedHeight(FILMSTRIP_HEIGHT)
+        self.setAutoFillBackground(True)
+
+    def paintEvent(self, event) -> None:  # noqa: N802
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        p.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, True)
+
+        bg = self.palette().window().color()
+        p.fillRect(self.rect(), bg)
+
+        h = FILMSTRIP_BASE_HEIGHT
+        gap = 2
+        y = 6
+
+        # 当前项目居中；两侧只是复用同一张照片做布局参照。
+        current_w = 160
+        side_w = 82
+
+        widths = [side_w, side_w, current_w, side_w, side_w]
+        total = sum(widths) + gap * (len(widths) - 1)
+        x = (self.width() - total) / 2.0
+
+        for i, tw in enumerate(widths):
+            r = QRectF(x, y, tw, h)
+            if not self._image.isNull():
+                self._draw_cover(p, self._image, r)
+            else:
+                shade = 210 - abs(i - 2) * 18
+                p.fillRect(r, QColor(shade, shade, shade))
+
+            if i == 2:
+                p.setPen(QPen(QColor("#1e73ff"), 3))
+                p.setBrush(Qt.BrushStyle.NoBrush)
+                p.drawRoundedRect(r.adjusted(1.5, 1.5, -1.5, -1.5), 3, 3)
+
+            x += tw + gap
+
+    @staticmethod
+    def _draw_cover(p: QPainter, image: QImage, target: QRectF) -> None:
+        iw = image.width()
+        ih = image.height()
+        if iw <= 0 or ih <= 0:
+            return
+
+        target_ratio = target.width() / target.height()
+        image_ratio = iw / ih
+
+        if image_ratio > target_ratio:
+            crop_h = ih
+            crop_w = crop_h * target_ratio
+            crop_x = (iw - crop_w) / 2.0
+            src = QRectF(crop_x, 0, crop_w, crop_h)
+        else:
+            crop_w = iw
+            crop_h = crop_w / target_ratio
+            crop_y = (ih - crop_h) / 2.0
+            src = QRectF(0, crop_y, crop_w, crop_h)
+
+        p.drawImage(target, image, src)
+
+
+class IPhotronPlaybackShadowDemo(QWidget):
+    """
+    只复刻 iPhotron Detail Playback 区域，不造 sidebar / fake app window。
+
+    直接子控件：
+        header
+        gl_viewport
+        shadow_overlay   <-- sibling，覆盖 gl_viewport 顶部
+        filmstrip
+
+    shadow_overlay 不参与 layout，因此不会把照片向下挤 28px。
+    """
+
+    HEADER_HEIGHT = 50
+
+    def __init__(self, photo_path: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setMinimumSize(900, 620)
+        self.setAutoFillBackground(True)
+
+        self.header = PlaybackHeader(self)
+        self.gl_viewport = PhotoGLViewport(photo_path, self)
+        self.shadow_overlay = ShadowOverlay(self)
+        self.filmstrip = Filmstrip(photo_path, self)
+
+        self.header.zoom_slider.valueChanged.connect(
+            self.gl_viewport.set_zoom_percent
+        )
+        self.header.zoom_out_button.clicked.connect(
+            lambda: self.header.zoom_slider.setValue(
+                max(
+                    self.header.zoom_slider.minimum(),
+                    self.header.zoom_slider.value() - 25,
+                )
+            )
+        )
+        self.header.zoom_in_button.clicked.connect(
+            lambda: self.header.zoom_slider.setValue(
+                min(
+                    self.header.zoom_slider.maximum(),
+                    self.header.zoom_slider.value() + 25,
+                )
+            )
+        )
+
+    def resizeEvent(self, event) -> None:  # noqa: N802
+        super().resizeEvent(event)
+
+        w = self.width()
+        h = self.height()
+
+        header_h = self.HEADER_HEIGHT
+        film_h = FILMSTRIP_HEIGHT
+        gap = PLAYER_FILMSTRIP_GAP
+
+        # 真实 toolbar
+        self.header.setGeometry(0, 0, w, header_h)
+
+        # GPU viewport：紧贴 toolbar，不为 shadow 预留高度
+        viewer_y = header_h
+        viewer_h = max(1, h - header_h - gap - film_h)
+        self.gl_viewport.setGeometry(0, viewer_y, w, viewer_h)
+
+        # 关键：shadow 是同一 parent 下的 sibling，
+        # 直接压在 OpenGL viewport 的 y=0 顶部。
+        self.shadow_overlay.setGeometry(
+            0,
+            viewer_y,
+            w,
+            min(SHADOW_HEIGHT, viewer_h),
+        )
+        self.shadow_overlay.raise_()
+
+        self.filmstrip.setGeometry(
+            0,
+            viewer_y + viewer_h + gap,
+            w,
+            film_h,
+        )
+        self.filmstrip.raise_()
+
+    def keyPressEvent(self, event) -> None:  # noqa: N802
+        # S 键可快速 A/B 对比阴影开/关
+        if event.key() == Qt.Key.Key_S:
+            self.shadow_overlay.setVisible(
+                not self.shadow_overlay.isVisible()
+            )
+            return
+        super().keyPressEvent(event)
+
+
+class MainWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle(
+            "iPhotron Playback - toolbar sibling shadow overlay demo"
+        )
+        self.resize(1440, 900)
+
+        demo = IPhotronPlaybackShadowDemo(PHOTO_PATH, self)
+        self.setCentralWidget(demo)
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")
+
+    # 保持浅色 Photos/iPhotron playback 观察环境。
+    pal = app.palette()
+    pal.setColor(pal.ColorRole.Window, QColor("#f7f7f7"))
+    pal.setColor(pal.ColorRole.Base, QColor("#ffffff"))
+    pal.setColor(pal.ColorRole.WindowText, QColor("#1f1f1f"))
+    pal.setColor(pal.ColorRole.Text, QColor("#1f1f1f"))
+    app.setPalette(pal)
+
+    win = MainWindow()
+    win.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,7 +291,8 @@ future side design. The active query path is SQL-first and windowed:
 - Active surface demands are leases. Sparse row windows may be disjoint, while
   the global micro cache remains bounded. Thumbnail L1 keys include display size,
   so Gallery and Filmstrip buckets coexist under one byte budget; hiding a surface
-  releases only its exclusive pins and queued work.
+  suspends its viewport publishers and releases only its exclusive pins and queued
+  work. Late viewport query results for a released surface are discarded.
 - Delegates consume one `GalleryTileSnapshot` through `TILE_SNAPSHOT`. A paint
   miss must remain memory-only; it schedules bounded background work and paints
   an available micro thumbnail or placeholder instead of reading SQLite or L2.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,10 +289,14 @@ future side design. The active query path is SQL-first and windowed:
   generations, visible rows, full-thumbnail guards, speculative work, display
   buckets, and micro-thumbnail warm ranges.
 - Active surface demands are leases. Sparse row windows may be disjoint, while
-  the global micro cache remains bounded. Thumbnail L1 keys include display size,
-  so Gallery and Filmstrip buckets coexist under one byte budget; hiding a surface
-  suspends its viewport publishers and releases only its exclusive pins and queued
-  work. Late viewport query results for a released surface are discarded.
+  the global micro cache remains bounded. Gallery and Filmstrip both resolve to
+  one canonical 512px full-thumbnail key, so their independent leases share the
+  same L1 QPixmap and L2 artifact. Hiding a surface suspends its viewport publishers
+  and releases only its exclusive pins and queued work. Late viewport query results
+  for a released surface are discarded.
+- Filmstrip keeps visible and two-screen full-thumbnail guard demand at 512px,
+  but does not add far-speculative full work. Gallery retains its wider
+  full-prefetch policy, and Filmstrip micro warm-up remains unchanged.
 - Delegates consume one `GalleryTileSnapshot` through `TILE_SNAPSHOT`. A paint
   miss must remain memory-only; it schedules bounded background work and paints
   an available micro thumbnail or placeholder instead of reading SQLite or L2.
@@ -591,7 +595,8 @@ far work must not consume workers reserved for urgent visible/guard requests.
 `ThumbnailRuntimePolicy` derives worker, staging, publish, and byte-budget limits
 from platform and physical memory. L1 eviction accounts for actual image bytes,
 pins the union of active visible surface demand, and prefers old/far speculative
-entries. Different display buckets coexist instead of flushing the pool. Disk access
+entries. Gallery and Filmstrip naturally deduplicate at the same 512px key; the
+size-qualified key remains available to other future surfaces. Disk access
 and image decoding stay off the GUI thread; only bounded `QPixmap` publication
 runs there. Thumbnail infrastructure may apply edit state, but edit persistence
 remains behind session/edit sidecar services.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -284,9 +284,14 @@ future side design. The active query path is SQL-first and windowed:
   window: `read_gallery_collection_window()` returns tile-rendering fields, and
   `read_thumbnail_hint_window()` returns only paths and existing full-thumbnail
   keys without repeating the collection count.
-- `GalleryViewportDemand` is the contract between scrolling, sparse row loading,
-  and thumbnail scheduling. It separates visible rows, the full-thumbnail guard,
-  far speculative full-thumbnail work, and the wider micro-thumbnail warm range.
+- `AssetViewportDemand` is the per-surface contract between scrolling, sparse row
+  loading, and thumbnail scheduling. Gallery and Filmstrip keep independent
+  generations, visible rows, full-thumbnail guards, speculative work, display
+  buckets, and micro-thumbnail warm ranges.
+- Active surface demands are leases. Sparse row windows may be disjoint, while
+  the global micro cache remains bounded. Thumbnail L1 keys include display size,
+  so Gallery and Filmstrip buckets coexist under one byte budget; hiding a surface
+  releases only its exclusive pins and queued work.
 - Delegates consume one `GalleryTileSnapshot` through `TILE_SNAPSHOT`. A paint
   miss must remain memory-only; it schedules bounded background work and paints
   an available micro thumbnail or placeholder instead of reading SQLite or L2.
@@ -437,8 +442,8 @@ sequenceDiagram
     participant Query as Asset Query Surface
     participant Repo as AssetRepositoryPort
 
-    Grid->>Demand: viewport + intent + generation
-    Demand->>Store: visible and micro-warm ranges
+    Grid->>Demand: surface + viewport + intent + generation
+    Demand->>Store: disjoint visible and micro-warm ranges
     Store->>Loader: bounded async requests
     Loader->>Query: gallery window / thumbnail hints
     Query->>Repo: narrow SQL projections
@@ -561,7 +566,7 @@ session.
 ```mermaid
 sequenceDiagram
     participant Paint as Delegate Paint
-    participant Demand as Gallery Demand
+    participant Demand as Surface Demands
     participant Thumb as Thumbnail Cache Service
     participant Worker as Visible/Guard/Far Workers
     participant L2 as Disk Cache
@@ -569,13 +574,13 @@ sequenceDiagram
 
     Paint->>Thumb: peek_full_thumbnail()
     Thumb-->>Paint: memory pixmap or miss
-    Demand->>Thumb: request_many(generation, priority)
+    Demand->>Thumb: upsert/release surface lease
     Thumb->>Worker: deduplicate/promote/schedule
     Worker->>L2: decode existing thumbnail to QImage
     Worker-->>GUI: bounded staging result
     GUI->>GUI: QImage to QPixmap within frame budget
     GUI-->>Paint: coalesced exact-row update
-    alt stale or superseded demand
+    alt surface key is no longer leased or revision is superseded
         Thumb->>Worker: cancel, back off, or discard result
     end
 ```
@@ -584,7 +589,8 @@ Visible recovery, near guard, and far speculation use separate scheduling lanes;
 far work must not consume workers reserved for urgent visible/guard requests.
 `ThumbnailRuntimePolicy` derives worker, staging, publish, and byte-budget limits
 from platform and physical memory. L1 eviction accounts for actual image bytes,
-pins active visible demand, and prefers old/far speculative entries. Disk access
+pins the union of active visible surface demand, and prefers old/far speculative
+entries. Different display buckets coexist instead of flushing the pool. Disk access
 and image decoding stay off the GUI thread; only bounded `QPixmap` publication
 runs there. Thumbnail infrastructure may apply edit state, but edit persistence
 remains behind session/edit sidecar services.

--- a/docs/misc/GALLERY_SCROLL_PIPELINE_GUARDRAILS.md
+++ b/docs/misc/GALLERY_SCROLL_PIPELINE_GUARDRAILS.md
@@ -25,6 +25,10 @@ repaint work.
   far speculative, and micro-warm ranges. New heuristics belong in the demand
   policy, not as independent widget/viewmodel prefetch loops. Filmstrip ranges
   come from actual horizontal geometry and map through every proxy layer.
+- Gallery and Filmstrip both request the canonical 512px full-thumbnail bucket.
+  Their logical leases stay independent, but identical assets must converge on
+  one size-qualified physical key. Filmstrip geometry must never be inflated to
+  force this resolution.
 - Continuous medium/fast bursts prioritize input and visible recovery: they must
   not start hint queries or speculative L2 reads. Slow/dwell/idle work remains
   generation-aware and cancellable.
@@ -32,9 +36,12 @@ repaint work.
   urgent guard capacity, and newly visible requests must promote matching
   in-flight prefetch work rather than duplicate it.
 - L1 is one byte-budgeted multi-surface cache. Cache keys include display size;
-  bucket changes must not flush the pool. Preserve the union of visible pins,
+  never alias one QPixmap under multiple size keys. Preserve the union of visible pins,
   per-surface lease release, demand-aware eviction, staging caps, miss TTLs,
   low-memory release, and speculative backoff when changing cache behavior.
+- Filmstrip full demand stops at its existing two-screen guard; it does not add
+  far speculation at 512px. Gallery full speculation and both surfaces' micro
+  warm ranges remain unchanged.
 - Paint, model data, and peek paths remain memory-only for every surface. A
   missing Filmstrip full thumbnail is recovered by viewport demand, never by a
   request issued from the delegate.

--- a/docs/misc/GALLERY_SCROLL_PIPELINE_GUARDRAILS.md
+++ b/docs/misc/GALLERY_SCROLL_PIPELINE_GUARDRAILS.md
@@ -38,6 +38,13 @@ repaint work.
 - Paint, model data, and peek paths remain memory-only for every surface. A
   missing Filmstrip full thumbnail is recovered by viewport demand, never by a
   request issued from the delegate.
+- A hidden surface is suspended before its lease is released: coalescing and
+  scroll-intent timers cannot republish while hidden, and late viewport window
+  results for a released surface are discarded. Explicit detail-row requests
+  remain independent of these viewport leases.
+- Filmstrip geometry is measured in proxy rows, but every demand range is
+  bounded by the root source model's asset count; spacer rows never enter guard,
+  prefetch, or micro-warm ranges.
 - Gallery SQL projections stay narrow: tile windows omit wide metadata, while
   hint windows return only paths and existing full-thumbnail keys and do not
   repeat collection counts.

--- a/docs/misc/GALLERY_SCROLL_PIPELINE_GUARDRAILS.md
+++ b/docs/misc/GALLERY_SCROLL_PIPELINE_GUARDRAILS.md
@@ -11,8 +11,9 @@ repaint work.
   memory-only. Never add SQLite queries, `Path.exists()`, L2 reads, image decode,
   blocking waits, synchronous layout, or `repaint()` to these paths.
 - Window rows and thumbnail hints are loaded by `GalleryWindowLoader` and
-  `GalleryThumbnailHintLoader`. Results must carry collection revision and
-  demand generation; stale results do not mutate the active viewport.
+  `GalleryThumbnailHintLoader`. Results carry collection revision, surface id,
+  and that surface's demand generation. A newer Filmstrip request must not
+  invalidate still-relevant Gallery work, or vice versa.
 - Workers decode to `QImage`. `QPixmap` creation remains on the GUI thread and
   is drained through the bounded item/time publish budget.
 - Thumbnail-ready updates are coalesced into exact row ranges and roles. Do not
@@ -20,18 +21,23 @@ repaint work.
 
 ## Demand And Cache Contract
 
-- `GalleryViewportDemand` is the single source for visible, full guard, far
-  speculative, and micro-warm ranges. New heuristics belong in the demand policy,
-  not as independent widget/viewmodel prefetch loops.
+- `AssetViewportDemand` is the single per-surface source for visible, full guard,
+  far speculative, and micro-warm ranges. New heuristics belong in the demand
+  policy, not as independent widget/viewmodel prefetch loops. Filmstrip ranges
+  come from actual horizontal geometry and map through every proxy layer.
 - Continuous medium/fast bursts prioritize input and visible recovery: they must
   not start hint queries or speculative L2 reads. Slow/dwell/idle work remains
   generation-aware and cancellable.
 - Keep visible, guard, and far speculative lanes isolated. Far work cannot use
   urgent guard capacity, and newly visible requests must promote matching
   in-flight prefetch work rather than duplicate it.
-- L1 is a byte-budgeted cache. Preserve visible pinning, demand-aware eviction,
-  staging caps, miss TTLs, low-memory release, and speculative backoff when
-  changing cache behavior.
+- L1 is one byte-budgeted multi-surface cache. Cache keys include display size;
+  bucket changes must not flush the pool. Preserve the union of visible pins,
+  per-surface lease release, demand-aware eviction, staging caps, miss TTLs,
+  low-memory release, and speculative backoff when changing cache behavior.
+- Paint, model data, and peek paths remain memory-only for every surface. A
+  missing Filmstrip full thumbnail is recovered by viewport demand, never by a
+  request issued from the delegate.
 - Gallery SQL projections stay narrow: tile windows omit wide metadata, while
   hint windows return only paths and existing full-thumbnail keys and do not
   repeat collection counts.

--- a/docs/requirements/GALLERY_SCROLL_PERFORMANCE_REARCHITECTURE.md
+++ b/docs/requirements/GALLERY_SCROLL_PERFORMANCE_REARCHITECTURE.md
@@ -316,7 +316,8 @@ Thumbnail Workers
   -> far speculative reads use one low/background-priority lane
   -> continuous burst / medium / fast immediately stop all non-visible work
   -> open the existing 512px L2 once with QFile and decoder-scale via QImageReader
-  -> return 256/384/512 display-bucket QImage results without writing extra L2 files
+  -> return the requested display-bucket QImage without writing extra L2 files;
+     Gallery and Filmstrip both request the canonical 512 bucket
   -> GUI publishes visible, predictive, then far results under a strict time budget
 ```
 
@@ -329,9 +330,10 @@ Thumbnail Workers
   direction for 600ms, and completes the next screen before spending work behind the
   viewport. A burst at 75ms cadence or faster, trackpad fast input, and scrollbar fast
   movement prohibit predictive reads and speculative QPixmap conversion.
-- Disk L2 remains one flat 512px JPEG per ready asset. L1 keys combine that stable L2
-  identity with a display bucket selected from 256/384/512 physical pixels using the
-  current tile size and DPR. No rescan or multi-size disk migration is required.
+- Disk L2 remains one flat 512px JPEG per ready asset. L1 keys remain size-qualified,
+  but Gallery and Filmstrip both select the canonical 512 bucket and therefore share
+  one physical entry. Other future surfaces may still resolve 256/384/512 from their
+  physical size and DPR. No rescan or multi-size disk migration is required.
 - Predictive concurrency is deadline/backpressure driven: Windows starts at two lanes and
   may use three; Linux uses at most two; macOS remains one. Visible queue wait above 12ms,
   publisher pressure, or cancellation pressure pauses non-visible work.

--- a/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
+++ b/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import (
     QObject,
     Qt,
     QThreadPool,
+    QTimer,
 )
 from PySide6.QtGui import QAction
 
@@ -43,6 +44,7 @@ from iPhoto.gui.ui.controllers.status_bar_controller import StatusBarController
 from iPhoto.gui.ui.controllers.window_theme_controller import WindowThemeController
 from iPhoto.gui.ui.media import MediaAdjustmentCommitter, MediaSelectionSession
 from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
+from iPhoto.gui.ui.models.thumbnail_surface_proxy_model import ThumbnailSurfaceProxyModel
 from iPhoto.gui.ui.widgets.asset_delegate import AssetGridDelegate
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailViewModel
 from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAdapter
@@ -323,8 +325,13 @@ class DesktopCoordinatorRuntime(QObject):
         window.ui.grid_view.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
 
         # Use SpacerProxyModel for Filmstrip to allow centering of first/last items
+        self._filmstrip_thumbnail_proxy = ThumbnailSurfaceProxyModel(
+            "filmstrip",
+            window.ui.filmstrip_view,
+        )
+        self._filmstrip_thumbnail_proxy.setSourceModel(self._asset_list_vm)
         self._filmstrip_proxy = SpacerProxyModel(window.ui.filmstrip_view)
-        self._filmstrip_proxy.setSourceModel(self._asset_list_vm)
+        self._filmstrip_proxy.setSourceModel(self._filmstrip_thumbnail_proxy)
         window.ui.filmstrip_view.setModel(self._filmstrip_proxy)
 
         # Assign Delegate for Filmstrip View
@@ -552,6 +559,12 @@ class DesktopCoordinatorRuntime(QObject):
             self._shutdown_complete = True
             self._is_shutting_down = False
 
+    def _handle_thumbnail_surface_visibility(self, surface_id: str, view, visible: bool) -> None:
+        if not visible:
+            self._asset_list_vm.release_viewport_surface(surface_id)
+            return
+        QTimer.singleShot(0, view.schedule_viewport_publish)
+
     def _connect_signals(self) -> None:
         """Connect application signals."""
         ui = self._window.ui
@@ -576,6 +589,17 @@ class DesktopCoordinatorRuntime(QObject):
         # Grid interactions
         ui.grid_view.itemClicked.connect(self._on_asset_clicked)
         ui.grid_view.viewportStateChanged.connect(self._asset_list_vm.update_viewport)
+        ui.filmstrip_view.viewportStateChanged.connect(self._asset_list_vm.update_viewport)
+        ui.grid_view.viewportVisibilityChanged.connect(
+            lambda visible: self._handle_thumbnail_surface_visibility(
+                "gallery", ui.grid_view, visible
+            )
+        )
+        ui.filmstrip_view.viewportVisibilityChanged.connect(
+            lambda visible: self._handle_thumbnail_surface_visibility(
+                "filmstrip", ui.filmstrip_view, visible
+            )
+        )
         if hasattr(ui.grid_view, "detailPrefetchRequested"):
             ui.grid_view.detailPrefetchRequested.connect(
                 self._playback.prefetch_descriptor

--- a/src/iPhoto/gui/coordinators/playback_coordinator.py
+++ b/src/iPhoto/gui/coordinators/playback_coordinator.py
@@ -45,6 +45,7 @@ from iPhoto.gui.ui.controllers.edit_zoom_handler import EditZoomHandler
 from iPhoto.gui.ui.controllers.header_controller import HeaderController
 from iPhoto.gui.ui.icons import load_icon
 from iPhoto.gui.ui.media.media_selection_session import MediaSelectionState
+from iPhoto.gui.ui.models.proxy_mapping import map_from_root_source, map_to_root_source
 from iPhoto.gui.ui.widgets import dialogs
 from iPhoto.gui.viewmodels.detail_viewmodel import DetailPresentation, DetailViewModel
 from iPhoto.utils.ffmpeg import probe_video_rotation_info
@@ -844,13 +845,8 @@ class PlaybackCoordinator(QObject):
 
     @Slot(QModelIndex)
     def _on_filmstrip_clicked(self, index: QModelIndex) -> None:
-        model = self._filmstrip_view.model()
-        if hasattr(model, "mapToSource"):
-            source_idx = model.mapToSource(index)
-            if source_idx.isValid():
-                self.play_asset(source_idx.row())
-                return
-        self.play_asset(index.row())
+        source_idx = map_to_root_source(index)
+        self.play_asset(source_idx.row() if source_idx.isValid() else index.row())
 
     @Slot(int)
     @Slot()
@@ -2246,8 +2242,10 @@ class PlaybackCoordinator(QObject):
 
         idx = self._asset_model.index(row, 0)
         model = self._filmstrip_view.model()
-        if hasattr(model, "mapFromSource"):
-            idx = model.mapFromSource(idx)
+        mapped = map_from_root_source(model, idx)
+        if not mapped.isValid() and hasattr(model, "mapFromSource"):
+            mapped = model.mapFromSource(idx)
+        idx = mapped
         if idx.isValid():
             self._filmstrip_view.select_index_for_centering(idx)
         return idx
@@ -2262,8 +2260,10 @@ class PlaybackCoordinator(QObject):
             return
         idx = self._asset_model.index(row, 0)
         model = self._filmstrip_view.model()
-        if hasattr(model, "mapFromSource"):
-            idx = model.mapFromSource(idx)
+        mapped = map_from_root_source(model, idx)
+        if not mapped.isValid() and hasattr(model, "mapFromSource"):
+            mapped = model.mapFromSource(idx)
+        idx = mapped
         if idx.isValid():
             self._filmstrip_view.center_on_index(idx)
 

--- a/src/iPhoto/gui/gallery_demand.py
+++ b/src/iPhoto/gui/gallery_demand.py
@@ -34,6 +34,8 @@ SCROLL_DIRECTIONAL_DWELL_MS = 75
 SCROLL_DIRECTION_RETENTION_MS = 600
 SCROLL_BURST_INTERVAL_MS = 75
 DISPLAY_THUMBNAIL_BUCKETS = (256, 384, 512)
+CANONICAL_FULL_THUMBNAIL_BUCKET = 512
+_CANONICAL_FULL_THUMBNAIL_SURFACES = frozenset({"gallery", "filmstrip"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -220,6 +222,7 @@ def build_viewport_demand(
         last + visible_count * guard_after,
     )
     before_screens, after_screens = _full_prefetch_screens(
+        surface_id=surface_id,
         phase=phase,
         intent=intent,
         direction=direction,
@@ -265,7 +268,7 @@ def build_viewport_demand(
             if predicted_input_interval_ms is None
             else max(0.0, float(predicted_input_interval_ms))
         ),
-        display_bucket=resolve_display_thumbnail_bucket(display_bucket),
+        display_bucket=resolve_surface_thumbnail_bucket(surface_id, display_bucket),
         full_guard_first=full_guard_first,
         full_guard_last=full_guard_last,
         full_prefetch_first=full_prefetch_first,
@@ -278,6 +281,17 @@ def build_viewport_demand(
 def resolve_display_thumbnail_bucket(physical_edge: int | float) -> int:
     edge = max(1, int(round(float(physical_edge))))
     return next((bucket for bucket in DISPLAY_THUMBNAIL_BUCKETS if bucket >= edge), 512)
+
+
+def resolve_surface_thumbnail_bucket(
+    surface_id: str,
+    physical_edge: int | float,
+) -> int:
+    """Resolve storage resolution independently from surface geometry."""
+
+    if str(surface_id) in _CANONICAL_FULL_THUMBNAIL_SURFACES:
+        return CANONICAL_FULL_THUMBNAIL_BUCKET
+    return resolve_display_thumbnail_bucket(physical_edge)
 
 
 def _bounded_range(row_count: int, first: int, last: int) -> tuple[int, int]:
@@ -302,6 +316,7 @@ def _full_guard_screens(
 
 def _full_prefetch_screens(
     *,
+    surface_id: str,
     phase: GalleryScrollPhase,
     intent: GalleryScrollIntent,
     direction: int,
@@ -316,6 +331,8 @@ def _full_prefetch_screens(
     )
     if not guard_before and not guard_after:
         return 0, 0
+    if surface_id == "filmstrip":
+        return guard_before, guard_after
 
     if intent == "idle":
         screens = FULL_GUARD_SCREENS + FULL_SPECULATIVE_IDLE_SCREENS
@@ -354,6 +371,7 @@ def _warm_window(
 
 
 __all__ = [
+    "CANONICAL_FULL_THUMBNAIL_BUCKET",
     "FAST_SCROLL_SCREENS_PER_SECOND",
     "DISPLAY_THUMBNAIL_BUCKETS",
     "MICRO_QUERY_CHUNK",
@@ -374,4 +392,5 @@ __all__ = [
     "build_viewport_demand",
     "classify_scroll_phase",
     "resolve_display_thumbnail_bucket",
+    "resolve_surface_thumbnail_bucket",
 ]

--- a/src/iPhoto/gui/gallery_demand.py
+++ b/src/iPhoto/gui/gallery_demand.py
@@ -37,9 +37,10 @@ DISPLAY_THUMBNAIL_BUCKETS = (256, 384, 512)
 
 
 @dataclass(frozen=True, slots=True)
-class GalleryViewportDemand:
-    """One immutable description of visible, full-prefetch, and micro-warm demand."""
+class AssetViewportDemand:
+    """One surface's immutable visible, full-prefetch, and micro-warm demand."""
 
+    surface_id: str
     generation: int
     visible_first: int
     visible_last: int
@@ -174,6 +175,7 @@ def classify_scroll_phase(
 
 def build_viewport_demand(
     *,
+    surface_id: str = "gallery",
     generation: int,
     row_count: int,
     visible_first: int,
@@ -185,7 +187,7 @@ def build_viewport_demand(
     prefetch_direction: int | None = None,
     predicted_input_interval_ms: float | None = None,
     display_bucket: int = 512,
-) -> GalleryViewportDemand:
+) -> AssetViewportDemand:
     """Build bounded visible, full-prefetch, and micro-warm ranges."""
 
     row_count = max(1, int(row_count))
@@ -244,7 +246,8 @@ def build_viewport_demand(
         direction=direction if intent != "idle" else 0,
     )
 
-    return GalleryViewportDemand(
+    return AssetViewportDemand(
+        surface_id=str(surface_id),
         generation=int(generation),
         visible_first=first,
         visible_last=last,
@@ -367,7 +370,7 @@ __all__ = [
     "SLOW_SCROLL_SCREENS_PER_SECOND",
     "GalleryScrollIntent",
     "GalleryScrollPhase",
-    "GalleryViewportDemand",
+    "AssetViewportDemand",
     "build_viewport_demand",
     "classify_scroll_phase",
     "resolve_display_thumbnail_bucket",

--- a/src/iPhoto/gui/ui/models/proxy_mapping.py
+++ b/src/iPhoto/gui/ui/models/proxy_mapping.py
@@ -1,0 +1,55 @@
+"""Helpers for mapping indexes through arbitrary Qt proxy chains."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QAbstractProxyModel, QModelIndex
+
+
+def root_source_model(model):
+    current = model
+    seen: set[int] = set()
+    while isinstance(current, QAbstractProxyModel) and id(current) not in seen:
+        seen.add(id(current))
+        source = current.sourceModel()
+        if source is None:
+            break
+        current = source
+    return current
+
+
+def map_to_root_source(index: QModelIndex) -> QModelIndex:
+    current = index
+    model = current.model() if current.isValid() else None
+    seen: set[int] = set()
+    while current.isValid() and isinstance(model, QAbstractProxyModel) and id(model) not in seen:
+        seen.add(id(model))
+        current = model.mapToSource(current)
+        if not current.isValid():
+            return QModelIndex()
+        model = model.sourceModel()
+    return current if current.isValid() else QModelIndex()
+
+
+def map_from_root_source(model, source_index: QModelIndex) -> QModelIndex:
+    """Map a root-source index into the outermost *model*."""
+
+    if model is None or not source_index.isValid():
+        return QModelIndex()
+    chain = []
+    current = model
+    seen: set[int] = set()
+    while isinstance(current, QAbstractProxyModel) and id(current) not in seen:
+        seen.add(id(current))
+        chain.append(current)
+        current = current.sourceModel()
+    if current is not source_index.model():
+        return QModelIndex()
+    mapped = source_index
+    for proxy in reversed(chain):
+        mapped = proxy.mapFromSource(mapped)
+        if not mapped.isValid():
+            return QModelIndex()
+    return mapped
+
+
+__all__ = ["map_from_root_source", "map_to_root_source", "root_source_model"]

--- a/src/iPhoto/gui/ui/models/thumbnail_surface_proxy_model.py
+++ b/src/iPhoto/gui/ui/models/thumbnail_surface_proxy_model.py
@@ -1,0 +1,40 @@
+"""Surface-specific, memory-only thumbnail presentation proxy."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QIdentityProxyModel, QModelIndex, Qt
+
+from .roles import Roles
+
+
+class ThumbnailSurfaceProxyModel(QIdentityProxyModel):
+    """Resolve thumbnail roles with one surface's display bucket."""
+
+    def __init__(self, surface_id: str, parent=None) -> None:
+        super().__init__(parent)
+        self._surface_id = str(surface_id)
+
+    @property
+    def surface_id(self) -> str:
+        return self._surface_id
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole):  # noqa: N802
+        if not index.isValid():
+            return None
+        source = self.sourceModel()
+        source_index = self.mapToSource(index)
+        if source is None or not source_index.isValid():
+            return None
+        role_int = int(role)
+        if role_int == Roles.TILE_SNAPSHOT:
+            getter = getattr(source, "tile_snapshot", None)
+            if callable(getter):
+                return getter(source_index.row(), self._surface_id)
+        if role_int == int(Qt.ItemDataRole.DecorationRole):
+            getter = getattr(source, "full_thumbnail", None)
+            if callable(getter):
+                return getter(source_index.row(), self._surface_id)
+        return source.data(source_index, role)
+
+
+__all__ = ["ThumbnailSurfaceProxyModel"]

--- a/src/iPhoto/gui/ui/widgets/asset_grid.py
+++ b/src/iPhoto/gui/ui/widgets/asset_grid.py
@@ -115,10 +115,13 @@ class AssetGrid(QListView):
 
     def showEvent(self, event) -> None:  # type: ignore[override]
         super().showEvent(event)
+        self._scroll_controller.resume()
         self.viewportVisibilityChanged.emit(True)
         QTimer.singleShot(0, self._schedule_visible_rows_update)
 
     def hideEvent(self, event) -> None:  # type: ignore[override]
+        self._update_timer.stop()
+        self._scroll_controller.suspend()
         self.viewportVisibilityChanged.emit(False)
         super().hideEvent(event)
 
@@ -283,7 +286,7 @@ class AssetGrid(QListView):
         return bool(buttons & Qt.MouseButton.LeftButton)
 
     def _schedule_visible_rows_update(self) -> None:
-        if not self._update_timer.isActive():
+        if self.isVisible() and not self._update_timer.isActive():
             self._update_timer.start()
 
     def _viewport_pos(self, event: QMouseEvent) -> QPoint:
@@ -331,6 +334,8 @@ class AssetGrid(QListView):
         return QPoint(event.x(), event.y())
 
     def _emit_visible_rows(self) -> None:
+        if not self.isVisible():
+            return
         model = self.model()
         if model is None:
             return

--- a/src/iPhoto/gui/ui/widgets/asset_grid.py
+++ b/src/iPhoto/gui/ui/widgets/asset_grid.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Type
 
 from PySide6.QtCore import QModelIndex, QPoint, QTimer, Qt, Signal
 from PySide6.QtGui import QDragEnterEvent, QDragMoveEvent, QDropEvent, QMouseEvent, QWheelEvent
 from PySide6.QtWidgets import QApplication, QListView
 
 from ....config import LONG_PRESS_THRESHOLD_MS
-from .gallery_scroll_controller import GalleryScrollController
+from .gallery_scroll_controller import AssetScrollController, GalleryScrollController
 
 _IS_DARWIN = sys.platform == "darwin"
 
@@ -30,10 +30,16 @@ class AssetGrid(QListView):
     viewportStateChanged = Signal(object)
     modelAboutToChange = Signal(object)
     modelChanged = Signal(object)
+    viewportVisibilityChanged = Signal(bool)
 
     _DRAG_CANCEL_THRESHOLD = 6
 
-    def __init__(self, parent=None) -> None:  # type: ignore[override]
+    def __init__(
+        self,
+        parent=None,
+        *,
+        scroll_controller_type: Type[AssetScrollController] = GalleryScrollController,
+    ) -> None:  # type: ignore[override]
         super().__init__(parent)
         self._press_timer = QTimer(self)
         self._press_timer.setSingleShot(True)
@@ -52,7 +58,7 @@ class AssetGrid(QListView):
         self._drop_handler: Optional[Callable[[List[Path]], None]] = None
         self._drop_validator: Optional[Callable[[List[Path]], bool]] = None
         self._preview_enabled = True
-        self._scroll_controller = GalleryScrollController(
+        self._scroll_controller = scroll_controller_type(
             self,
             self._schedule_visible_rows_update,
         )
@@ -109,7 +115,15 @@ class AssetGrid(QListView):
 
     def showEvent(self, event) -> None:  # type: ignore[override]
         super().showEvent(event)
+        self.viewportVisibilityChanged.emit(True)
         QTimer.singleShot(0, self._schedule_visible_rows_update)
+
+    def hideEvent(self, event) -> None:  # type: ignore[override]
+        self.viewportVisibilityChanged.emit(False)
+        super().hideEvent(event)
+
+    def schedule_viewport_publish(self) -> None:
+        self._schedule_visible_rows_update()
 
     # ------------------------------------------------------------------
     # Preview configuration

--- a/src/iPhoto/gui/ui/widgets/filmstrip_view.py
+++ b/src/iPhoto/gui/ui/widgets/filmstrip_view.py
@@ -9,9 +9,11 @@ from PySide6.QtCore import QEvent, QItemSelectionModel, QModelIndex, QSize, Qt, 
 from PySide6.QtGui import QPalette, QResizeEvent, QWheelEvent
 from PySide6.QtWidgets import QListView, QSizePolicy, QStyleOptionViewItem
 
+from ..models.proxy_mapping import map_from_root_source, root_source_model
 from ..models.roles import Roles
 from ..styles import modern_scrollbar_style
 from .asset_grid import AssetGrid
+from .filmstrip_viewport_controller import FilmstripViewportController
 
 
 class FilmstripView(AssetGrid):
@@ -26,7 +28,7 @@ class FilmstripView(AssetGrid):
     )
 
     def __init__(self, parent=None) -> None:  # type: ignore[override]
-        super().__init__(parent)
+        super().__init__(parent, scroll_controller_type=FilmstripViewportController)
         self._base_height = 120
         self._spacing = 2
         self._default_ratio = 0.6
@@ -291,13 +293,7 @@ class FilmstripView(AssetGrid):
         if path is None or model is None:
             return QModelIndex()
 
-        source_model = model
-        source_getter = getattr(model, "sourceModel", None)
-        map_from_source = getattr(model, "mapFromSource", None)
-        if callable(source_getter):
-            candidate = source_getter()
-            if candidate is not None:
-                source_model = candidate
+        source_model = root_source_model(model)
 
         resolver = getattr(source_model, "cached_row_for_path", None)
         if not callable(resolver):
@@ -309,11 +305,7 @@ class FilmstripView(AssetGrid):
         source_index = source_model.index(row, 0)
         if not source_index.isValid():
             return QModelIndex()
-        index = (
-            map_from_source(source_index)
-            if source_model is not model and callable(map_from_source)
-            else source_index
-        )
+        index = map_from_root_source(model, source_index)
         if not index.isValid() or bool(index.data(Roles.IS_SPACER)):
             return QModelIndex()
         resolved_path = index.data(Roles.ABS)

--- a/src/iPhoto/gui/ui/widgets/filmstrip_viewport_controller.py
+++ b/src/iPhoto/gui/ui/widgets/filmstrip_viewport_controller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from PySide6.QtCore import QModelIndex, QPoint
 
-from ..models.proxy_mapping import map_to_root_source
+from ..models.proxy_mapping import map_to_root_source, root_source_model
 from ..models.roles import Roles
 from .gallery_scroll_controller import AssetScrollController
 
@@ -23,6 +23,11 @@ class FilmstripViewportController(AssetScrollController):
     def _display_edge(self) -> int:
         icon = self._view.iconSize()
         return max(1, int(icon.width()), int(icon.height()))
+
+    def _demand_row_count(self, proxy_row_count: int) -> int:
+        del proxy_row_count
+        source = root_source_model(self._view.model())
+        return int(source.rowCount()) if source is not None else 0
 
     def _resolve_visible_range(self, row_count: int) -> tuple[int, int] | None:
         model = self._view.model()

--- a/src/iPhoto/gui/ui/widgets/filmstrip_viewport_controller.py
+++ b/src/iPhoto/gui/ui/widgets/filmstrip_viewport_controller.py
@@ -1,0 +1,96 @@
+"""Geometry-aware horizontal viewport demand for the Filmstrip surface."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QModelIndex, QPoint
+
+from ..models.proxy_mapping import map_to_root_source
+from ..models.roles import Roles
+from .gallery_scroll_controller import AssetScrollController
+
+
+class FilmstripViewportController(AssetScrollController):
+    """Publish source-row demand from non-uniform horizontal item geometry."""
+
+    def __init__(self, view, publish) -> None:
+        super().__init__(view, publish, surface_id="filmstrip", axis="horizontal")
+
+    def handle_wheel(self, event) -> bool:
+        # FilmstripView owns wheel-as-navigation behavior.
+        del event
+        return False
+
+    def _display_edge(self) -> int:
+        icon = self._view.iconSize()
+        return max(1, int(icon.width()), int(icon.height()))
+
+    def _resolve_visible_range(self, row_count: int) -> tuple[int, int] | None:
+        model = self._view.model()
+        viewport = self._view.viewport()
+        if model is None or row_count <= 0 or viewport.width() <= 0:
+            return None
+
+        anchor = self._find_anchor_index()
+        if not anchor.isValid():
+            return None
+
+        viewport_rect = viewport.rect()
+        visible_rows: list[int] = []
+
+        def collect(proxy_row: int) -> bool:
+            index = model.index(proxy_row, 0)
+            if not index.isValid():
+                return False
+            rect = self._view.visualRect(index)
+            if not rect.isValid() or not rect.intersects(viewport_rect):
+                return False
+            if not bool(index.data(Roles.IS_SPACER)):
+                source_index = map_to_root_source(index)
+                if source_index.isValid():
+                    visible_rows.append(int(source_index.row()))
+            return True
+
+        anchor_row = int(anchor.row())
+        collect(anchor_row)
+
+        for proxy_row in range(anchor_row - 1, -1, -1):
+            index = model.index(proxy_row, 0)
+            rect = self._view.visualRect(index)
+            if rect.isValid() and rect.right() < viewport_rect.left():
+                break
+            collect(proxy_row)
+
+        for proxy_row in range(anchor_row + 1, row_count):
+            index = model.index(proxy_row, 0)
+            rect = self._view.visualRect(index)
+            if rect.isValid() and rect.left() > viewport_rect.right():
+                break
+            collect(proxy_row)
+
+        if not visible_rows:
+            return None
+        return min(visible_rows), max(visible_rows)
+
+    def _find_anchor_index(self) -> QModelIndex:
+        viewport = self._view.viewport()
+        width = max(1, viewport.width())
+        height = max(1, viewport.height())
+        center_x = width // 2
+        xs = [center_x, 0, width - 1]
+        for offset in range(1, 9):
+            xs.extend((max(0, center_x - offset), min(width - 1, center_x + offset)))
+        ys = (height // 2, max(0, min(height - 1, self._view.iconSize().height() // 2)), 1)
+        seen: set[tuple[int, int]] = set()
+        for y in ys:
+            for x in xs:
+                point = (x, y)
+                if point in seen:
+                    continue
+                seen.add(point)
+                index = self._view.indexAt(QPoint(x, y))
+                if index.isValid():
+                    return index
+        return QModelIndex()
+
+
+__all__ = ["FilmstripViewportController"]

--- a/src/iPhoto/gui/ui/widgets/gallery_scroll_controller.py
+++ b/src/iPhoto/gui/ui/widgets/gallery_scroll_controller.py
@@ -6,6 +6,7 @@ import math
 import time
 from collections import deque
 from collections.abc import Callable
+from typing import Literal
 
 from PySide6.QtCore import QObject, QTimer
 from PySide6.QtWidgets import QApplication
@@ -17,29 +18,43 @@ from iPhoto.gui.gallery_demand import (
     SCROLL_DIRECTIONAL_DWELL_MS,
     SCROLL_SETTLED_TIMEOUT_MS,
     SCROLL_VELOCITY_EWMA_SECONDS,
-    GalleryViewportDemand,
+    AssetViewportDemand,
     build_viewport_demand,
     resolve_display_thumbnail_bucket,
 )
 from iPhoto.infrastructure.services.performance_events import emit_perf_event
 
-class GalleryScrollController(QObject):
-    """Keep wheel input responsive and publish at most one viewport state per event-loop turn."""
+class AssetScrollController(QObject):
+    """Track scroll intent and publish one surface demand per event-loop turn."""
 
-    def __init__(self, view, publish: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        view,
+        publish: Callable[[], None],
+        *,
+        surface_id: str,
+        axis: Literal["horizontal", "vertical"],
+    ) -> None:
         super().__init__(view)
         self._view = view
         self._publish = publish
+        self._surface_id = str(surface_id)
+        self._axis = axis
+        self._scrollbar = (
+            self._view.horizontalScrollBar()
+            if axis == "horizontal"
+            else self._view.verticalScrollBar()
+        )
         self._pending_pixel_delta = 0.0
         self._generation = 0
-        self._last_value = int(self._view.verticalScrollBar().value())
+        self._last_value = int(self._scrollbar.value())
         self._last_value_at = time.monotonic()
         self._direction = 0
         self._screens_per_second = 0.0
         self._input_kind = "none"
         self._intent = "idle"
         self._last_input_at = 0.0
-        self._last_demand: GalleryViewportDemand | None = None
+        self._last_demand: AssetViewportDemand | None = None
         self._angle_intervals_ms: deque[float] = deque(maxlen=4)
 
         self._apply_timer = QTimer(self)
@@ -61,7 +76,7 @@ class GalleryScrollController(QObject):
         self._direction_expiry_timer.setInterval(SCROLL_DIRECTION_RETENTION_MS)
         self._direction_expiry_timer.timeout.connect(self._publish_expired_direction)
 
-        self._view.verticalScrollBar().valueChanged.connect(self._on_scroll_value_changed)
+        self._scrollbar.valueChanged.connect(self._on_scroll_value_changed)
 
     def handle_wheel(self, event) -> bool:
         """Accumulate one wheel event without introducing inertial drag."""
@@ -127,21 +142,17 @@ class GalleryScrollController(QObject):
     def schedule_publish(self) -> None:
         self._publish()
 
-    def viewport_state(self, row_count: int) -> GalleryViewportDemand | None:
+    def viewport_state(self, row_count: int) -> AssetViewportDemand | None:
         if row_count <= 0:
             return None
-        cell_height = max(1, self._view.gridSize().height() or self._view.iconSize().height())
-        cell_width = max(1, self._view.gridSize().width() or self._view.iconSize().width())
+        resolved = self._resolve_visible_range(row_count)
+        if resolved is None:
+            return None
+        first, last = resolved
         viewport = self._view.viewport()
-        columns = max(1, viewport.width() // cell_width)
-        scroll_y = max(0, self._view.verticalScrollBar().value())
-        first_grid_row = scroll_y // cell_height
-        visible_grid_rows = max(1, math.ceil(viewport.height() / cell_height) + 1)
-        first = min(row_count - 1, first_grid_row * columns)
-        last = min(row_count - 1, (first_grid_row + visible_grid_rows) * columns - 1)
         dpr = max(1.0, float(viewport.devicePixelRatioF()))
         display_bucket = resolve_display_thumbnail_bucket(
-            max(1, self._view.iconSize().width()) * dpr
+            self._display_edge() * dpr
         )
         predicted_interval = (
             sum(self._angle_intervals_ms) / len(self._angle_intervals_ms)
@@ -149,6 +160,7 @@ class GalleryScrollController(QObject):
             else None
         )
         demand = build_viewport_demand(
+            surface_id=self._surface_id,
             generation=self._generation + 1,
             row_count=row_count,
             visible_first=first,
@@ -168,6 +180,7 @@ class GalleryScrollController(QObject):
         self._last_demand = demand
         emit_perf_event(
             "gallery_scroll_intent",
+            surface_id=self._surface_id,
             generation=demand.generation,
             input_kind=self._input_kind,
             intent=demand.intent,
@@ -178,12 +191,29 @@ class GalleryScrollController(QObject):
         )
         return demand
 
+    def _resolve_visible_range(self, row_count: int) -> tuple[int, int] | None:
+        """Return source-model rows visible on this controller's surface."""
+
+        cell_height = max(1, self._view.gridSize().height() or self._view.iconSize().height())
+        cell_width = max(1, self._view.gridSize().width() or self._view.iconSize().width())
+        viewport = self._view.viewport()
+        columns = max(1, viewport.width() // cell_width)
+        scroll_y = max(0, self._view.verticalScrollBar().value())
+        first_grid_row = scroll_y // cell_height
+        visible_grid_rows = max(1, math.ceil(viewport.height() / cell_height) + 1)
+        first = min(row_count - 1, first_grid_row * columns)
+        last = min(row_count - 1, (first_grid_row + visible_grid_rows) * columns - 1)
+        return first, max(first, last)
+
+    def _display_edge(self) -> int:
+        return max(1, int(self._view.iconSize().width()))
+
     def _apply_pending_scroll(self) -> None:
         delta = self._pending_pixel_delta
         self._pending_pixel_delta = 0.0
         if not delta:
             return
-        scrollbar = self._view.verticalScrollBar()
+        scrollbar = self._scrollbar
         target = max(
             scrollbar.minimum(),
             min(scrollbar.maximum(), scrollbar.value() + round(delta)),
@@ -197,8 +227,13 @@ class GalleryScrollController(QObject):
         elapsed = max(1e-6, now - self._last_value_at)
         distance = int(value) - self._last_value
         self._direction = 1 if distance > 0 else (-1 if distance < 0 else self._direction)
-        viewport_height = max(1, self._view.viewport().height())
-        instantaneous = abs(float(distance)) / elapsed / viewport_height
+        viewport_extent = max(
+            1,
+            self._view.viewport().width()
+            if self._axis == "horizontal"
+            else self._view.viewport().height(),
+        )
+        instantaneous = abs(float(distance)) / elapsed / viewport_extent
         alpha = 1.0 - math.exp(-elapsed / SCROLL_VELOCITY_EWMA_SECONDS)
         self._screens_per_second += alpha * (instantaneous - self._screens_per_second)
         recent_wheel_input = now - self._last_input_at <= 0.05
@@ -243,4 +278,11 @@ class GalleryScrollController(QObject):
         self._angle_intervals_ms.clear()
 
 
-__all__ = ["GalleryScrollController", "GalleryViewportDemand"]
+class GalleryScrollController(AssetScrollController):
+    """Vertical Gallery controller with low-latency wheel accumulation."""
+
+    def __init__(self, view, publish: Callable[[], None]) -> None:
+        super().__init__(view, publish, surface_id="gallery", axis="vertical")
+
+
+__all__ = ["AssetScrollController", "AssetViewportDemand", "GalleryScrollController"]

--- a/src/iPhoto/gui/ui/widgets/gallery_scroll_controller.py
+++ b/src/iPhoto/gui/ui/widgets/gallery_scroll_controller.py
@@ -40,6 +40,7 @@ class AssetScrollController(QObject):
         self._publish = publish
         self._surface_id = str(surface_id)
         self._axis = axis
+        self._suspended = not bool(self._view.isVisible())
         self._scrollbar = (
             self._view.horizontalScrollBar()
             if axis == "horizontal"
@@ -81,6 +82,8 @@ class AssetScrollController(QObject):
     def handle_wheel(self, event) -> bool:
         """Accumulate one wheel event without introducing inertial drag."""
 
+        if self._suspended:
+            return False
         now = time.monotonic()
         pixel_delta = event.pixelDelta()
         pixel_y = pixel_delta.y() if not pixel_delta.isNull() else 0
@@ -140,15 +143,43 @@ class AssetScrollController(QObject):
         return True
 
     def schedule_publish(self) -> None:
-        self._publish()
+        if not self._suspended:
+            self._publish()
+
+    def suspend(self) -> None:
+        """Stop delayed publications while the owning surface is hidden."""
+
+        self._suspended = True
+        self._pending_pixel_delta = 0.0
+        for timer in (
+            self._apply_timer,
+            self._idle_timer,
+            self._dwell_timer,
+            self._direction_expiry_timer,
+        ):
+            timer.stop()
+
+    def resume(self) -> None:
+        """Resume observation from the scrollbar's current position."""
+
+        self._suspended = False
+        self._last_value = int(self._scrollbar.value())
+        self._last_value_at = time.monotonic()
+        self._screens_per_second = 0.0
+        self._input_kind = "none"
+        self._intent = "idle"
+        self._clear_angle_cadence()
 
     def viewport_state(self, row_count: int) -> AssetViewportDemand | None:
-        if row_count <= 0:
+        if self._suspended or row_count <= 0:
             return None
         resolved = self._resolve_visible_range(row_count)
         if resolved is None:
             return None
         first, last = resolved
+        demand_row_count = self._demand_row_count(row_count)
+        if demand_row_count <= 0:
+            return None
         viewport = self._view.viewport()
         dpr = max(1.0, float(viewport.devicePixelRatioF()))
         display_bucket = resolve_display_thumbnail_bucket(
@@ -162,7 +193,7 @@ class AssetScrollController(QObject):
         demand = build_viewport_demand(
             surface_id=self._surface_id,
             generation=self._generation + 1,
-            row_count=row_count,
+            row_count=demand_row_count,
             visible_first=first,
             visible_last=max(first, last),
             direction=self._direction,
@@ -190,6 +221,9 @@ class AssetScrollController(QObject):
             display_bucket=display_bucket,
         )
         return demand
+
+    def _demand_row_count(self, proxy_row_count: int) -> int:
+        return max(0, int(proxy_row_count))
 
     def _resolve_visible_range(self, row_count: int) -> tuple[int, int] | None:
         """Return source-model rows visible on this controller's surface."""
@@ -223,6 +257,10 @@ class AssetScrollController(QObject):
         self.schedule_publish()
 
     def _on_scroll_value_changed(self, value: int) -> None:
+        if self._suspended:
+            self._last_value = int(value)
+            self._last_value_at = time.monotonic()
+            return
         now = time.monotonic()
         elapsed = max(1e-6, now - self._last_value_at)
         distance = int(value) - self._last_value

--- a/src/iPhoto/gui/ui/widgets/gallery_scroll_controller.py
+++ b/src/iPhoto/gui/ui/widgets/gallery_scroll_controller.py
@@ -20,9 +20,10 @@ from iPhoto.gui.gallery_demand import (
     SCROLL_VELOCITY_EWMA_SECONDS,
     AssetViewportDemand,
     build_viewport_demand,
-    resolve_display_thumbnail_bucket,
+    resolve_surface_thumbnail_bucket,
 )
 from iPhoto.infrastructure.services.performance_events import emit_perf_event
+
 
 class AssetScrollController(QObject):
     """Track scroll intent and publish one surface demand per event-loop turn."""
@@ -182,7 +183,8 @@ class AssetScrollController(QObject):
             return None
         viewport = self._view.viewport()
         dpr = max(1.0, float(viewport.devicePixelRatioF()))
-        display_bucket = resolve_display_thumbnail_bucket(
+        display_bucket = resolve_surface_thumbnail_bucket(
+            self._surface_id,
             self._display_edge() * dpr
         )
         predicted_interval = (

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -825,6 +825,12 @@ class GalleryCollectionStore:
         )
         current_surface_demand = self._surface_demands.get(result.surface_id)
         if (
+            result.purpose == "viewport"
+            and int(result.demand_generation) > 0
+            and current_surface_demand is None
+        ):
+            return False
+        if (
             current_surface_demand is not None
             and result.demand_generation < current_surface_demand.generation
         ):

--- a/src/iPhoto/gui/viewmodels/gallery_collection_store.py
+++ b/src/iPhoto/gui/viewmodels/gallery_collection_store.py
@@ -15,7 +15,7 @@ from iPhoto.gui.detail_profile import emit_detail_event
 from iPhoto.gui.gallery_demand import (
     MICRO_QUERY_CHUNK,
     MICRO_WARM_LIMIT,
-    GalleryViewportDemand,
+    AssetViewportDemand,
 )
 from iPhoto.gui.viewmodels.asset_dto_converter import (
     geotagged_asset_to_dto as _geotagged_asset_to_dto_fn,
@@ -145,6 +145,7 @@ class GalleryCollectionStore:
         self._window_range: Optional[tuple[int, int]] = None
         self._visible_range: Optional[tuple[int, int]] = None
         self._warm_range: Optional[tuple[int, int]] = None
+        self._surface_demands: dict[str, AssetViewportDemand] = {}
         self._active_root: Optional[Path] = None
         self._path_cache = PathExistsCache()
         self._pending_moves: List[_PendingMove] = []
@@ -375,8 +376,11 @@ class GalleryCollectionStore:
         self._reload_window_for_visible_range(row, row, emit_signals=emit_signals)
         return row in self._row_cache
 
-    def snapshot_signature(self) -> tuple[int, Optional[tuple[int, int]], int]:
-        return (self._total_count, self._window_range, self._collection_revision)
+    def snapshot_signature(
+        self,
+    ) -> tuple[int, Optional[tuple[tuple[int, int], ...]], int]:
+        ranges = self._cache_window_ranges()
+        return (self._total_count, ranges or None, self._collection_revision)
 
     def diagnostic_snapshot(self) -> dict[str, object]:
         """Return privacy-safe in-memory state for opt-in runtime diagnostics."""
@@ -386,6 +390,7 @@ class GalleryCollectionStore:
             "row_count": self._total_count,
             "cached_rows": len(self._row_cache),
             "window": self._window_range,
+            "window_ranges": self._cache_window_ranges(),
             "visible": self._visible_range,
             "collection_revision": self._collection_revision,
             "pinned_row": self._pinned_row,
@@ -697,12 +702,14 @@ class GalleryCollectionStore:
                 emit_source_changed=should_refresh,
             )
 
-    def reconcile_viewport_demand(self, demand: GalleryViewportDemand) -> None:
+    def reconcile_viewport_demand(self, demand: AssetViewportDemand) -> None:
         """Warm visible, hot, and micro ranges without replacing cached rows."""
 
-        self._visible_range = demand.visible_range
-        self._warm_range = demand.warm_range
-        self._window_range = demand.warm_range
+        self._surface_demands[demand.surface_id] = demand
+        primary = self._surface_demands.get("gallery", demand)
+        self._visible_range = primary.visible_range
+        self._warm_range = primary.warm_range
+        self._window_range = self._cache_window_range()
         self._demand_generation = max(self._demand_generation, int(demand.generation))
         if self._direct_mode or self._current_query is None:
             return
@@ -761,6 +768,7 @@ class GalleryCollectionStore:
                 chunk_last,
                 demand_generation=demand.generation,
                 priority=priority,
+                surface_id=demand.surface_id,
             )
         self.trim_row_cache_step()
         emit_perf_event(
@@ -775,7 +783,20 @@ class GalleryCollectionStore:
             warm_count=demand.warm_last - demand.warm_first + 1,
             cached_count=len(self._row_cache),
             queued_chunks=len(chunks),
+            surface_id=demand.surface_id,
         )
+
+    def release_viewport_demand(self, surface_id: str) -> None:
+        """Release one surface while retaining other sparse-window leases."""
+
+        self._surface_demands.pop(str(surface_id), None)
+        primary = self._surface_demands.get("gallery")
+        if primary is None and self._surface_demands:
+            primary = next(reversed(self._surface_demands.values()))
+        self._visible_range = primary.visible_range if primary is not None else None
+        self._warm_range = primary.warm_range if primary is not None else None
+        self._window_range = self._cache_window_range()
+        self.trim_row_cache_step()
 
     def apply_window_result(self, result: GalleryWindowResult) -> bool:
         """Publish one background-loaded window on the owning GUI thread."""
@@ -802,9 +823,10 @@ class GalleryCollectionStore:
             and self._anchor_result_matches_current(anchor_result)
             and result.generation >= self._selection_anchor_latest_result_generation
         )
+        current_surface_demand = self._surface_demands.get(result.surface_id)
         if (
-            self._demand_generation > 0
-            and result.demand_generation < self._demand_generation
+            current_surface_demand is not None
+            and result.demand_generation < current_surface_demand.generation
         ):
             relevant_rows = {
                 row: dto
@@ -1205,6 +1227,7 @@ class GalleryCollectionStore:
         request_backfill: bool = True,
         purpose: str = "viewport",
         selection_anchor_retry_attempt: int = 0,
+        surface_id: str = "gallery",
     ) -> bool:
         if (
             self._window_request_handler is None
@@ -1271,6 +1294,7 @@ class GalleryCollectionStore:
                 selection_anchor_retry_attempt=int(
                     selection_anchor_retry_attempt
                 ),
+                surface_id=str(surface_id),
             )
         )
         if self._selection_anchor is not None:
@@ -1288,9 +1312,21 @@ class GalleryCollectionStore:
             return True
         if row in self._pending_row_loads:
             return True
+        if any(
+            demand.warm_first <= row <= demand.warm_last
+            or demand.full_guard_first <= row <= demand.full_guard_last
+            for demand in self._surface_demands.values()
+        ):
+            return True
         if self._warm_range is None:
             return False
         return self._warm_range[0] <= row <= self._warm_range[1]
+
+    def _row_is_critical(self, row: int) -> bool:
+        return row == self._pinned_row or row in self._pending_row_loads or any(
+            demand.full_guard_first <= row <= demand.full_guard_last
+            for demand in self._surface_demands.values()
+        )
 
     def row_cache_needs_trim(self) -> bool:
         max_items = MICRO_WARM_LIMIT + (1 if self._pinned_row is not None else 0)
@@ -1317,6 +1353,11 @@ class GalleryCollectionStore:
                 ),
                 None,
             )
+            if evict is None:
+                evict = next(
+                    (row for row in self._row_cache if not self._row_is_critical(row)),
+                    None,
+                )
             if evict is None:
                 evict = next(
                     (row for row in self._row_cache if row != self._pinned_row),
@@ -1350,10 +1391,23 @@ class GalleryCollectionStore:
     def _cache_window_range(self) -> tuple[int, int] | None:
         if not self._row_cache or self._total_count <= 0:
             return None
-        if self._warm_range is not None:
-            return self._warm_range
         rows = self._row_cache.keys()
         return min(rows), max(rows)
+
+    def _cache_window_ranges(self) -> tuple[tuple[int, int], ...]:
+        rows = sorted(self._row_cache)
+        if not rows:
+            return ()
+        ranges: list[tuple[int, int]] = []
+        first = last = rows[0]
+        for row in rows[1:]:
+            if row == last + 1:
+                last = row
+                continue
+            ranges.append((first, last))
+            first = last = row
+        ranges.append((first, last))
+        return tuple(ranges)
 
     def pin_row(self, row: int) -> None:
         if row < 0 or row >= self._total_count:
@@ -2235,6 +2289,7 @@ class GalleryCollectionStore:
         self._window_range = None
         self._visible_range = None
         self._warm_range = None
+        self._surface_demands.clear()
         self._pinned_row = None
         self._selection_anchor = (
             GallerySelectionAnchor(

--- a/src/iPhoto/gui/viewmodels/gallery_demand_coordinator.py
+++ b/src/iPhoto/gui/viewmodels/gallery_demand_coordinator.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable, Mapping
 from PySide6.QtCore import QSize
 
 from iPhoto.application.dtos import AssetDTO
-from iPhoto.gui.gallery_demand import GalleryViewportDemand
+from iPhoto.gui.gallery_demand import AssetViewportDemand
 from iPhoto.infrastructure.services.thumbnail_cache_service import (
     ThumbnailDemandSnapshot,
     ThumbnailPrefetchCandidate,
@@ -25,26 +25,28 @@ class GalleryDemandCoordinator:
     """Merge viewport, row snapshots, and reusable hint results into one demand."""
 
     def __init__(self) -> None:
-        self.viewport: GalleryViewportDemand | None = None
+        self.viewports: dict[str, AssetViewportDemand] = {}
+        self._latest_surface_id = "gallery"
         self.root: Path | None = None
         self.query: Any | None = None
         self.collection_revision = 0
         self.revision = 0
-        self._scheduling_identity: tuple[object, ...] | None = None
+        self._scheduling_identities: dict[str, tuple[object, ...]] = {}
         self.hint_candidates_by_row: dict[int, GalleryThumbnailCandidate] = {}
 
     def reset(self) -> None:
-        self.viewport = None
+        self.viewports.clear()
+        self._latest_surface_id = "gallery"
         self.root = None
         self.query = None
         self.collection_revision = 0
         self.revision = 0
-        self._scheduling_identity = None
+        self._scheduling_identities.clear()
         self.hint_candidates_by_row.clear()
 
     def update_viewport(
         self,
-        viewport: GalleryViewportDemand,
+        viewport: AssetViewportDemand,
         *,
         root: Path | None,
         query: Any | None,
@@ -68,34 +70,53 @@ class GalleryDemandCoordinator:
             query,
             int(collection_revision),
         )
-        if scheduling_identity != self._scheduling_identity:
+        surface_id = viewport.surface_id
+        if scheduling_identity != self._scheduling_identities.get(surface_id):
             self.revision = max(self.revision + 1, int(viewport.generation))
-            self._scheduling_identity = scheduling_identity
+            self._scheduling_identities[surface_id] = scheduling_identity
         effective_viewport = (
             viewport
             if viewport.generation == self.revision
             else replace(viewport, generation=self.revision)
         )
-        self.viewport = effective_viewport
+        self.viewports[surface_id] = effective_viewport
+        self._latest_surface_id = surface_id
         self.root = root
         self.query = query
         self.collection_revision = int(collection_revision)
         self.prune_hints()
 
     def prune_hints(self) -> None:
-        if self.viewport is None or not self.hint_candidates_by_row:
+        if not self.viewports or not self.hint_candidates_by_row:
             return
-        first, last = self.viewport.full_prefetch_range
         self.hint_candidates_by_row = {
             row: candidate
             for row, candidate in self.hint_candidates_by_row.items()
-            if first <= row <= last
+            if any(
+                viewport.full_prefetch_first <= row <= viewport.full_prefetch_last
+                for viewport in self.viewports.values()
+            )
         }
+
+    @property
+    def viewport(self) -> AssetViewportDemand | None:
+        return self.viewports.get(self._latest_surface_id)
+
+    def viewport_for(self, surface_id: str) -> AssetViewportDemand | None:
+        return self.viewports.get(str(surface_id))
+
+    def release_viewport(self, surface_id: str) -> None:
+        surface_id = str(surface_id)
+        self.viewports.pop(surface_id, None)
+        self._scheduling_identities.pop(surface_id, None)
+        if self._latest_surface_id == surface_id:
+            self._latest_surface_id = next(reversed(self.viewports), "gallery")
+        self.prune_hints()
 
     def merge_hint_result(self, result: GalleryThumbnailHintResult) -> int:
         """Accept old-generation work when it still covers the current demand."""
 
-        viewport = self.viewport
+        viewport = self.viewport_for(getattr(result, "surface_id", "gallery"))
         if (
             viewport is None
             or result.error is not None
@@ -121,11 +142,12 @@ class GalleryDemandCoordinator:
     def build_thumbnail_snapshot(
         self,
         *,
+        surface_id: str = "gallery",
         visible_rows: Iterable[tuple[int, AssetDTO]],
         prefetched_rows: Mapping[int, AssetDTO],
         size: QSize,
     ) -> ThumbnailDemandSnapshot | None:
-        viewport = self.viewport
+        viewport = self.viewport_for(surface_id)
         if viewport is None:
             return None
         visible_rows = tuple(visible_rows)

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -548,6 +548,8 @@ class GalleryListModelAdapter(QAbstractListModel):
         """Release one view's row, hint, and thumbnail leases."""
 
         surface_id = str(surface_id)
+        self._window_loader.discard_queued(surface_id)
+        self._thumbnail_hint_loader.discard_queued(surface_id)
         self._demand_coordinator.release_viewport(surface_id)
         release_store = getattr(self._store, "release_viewport_demand", None)
         if callable(release_store):

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -26,7 +26,7 @@ from iPhoto.application.ports import EditServicePort
 from iPhoto.bootstrap.startup_profile import mark
 from iPhoto.domain.models.query import AssetQuery
 from iPhoto.gui.detail_pipeline import AssetSourceIdentity, DetailPrefetchDescriptor
-from iPhoto.gui.gallery_demand import GalleryViewportDemand
+from iPhoto.gui.gallery_demand import AssetViewportDemand
 from iPhoto.gui.ui.models.roles import Roles, role_names
 from iPhoto.infrastructure.services.performance_events import (
     emit_perf_event,
@@ -88,15 +88,16 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._thumbnails = thumbnail_service
         self._edit_service_getter = edit_service_getter
         self._thumb_size = QSize(512, 512)
+        self._surface_sizes: dict[str, QSize] = {"gallery": QSize(512, 512)}
         self._current_row = -1
         self._current_path: Path | None = None
-        self._last_snapshot: Optional[tuple[int, Optional[tuple[int, int]], int]] = None
+        self._last_snapshot: Optional[tuple[int, object, int]] = None
         self._last_selection_signature: tuple[str, str, str] | None = None
         self._last_window_identity_signature: tuple[str, ...] | None = None
         self._duration_cache: dict[Path, float] = {}
         self._pending_prioritize_range: tuple[int, int] | None = None
         self._viewport_generation = 0
-        self._viewport_demand: GalleryViewportDemand | None = None
+        self._viewport_demand: AssetViewportDemand | None = None
         self._demand_coordinator = GalleryDemandCoordinator()
         self._pending_thumbnail_rows: set[int] = set()
         self._locally_stale_thumbnail_paths: set[Path] = set()
@@ -290,48 +291,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         if role_int == Qt.ItemDataRole.DisplayRole:
             return asset.rel_path.name
         if role_int == Roles.TILE_SNAPSHOT:
-            thumbnail_current = (
-                asset.abs_path not in self._locally_stale_thumbnail_paths
-                and (
-                    asset.thumbnail_state == "ready"
-                    or asset.abs_path in self._published_thumbnail_paths
-                )
-            )
-            full = (
-                self._thumbnails.peek_full_thumbnail(asset.abs_path, self._thumb_size)
-                if thumbnail_current
-                else None
-            )
-            micro = (
-                asset.micro_thumbnail
-                if thumbnail_current
-                and asset.thumbnail_state == "ready"
-                and isinstance(asset.micro_thumbnail, QImage)
-                else None
-            )
-            loading_state = (
-                "full"
-                if isinstance(full, QPixmap) and not full.isNull()
-                else "micro"
-                if micro is not None and not micro.isNull()
-                else "placeholder"
-            )
-            return GalleryTileSnapshot(
-                record=GalleryTileRecord(
-                    asset_id=str(asset.id),
-                    abs_path=asset.abs_path,
-                    rel_path=asset.rel_path,
-                    media_type=asset.media_type,
-                    duration=asset.duration,
-                    is_favorite=asset.is_favorite,
-                    is_live=asset.is_live,
-                    is_pano=asset.is_pano,
-                ),
-                micro_image=micro,
-                full_pixmap=full if isinstance(full, QPixmap) else None,
-                loading_state=loading_state,
-                is_current=row == self._current_row,
-            )
+            return self._tile_snapshot_for_asset(row, asset, "gallery")
         if role_int == Qt.DecorationRole:
             if (
                 asset.abs_path in self._locally_stale_thumbnail_paths
@@ -341,7 +301,7 @@ class GalleryListModelAdapter(QAbstractListModel):
                 )
             ):
                 return None
-            return self._thumbnails.peek_full_thumbnail(asset.abs_path, self._thumb_size)
+            return self.full_thumbnail(row, "gallery")
         if role_int == Qt.ItemDataRole.ToolTipRole:
             return str(asset.abs_path)
 
@@ -402,6 +362,79 @@ class GalleryListModelAdapter(QAbstractListModel):
         if role_int == Roles.IS_PANO:
             return asset.is_pano
         return None
+
+    def tile_snapshot(self, row: int, surface_id: str = "gallery") -> GalleryTileSnapshot:
+        """Return one surface-sized tile snapshot without performing I/O."""
+
+        asset = self._store.asset_at(int(row))
+        if asset is None:
+            return GalleryTileSnapshot(
+                record=None,
+                micro_image=None,
+                full_pixmap=None,
+                loading_state="placeholder",
+                is_current=int(row) == self._current_row,
+            )
+        return self._tile_snapshot_for_asset(int(row), asset, str(surface_id))
+
+    def full_thumbnail(self, row: int, surface_id: str = "gallery") -> Any:
+        """Peek one surface's full thumbnail from L1 only."""
+
+        asset = self._store.asset_at(int(row))
+        if asset is None or asset.abs_path in self._locally_stale_thumbnail_paths:
+            return None
+        if (
+            asset.thumbnail_state != "ready"
+            and asset.abs_path not in self._published_thumbnail_paths
+        ):
+            return None
+        size = self._surface_sizes.get(str(surface_id), self._surface_sizes["gallery"])
+        return self._thumbnails.peek_full_thumbnail(asset.abs_path, size)
+
+    def _tile_snapshot_for_asset(
+        self,
+        row: int,
+        asset: AssetDTO,
+        surface_id: str,
+    ) -> GalleryTileSnapshot:
+        thumbnail_current = (
+            asset.abs_path not in self._locally_stale_thumbnail_paths
+            and (
+                asset.thumbnail_state == "ready"
+                or asset.abs_path in self._published_thumbnail_paths
+            )
+        )
+        full = self.full_thumbnail(row, surface_id) if thumbnail_current else None
+        micro = (
+            asset.micro_thumbnail
+            if thumbnail_current
+            and asset.thumbnail_state == "ready"
+            and isinstance(asset.micro_thumbnail, QImage)
+            else None
+        )
+        loading_state = (
+            "full"
+            if isinstance(full, QPixmap) and not full.isNull()
+            else "micro"
+            if micro is not None and not micro.isNull()
+            else "placeholder"
+        )
+        return GalleryTileSnapshot(
+            record=GalleryTileRecord(
+                asset_id=str(asset.id),
+                abs_path=asset.abs_path,
+                rel_path=asset.rel_path,
+                media_type=asset.media_type,
+                duration=asset.duration,
+                is_favorite=asset.is_favorite,
+                is_live=asset.is_live,
+                is_pano=asset.is_pano,
+            ),
+            micro_image=micro,
+            full_pixmap=full if isinstance(full, QPixmap) else None,
+            loading_state=loading_state,
+            is_current=row == self._current_row,
+        )
 
     def info_for_row(self, row: int) -> Optional[dict[str, Any]]:
         asset = self._store.asset_at(row)
@@ -474,7 +507,7 @@ class GalleryListModelAdapter(QAbstractListModel):
     def update_viewport(self, state: object) -> None:
         """Continuously reconcile micro warm-up and full-thumbnail demand."""
 
-        if not isinstance(state, GalleryViewportDemand):
+        if not isinstance(state, AssetViewportDemand):
             return
         if not self._startup_diag_logged_viewport:
             self._startup_diag_logged_viewport = True
@@ -492,11 +525,16 @@ class GalleryListModelAdapter(QAbstractListModel):
             query=self._store.current_query(),
             collection_revision=self._current_collection_revision(),
         )
-        effective = self._demand_coordinator.viewport or state
-        self._thumb_size = QSize(effective.display_bucket, effective.display_bucket)
-        self._viewport_generation = effective.generation
-        self._viewport_demand = effective
-        if self._startup_gallery_warmup_active:
+        effective = self._demand_coordinator.viewport_for(state.surface_id) or state
+        surface_size = QSize(effective.display_bucket, effective.display_bucket)
+        self._surface_sizes[effective.surface_id] = surface_size
+        if effective.surface_id == "gallery":
+            self._thumb_size = surface_size
+        if effective.surface_id == "gallery":
+            self._viewport_generation = effective.generation
+            self._viewport_demand = effective
+        gallery_startup = self._startup_gallery_warmup_active and effective.surface_id == "gallery"
+        if gallery_startup:
             self._startup_gallery_viewport_seen = True
             mark("gallery_startup_warmup.viewport_demand")
             self._store.reconcile_viewport_demand(effective)
@@ -504,7 +542,21 @@ class GalleryListModelAdapter(QAbstractListModel):
         else:
             self._store.reconcile_viewport_demand(effective)
             self._request_thumbnail_hints(effective)
-        self._reconcile_full_thumbnail_demand()
+        self._reconcile_full_thumbnail_demand(effective.surface_id)
+
+    def release_viewport_surface(self, surface_id: str) -> None:
+        """Release one view's row, hint, and thumbnail leases."""
+
+        surface_id = str(surface_id)
+        self._demand_coordinator.release_viewport(surface_id)
+        release_store = getattr(self._store, "release_viewport_demand", None)
+        if callable(release_store):
+            release_store(surface_id)
+        release_thumbnails = getattr(self._thumbnails, "release_surface_demand", None)
+        if callable(release_thumbnails):
+            release_thumbnails(surface_id)
+        if surface_id == "gallery":
+            self._viewport_demand = None
 
     @Slot()
     def _flush_pending_prioritize_rows(self) -> None:
@@ -552,7 +604,7 @@ class GalleryListModelAdapter(QAbstractListModel):
                 )
             if self._store.row_cache_needs_trim() and not self._micro_trim_timer.isActive():
                 self._micro_trim_timer.start()
-            self._reconcile_full_thumbnail_demand()
+            self._reconcile_full_thumbnail_demand(getattr(result, "surface_id", "gallery"))
             self._maybe_finish_startup_gallery_warmup("window_applied")
 
     @Slot()
@@ -659,11 +711,13 @@ class GalleryListModelAdapter(QAbstractListModel):
         if desired_revision:
             self._locally_stale_thumbnail_paths.add(path)
             self._published_thumbnail_paths.pop(path, None)
-        self._thumbnails.invalidate(
-            path,
-            size=self._thumb_size,
-            desired_revision=desired_revision,
-        )
+        sizes = {size.width(): size for size in self._surface_sizes.values()}
+        for size in sizes.values():
+            self._thumbnails.invalidate(
+                path,
+                size=size,
+                desired_revision=desired_revision,
+            )
         self._duration_cache.pop(path, None)
         row = self._store.row_for_path(path)
         if row is None:
@@ -685,6 +739,7 @@ class GalleryListModelAdapter(QAbstractListModel):
                 self._thumb_size,
                 priority="high",
             )
+        self._reconcile_full_thumbnail_demand()
         idx = self.index(row, 0)
         if idx.isValid():
             self.dataChanged.emit(
@@ -910,75 +965,100 @@ class GalleryListModelAdapter(QAbstractListModel):
     def _republish_thumbnail_demand_for_collection_revision(self) -> None:
         """Rebuild guard demand even when the viewport itself did not move."""
 
-        demand = self._viewport_demand
-        if demand is None:
-            return
-        self._ensure_coordinator_viewport(demand)
-        effective = self._viewport_demand or demand
-        self._viewport_generation = effective.generation
-        self._request_thumbnail_hints(
-            effective,
-            guard_only=self._startup_gallery_warmup_active,
-        )
+        for surface_id, demand in tuple(self._demand_coordinator.viewports.items()):
+            self._ensure_coordinator_viewport(demand)
+            effective = self._demand_coordinator.viewport_for(surface_id) or demand
+            if surface_id == "gallery":
+                self._viewport_demand = effective
+                self._viewport_generation = effective.generation
+            self._request_thumbnail_hints(
+                effective,
+                guard_only=self._startup_gallery_warmup_active and surface_id == "gallery",
+            )
         self._reconcile_full_thumbnail_demand()
 
     def _emit_data_refresh(
         self,
-        previous_window: Optional[tuple[int, int]],
-        current_window: Optional[tuple[int, int]],
+        previous_window: object,
+        current_window: object,
     ) -> None:
         count = self.rowCount()
         if count <= 0:
             return
-        windows = [
-            window
-            for window in (previous_window, current_window)
-            if window is not None
-        ]
-        if windows:
-            first = min(window[0] for window in windows)
-            last = max(window[1] for window in windows)
-        else:
-            first = 0
-            last = count - 1
-        first = max(0, min(first, count - 1))
-        last = max(first, min(last, count - 1))
-        emit_perf_event(
-            "gallery_model_data_refresh",
-            rows=count,
-            first=first,
-            last=last,
+        windows = self._normalise_window_ranges(previous_window) + self._normalise_window_ranges(
+            current_window
         )
-        top = self.index(first, 0)
-        bottom = self.index(last, 0)
-        if top.isValid() and bottom.isValid():
-            self.dataChanged.emit(top, bottom, [])
+        if not windows:
+            windows = ((0, count - 1),)
+        merged: list[list[int]] = []
+        for first, last in sorted(windows):
+            first = max(0, min(first, count - 1))
+            last = max(first, min(last, count - 1))
+            if merged and first <= merged[-1][1] + 1:
+                merged[-1][1] = max(merged[-1][1], last)
+            else:
+                merged.append([first, last])
+        for first, last in merged:
+            emit_perf_event(
+                "gallery_model_data_refresh",
+                rows=count,
+                first=first,
+                last=last,
+            )
+            top = self.index(first, 0)
+            bottom = self.index(last, 0)
+            if top.isValid() and bottom.isValid():
+                self.dataChanged.emit(top, bottom, [])
 
     def _window_identity_signature(
         self,
-        window: Optional[tuple[int, int]],
+        window: object,
     ) -> tuple[str, ...] | None:
         count = self.rowCount()
         if count <= 0:
             return ()
-        if window is None:
+        windows = self._normalise_window_ranges(window)
+        if not windows:
             return None
-        first = max(0, min(window[0], count - 1))
-        last = max(first, min(window[1], count - 1))
         identity: list[str] = []
-        for row in range(first, last + 1):
-            asset = self._store.asset_at(row)
-            if asset is None:
-                return None
-            key = (
-                getattr(asset, "id", None)
-                or getattr(asset, "abs_path", None)
-                or getattr(asset, "rel_path", None)
-            )
-            if key is None:
-                return None
-            identity.append(str(key))
+        for range_first, range_last in windows:
+            first = max(0, min(range_first, count - 1))
+            last = max(first, min(range_last, count - 1))
+            for row in range(first, last + 1):
+                asset = self._store.asset_at(row)
+                if asset is None:
+                    return None
+                key = (
+                    getattr(asset, "id", None)
+                    or getattr(asset, "abs_path", None)
+                    or getattr(asset, "rel_path", None)
+                )
+                if key is None:
+                    return None
+                identity.append(str(key))
         return tuple(identity)
+
+    @staticmethod
+    def _normalise_window_ranges(window: object) -> tuple[tuple[int, int], ...]:
+        if window is None:
+            return ()
+        if (
+            isinstance(window, tuple)
+            and len(window) == 2
+            and all(isinstance(value, int) for value in window)
+        ):
+            return ((int(window[0]), int(window[1])),)
+        if isinstance(window, (tuple, list)):
+            ranges: list[tuple[int, int]] = []
+            for candidate in window:
+                if (
+                    isinstance(candidate, (tuple, list))
+                    and len(candidate) == 2
+                    and all(isinstance(value, int) for value in candidate)
+                ):
+                    ranges.append((int(candidate[0]), int(candidate[1])))
+            return tuple(ranges)
+        return ()
 
     def _selection_signature(self) -> tuple[str, str, str]:
         active_root = getattr(self._store, "active_root", lambda: None)()
@@ -998,18 +1078,28 @@ class GalleryListModelAdapter(QAbstractListModel):
         count = self.rowCount()
         if count <= 0:
             return
-        demand = self._viewport_demand
-        if demand is not None:
-            first = max(first, demand.visible_first)
-            last = min(last, demand.visible_last)
-            if last < first:
-                return
-        first = max(0, min(first, count - 1))
-        last = max(first, min(last, count - 1))
-        top = self.index(first, 0)
-        bottom = self.index(last, 0)
-        if top.isValid() and bottom.isValid():
-            self.dataChanged.emit(top, bottom, [])
+        demands = tuple(self._demand_coordinator.viewports.values())
+        ranges = []
+        if demands:
+            for demand in demands:
+                visible_first = max(first, demand.visible_first)
+                visible_last = min(last, demand.visible_last)
+                if visible_last >= visible_first:
+                    ranges.append((visible_first, visible_last))
+        elif self._viewport_demand is not None:
+            visible_first = max(first, self._viewport_demand.visible_first)
+            visible_last = min(last, self._viewport_demand.visible_last)
+            if visible_last >= visible_first:
+                ranges.append((visible_first, visible_last))
+        else:
+            ranges.append((first, last))
+        for range_first, range_last in dict.fromkeys(ranges):
+            range_first = max(0, min(range_first, count - 1))
+            range_last = max(range_first, min(range_last, count - 1))
+            top = self.index(range_first, 0)
+            bottom = self.index(range_last, 0)
+            if top.isValid() and bottom.isValid():
+                self.dataChanged.emit(top, bottom, [])
 
     def _on_thumbnail_ready(self, path: Path) -> None:
         path = Path(path)
@@ -1239,18 +1329,29 @@ class GalleryListModelAdapter(QAbstractListModel):
             **snapshot,
         )
 
-    def _reconcile_full_thumbnail_demand(self) -> None:
-        demand = self._viewport_demand
+    def _reconcile_full_thumbnail_demand(self, surface_id: str | None = None) -> None:
+        if not self._demand_coordinator.viewports and self._viewport_demand is not None:
+            self._ensure_coordinator_viewport(self._viewport_demand)
+        surface_ids = (
+            (str(surface_id),)
+            if surface_id is not None
+            else tuple(self._demand_coordinator.viewports)
+        )
+        for current_surface in surface_ids:
+            self._reconcile_surface_thumbnail_demand(current_surface)
+
+    def _reconcile_surface_thumbnail_demand(self, surface_id: str) -> None:
+        demand = self._demand_coordinator.viewport_for(surface_id)
         if demand is None:
             return
         self._ensure_coordinator_viewport(demand)
-        demand = self._viewport_demand or demand
+        demand = self._demand_coordinator.viewport_for(surface_id) or demand
         visible_rows = self._store.cached_rows(*demand.visible_range)
-        if self._startup_gallery_warmup_active:
+        if self._startup_gallery_warmup_active and surface_id == "gallery":
             startup_snapshot = self._startup_thumbnail_snapshot(demand, visible_rows)
             if startup_snapshot is not None:
                 mark("gallery_startup_warmup.visible_demand_reconciled")
-                self._thumbnails.reconcile_demand(startup_snapshot)
+                self._submit_thumbnail_demand(surface_id, startup_snapshot)
                 self._maybe_finish_startup_gallery_warmup("demand_terminal")
             return
         prefetched_rows = dict(self._store.cached_rows(*demand.full_prefetch_range))
@@ -1258,9 +1359,10 @@ class GalleryListModelAdapter(QAbstractListModel):
         guard_rows = tuple(demand.iter_full_guard_rows())
         speculative_rows = tuple(demand.iter_full_speculative_rows())
         snapshot = self._demand_coordinator.build_thumbnail_snapshot(
+            surface_id=surface_id,
             visible_rows=visible_rows,
             prefetched_rows=prefetched_rows,
-            size=self._thumb_size,
+            size=self._surface_sizes.get(surface_id, self._surface_sizes["gallery"]),
         )
         if snapshot is None:
             return
@@ -1268,7 +1370,10 @@ class GalleryListModelAdapter(QAbstractListModel):
             full_count = 0
             micro_count = 0
             for _row, dto in visible_rows:
-                if self._thumbnails.has_full_thumbnail(dto.abs_path, self._thumb_size) is True:
+                if self._thumbnails.has_full_thumbnail(
+                    dto.abs_path,
+                    self._surface_sizes.get(surface_id, self._surface_sizes["gallery"]),
+                ) is True:
                     full_count += 1
                 elif isinstance(dto.micro_thumbnail, QImage) and not dto.micro_thumbnail.isNull():
                     micro_count += 1
@@ -1278,11 +1383,12 @@ class GalleryListModelAdapter(QAbstractListModel):
                 if row in prefetched_rows
                 and self._thumbnails.has_full_thumbnail(
                     prefetched_rows[row].abs_path,
-                    self._thumb_size,
+                    self._surface_sizes.get(surface_id, self._surface_sizes["gallery"]),
                 )
             )
             emit_perf_event(
                 "gallery_visible_layers",
+                surface_id=surface_id,
                 generation=demand.generation,
                 phase=demand.phase,
                 visible=visible_count,
@@ -1292,21 +1398,37 @@ class GalleryListModelAdapter(QAbstractListModel):
             )
             emit_perf_event(
                 "gallery_full_resident_before_visible",
+                surface_id=surface_id,
                 generation=demand.generation,
                 guard_rows=len(guard_rows),
                 speculative_rows=len(speculative_rows),
                 resident=guard_resident,
                 guard_coverage=(guard_resident / len(guard_rows) if guard_rows else 1.0),
             )
-        self._thumbnails.reconcile_demand(snapshot)
+        self._submit_thumbnail_demand(surface_id, snapshot)
+
+    def _submit_thumbnail_demand(
+        self,
+        surface_id: str,
+        snapshot: ThumbnailDemandSnapshot,
+    ) -> None:
+        # Keep the established Gallery entry point for embedders; secondary
+        # surfaces use the explicit lease API.
+        if surface_id == "gallery":
+            self._thumbnails.reconcile_demand(snapshot)
+            return
+        upsert = getattr(self._thumbnails, "upsert_surface_demand", None)
+        if callable(upsert):
+            upsert(surface_id, snapshot)
 
     def _startup_thumbnail_snapshot(
         self,
-        demand: GalleryViewportDemand,
+        demand: AssetViewportDemand,
         visible_rows: list[tuple[int, AssetDTO]],
     ):
         guard_rows = dict(self._store.cached_rows(*demand.full_guard_range))
         snapshot = self._demand_coordinator.build_thumbnail_snapshot(
+            surface_id="gallery",
             visible_rows=visible_rows,
             prefetched_rows=guard_rows,
             size=self._thumb_size,
@@ -1328,13 +1450,13 @@ class GalleryListModelAdapter(QAbstractListModel):
 
     def _request_thumbnail_hints(
         self,
-        demand: GalleryViewportDemand,
+        demand: AssetViewportDemand,
         *,
         guard_only: bool = False,
     ) -> None:
         if demand.intent == "continuous_burst":
             self._thumbnail_hint_request_id += 1
-            self._thumbnail_hint_loader.discard_queued()
+            self._thumbnail_hint_loader.discard_queued(demand.surface_id)
             return
         query = self._store.current_query()
         root = self._store.active_root() or self._store.library_root()
@@ -1382,6 +1504,7 @@ class GalleryListModelAdapter(QAbstractListModel):
                 limit=last - first + 1,
                 ordered_rows=ordered_rows,
                 guard_rows=guard_rows,
+                surface_id=demand.surface_id,
             )
         )
 
@@ -1422,17 +1545,21 @@ class GalleryListModelAdapter(QAbstractListModel):
     ) -> tuple[GalleryThumbnailCandidate, ...]:
         return self._demand_coordinator.hint_candidates(ordered_rows, guard_rows)
 
-    def _prune_thumbnail_hint_candidates(self, demand: GalleryViewportDemand) -> None:
+    def _prune_thumbnail_hint_candidates(self, demand: AssetViewportDemand) -> None:
         del demand
         self._demand_coordinator.prune_hints()
 
     @Slot(object)
     def _on_thumbnail_hint_result(self, result: GalleryThumbnailHintResult) -> None:
-        demand = self._viewport_demand
+        surface_id = getattr(result, "surface_id", "gallery")
+        demand = self._demand_coordinator.viewport_for(surface_id)
+        if demand is None and surface_id == "gallery" and self._viewport_demand is not None:
+            self._ensure_coordinator_viewport(self._viewport_demand)
+            demand = self._demand_coordinator.viewport_for(surface_id)
         if demand is None or demand.intent == "continuous_burst":
             return
         self._ensure_coordinator_viewport(demand)
-        demand = self._viewport_demand or demand
+        demand = self._demand_coordinator.viewport_for(surface_id) or demand
         merged = self._demand_coordinator.merge_hint_result(result)
         if not merged:
             return
@@ -1447,9 +1574,9 @@ class GalleryListModelAdapter(QAbstractListModel):
             ),
             total=merged,
         )
-        self._reconcile_full_thumbnail_demand()
+        self._reconcile_full_thumbnail_demand(surface_id)
 
-    def _ensure_coordinator_viewport(self, demand: GalleryViewportDemand) -> None:
+    def _ensure_coordinator_viewport(self, demand: AssetViewportDemand) -> None:
         """Keep private/test entry points on the same coordinator-owned state."""
 
         self._demand_coordinator.update_viewport(
@@ -1458,7 +1585,9 @@ class GalleryListModelAdapter(QAbstractListModel):
             query=self._store.current_query(),
             collection_revision=self._current_collection_revision(),
         )
-        self._viewport_demand = self._demand_coordinator.viewport or demand
+        effective = self._demand_coordinator.viewport_for(demand.surface_id) or demand
+        if demand.surface_id == "gallery":
+            self._viewport_demand = effective
 
     def _thumbnail_hint_result_matches_current_selection(
         self,

--- a/src/iPhoto/gui/viewmodels/gallery_thumbnail_hint_loader.py
+++ b/src/iPhoto/gui/viewmodels/gallery_thumbnail_hint_loader.py
@@ -38,6 +38,7 @@ class GalleryThumbnailHintRequest:
     limit: int
     ordered_rows: tuple[int, ...]
     guard_rows: frozenset[int]
+    surface_id: str = "gallery"
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +53,7 @@ class GalleryThumbnailHintResult:
     candidates: tuple[GalleryThumbnailCandidate, ...]
     elapsed_ms: float
     error: str | None = None
+    surface_id: str = "gallery"
 
 
 class _HintSignals(QObject):
@@ -133,6 +135,7 @@ class _HintWorker(QRunnable):
                 limit=request.limit,
                 candidates=candidates,
                 elapsed_ms=(time.perf_counter() - started) * 1000.0,
+                surface_id=request.surface_id,
             )
         except Exception as exc:  # noqa: BLE001 - worker boundary
             result = GalleryThumbnailHintResult(
@@ -146,6 +149,7 @@ class _HintWorker(QRunnable):
                 candidates=(),
                 elapsed_ms=(time.perf_counter() - started) * 1000.0,
                 error=f"{type(exc).__name__}: {exc}",
+                surface_id=request.surface_id,
             )
         self._signals.completed.emit(result)
 
@@ -160,26 +164,34 @@ class GalleryThumbnailHintLoader(QObject):
         self._pool = QThreadPool(self)
         self._pool.setMaxThreadCount(1)
         self._active = False
-        self._queued: GalleryThumbnailHintRequest | None = None
+        self._active_surface_id: str | None = None
+        self._queued: dict[str, GalleryThumbnailHintRequest] = {}
         self._signals: _HintSignals | None = None
         self._latest_request_id = 0
-        self._minimum_valid_request_id = 0
+        self._minimum_valid_request_ids: dict[str, int] = {}
 
     def request(self, request: GalleryThumbnailHintRequest) -> None:
         self._latest_request_id = max(self._latest_request_id, int(request.request_id))
         if self._active:
-            self._queued = request
+            self._queued[request.surface_id] = request
             return
         self._start(request)
 
-    def discard_queued(self) -> None:
+    def discard_queued(self, surface_id: str | None = None) -> None:
         """Drop coalesced work without invalidating the active read."""
 
-        self._queued = None
+        if surface_id is None:
+            self._queued.clear()
+        else:
+            self._queued.pop(str(surface_id), None)
 
     def cancel_pending(self) -> None:
+        surface_ids = set(self._queued)
         self.discard_queued()
-        self._minimum_valid_request_id = self._latest_request_id + 1
+        if self._active_surface_id is not None:
+            surface_ids.add(self._active_surface_id)
+        for surface_id in surface_ids or {"gallery", "filmstrip"}:
+            self._minimum_valid_request_ids[surface_id] = self._latest_request_id + 1
         self._pool.clear()
 
     def shutdown(self) -> None:
@@ -187,6 +199,7 @@ class GalleryThumbnailHintLoader(QObject):
 
     def _start(self, request: GalleryThumbnailHintRequest) -> None:
         self._active = True
+        self._active_surface_id = request.surface_id
         signals = _HintSignals()
         signals.completed.connect(self._handle_completed)
         self._signals = signals
@@ -197,9 +210,9 @@ class GalleryThumbnailHintLoader(QObject):
             self._signals.deleteLater()
         self._signals = None
         self._active = False
-        if result.request_id < self._minimum_valid_request_id:
-            queued = self._queued
-            self._queued = None
+        self._active_surface_id = None
+        if result.request_id < self._minimum_valid_request_ids.get(result.surface_id, 0):
+            queued = self._pop_queued()
             if queued is not None:
                 self._start(queued)
             return
@@ -211,10 +224,15 @@ class GalleryThumbnailHintLoader(QObject):
             error=result.error,
         )
         self.resultReady.emit(result)
-        queued = self._queued
-        self._queued = None
+        queued = self._pop_queued()
         if queued is not None:
             self._start(queued)
+
+    def _pop_queued(self) -> GalleryThumbnailHintRequest | None:
+        if not self._queued:
+            return None
+        surface_id = next(iter(self._queued))
+        return self._queued.pop(surface_id)
 
 
 __all__ = [

--- a/src/iPhoto/gui/viewmodels/gallery_window_loader.py
+++ b/src/iPhoto/gui/viewmodels/gallery_window_loader.py
@@ -67,6 +67,7 @@ class GalleryWindowRequest:
     priority: int = 1
     purpose: Literal["viewport", "selection_anchor_retry"] = "viewport"
     selection_anchor_retry_attempt: int = 0
+    surface_id: str = "gallery"
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +86,7 @@ class GalleryWindowResult:
     selection_anchor_result: GallerySelectionAnchorResult | None = None
     purpose: Literal["viewport", "selection_anchor_retry"] = "viewport"
     selection_anchor_retry_attempt: int = 0
+    surface_id: str = "gallery"
 
 
 class _GalleryWindowSignals(QObject):
@@ -278,6 +280,7 @@ class _GalleryWindowWorker(QRunnable):
                     selection_anchor_retry_attempt=(
                         request.selection_anchor_retry_attempt
                     ),
+                    surface_id=request.surface_id,
                 )
             )
             request_backfill = getattr(request.query_service, "request_thumbnail_backfill", None)
@@ -312,6 +315,7 @@ class _GalleryWindowWorker(QRunnable):
                     selection_anchor_retry_attempt=(
                         request.selection_anchor_retry_attempt
                     ),
+                    surface_id=request.surface_id,
                 )
             )
 
@@ -329,17 +333,22 @@ class GalleryWindowLoader(QObject):
         self._active_generation: int | None = None
         self._active_request: GalleryWindowRequest | None = None
         self._queued_requests: list[GalleryWindowRequest] = []
-        self._latest_demand_generation = 0
+        self._latest_demand_generations: dict[str, int] = {}
+        self._last_started_surface: str | None = None
         self._signals: dict[int, _GalleryWindowSignals] = {}
 
     def request(self, request: GalleryWindowRequest) -> None:
         demand_generation = int(request.demand_generation)
-        if demand_generation > self._latest_demand_generation:
-            self._latest_demand_generation = demand_generation
+        surface_id = str(request.surface_id)
+        latest_generation = self._latest_demand_generations.get(surface_id, 0)
+        if demand_generation > latest_generation:
+            self._latest_demand_generations[surface_id] = demand_generation
             dropped = [
                 queued.generation
                 for queued in self._queued_requests
                 if (
+                    queued.surface_id == surface_id
+                    and
                     int(queued.demand_generation) < demand_generation
                     and int(queued.demand_generation) > 0
                 )
@@ -348,13 +357,14 @@ class GalleryWindowLoader(QObject):
                 queued
                 for queued in self._queued_requests
                 if (
-                    int(queued.demand_generation) >= demand_generation
+                    queued.surface_id != surface_id
+                    or int(queued.demand_generation) >= demand_generation
                     or int(queued.demand_generation) == 0
                 )
             ]
             if dropped:
                 self.requestsDropped.emit(tuple(dropped))
-        elif demand_generation > 0 and demand_generation < self._latest_demand_generation:
+        elif demand_generation > 0 and demand_generation < latest_generation:
             self.requestsDropped.emit((request.generation,))
             return
 
@@ -379,7 +389,10 @@ class GalleryWindowLoader(QObject):
     def shutdown(self) -> None:
         dropped = tuple(request.generation for request in self._queued_requests)
         self._queued_requests.clear()
-        self._latest_demand_generation += 1
+        self._latest_demand_generations = {
+            surface_id: generation + 1
+            for surface_id, generation in self._latest_demand_generations.items()
+        }
         self._pool.clear()
         if dropped:
             self.requestsDropped.emit(dropped)
@@ -387,6 +400,7 @@ class GalleryWindowLoader(QObject):
     def _start(self, request: GalleryWindowRequest) -> None:
         self._active_generation = request.generation
         self._active_request = request
+        self._last_started_surface = request.surface_id
         signals = _GalleryWindowSignals()
         signals.completed.connect(self._handle_completed)
         self._signals[request.generation] = signals
@@ -408,7 +422,11 @@ class GalleryWindowLoader(QObject):
             return
         best_index = min(
             range(len(self._queued_requests)),
-            key=lambda index: self._queued_requests[index].priority,
+            key=lambda index: (
+                self._queued_requests[index].priority,
+                self._queued_requests[index].surface_id == self._last_started_surface,
+                -int(self._queued_requests[index].demand_generation),
+            ),
         )
         self._start(self._queued_requests.pop(best_index))
 
@@ -430,6 +448,7 @@ class GalleryWindowLoader(QObject):
             request.collection_revision,
             request.purpose,
             request.selection_anchor_retry_attempt,
+            request.surface_id,
         )
 
 

--- a/src/iPhoto/gui/viewmodels/gallery_window_loader.py
+++ b/src/iPhoto/gui/viewmodels/gallery_window_loader.py
@@ -386,6 +386,25 @@ class GalleryWindowLoader(QObject):
             return
         self._start(request)
 
+    def discard_queued(self, surface_id: str) -> None:
+        """Drop queued viewport work owned only by *surface_id*."""
+
+        surface_id = str(surface_id)
+        dropped = tuple(
+            request.generation
+            for request in self._queued_requests
+            if request.surface_id == surface_id and int(request.demand_generation) > 0
+        )
+        if not dropped:
+            return
+        dropped_set = set(dropped)
+        self._queued_requests = [
+            request
+            for request in self._queued_requests
+            if request.generation not in dropped_set
+        ]
+        self.requestsDropped.emit(dropped)
+
     def shutdown(self) -> None:
         dropped = tuple(request.generation for request in self._queued_requests)
         self._queued_requests.clear()

--- a/src/iPhoto/infrastructure/services/thumbnail_cache_service.py
+++ b/src/iPhoto/infrastructure/services/thumbnail_cache_service.py
@@ -335,7 +335,10 @@ class ThumbnailCacheService(QObject):
         self._pinned_keys: Set[str] = set()
         self._current_l1_demand_keys: Set[str] | None = None
         self._current_guard_keys: Set[str] = set()
-        self._current_cache_size: tuple[int, int] | None = None
+        self._surface_demands: Dict[str, ThumbnailDemandSnapshot] = {}
+        self._surface_activity: Dict[str, int] = {}
+        self._surface_activity_serial = 0
+        self._demand_revision = 0
         self._slot_allocations = 0
         self._slot_reuses = 0
         self._slot_releases = 0
@@ -454,6 +457,8 @@ class ThumbnailCacheService(QObject):
         self._active_decode_reservations.clear()
         self._active_decode_kinds.clear()
         self._visible_active_tokens.clear()
+        self._surface_demands.clear()
+        self._surface_activity.clear()
         self._staging_used_bytes = 0
         self._release_all_l1_slots("shutdown")
         self._eviction_timer.stop()
@@ -474,7 +479,9 @@ class ThumbnailCacheService(QObject):
         self._pinned_keys.clear()
         self._current_l1_demand_keys = None
         self._current_guard_keys.clear()
-        self._current_cache_size = None
+        self._surface_demands.clear()
+        self._surface_activity.clear()
+        self._demand_revision = 0
         self._eviction_timer.stop()
         self._pending_eviction_target_bytes = None
         self._pending_stale_eviction = False
@@ -682,74 +689,167 @@ class ThumbnailCacheService(QObject):
         self,
         demand: ThumbnailDemandSnapshot,
     ) -> None:
-        """Atomically replace visible, guard, and best-effort thumbnail demand."""
+        """Compatibility entry point for the primary Gallery surface."""
 
-        self._current_phase = demand.phase
-        self._current_intent = demand.intent
-        cache_size = (int(demand.size.width()), int(demand.size.height()))
-        if self._current_cache_size is not None and cache_size != self._current_cache_size:
-            self._release_all_l1_slots("display_bucket_changed")
-        self._current_cache_size = cache_size
-        visible = list(dict.fromkeys(Path(path) for path in demand.visible_paths))
-        visible_set = set(visible)
-        candidate_by_path = {
-            Path(candidate.path): candidate for candidate in demand.candidates
-        }
-        guard = [
-            Path(path)
-            for path in dict.fromkeys(Path(path) for path in demand.guard_paths)
-            if Path(path) not in visible_set
-        ]
-        guard_set = set(guard)
-        speculative = [
-            Path(path)
-            for path in dict.fromkeys(Path(path) for path in demand.speculative_paths)
-            if Path(path) not in visible_set and Path(path) not in guard_set
-        ]
-        if self._motion_blocks_prefetch(
-            self._current_phase,
-            self._current_intent,
-        ):
-            guard = []
-            speculative = []
-        self._current_generation = max(self._current_generation, int(demand.revision))
-        self.pin_visible(visible, demand.size)
-        guard, speculative = self._admit_prefetch_paths(
-            visible,
-            guard,
-            speculative,
-            demand.size,
+        self.upsert_surface_demand("gallery", demand)
+
+    def upsert_surface_demand(
+        self,
+        surface_id: str,
+        demand: ThumbnailDemandSnapshot,
+    ) -> None:
+        """Create or replace one surface lease and reconcile aggregate demand."""
+
+        surface_id = str(surface_id)
+        previous = self._surface_demands.get(surface_id)
+        self._surface_demands[surface_id] = demand
+        interaction_changed = previous is None or int(previous.revision) != int(demand.revision)
+        if interaction_changed:
+            self._surface_activity_serial += 1
+            self._surface_activity[surface_id] = self._surface_activity_serial
+        self._reconcile_surface_demands(
+            updated_surface=surface_id if interaction_changed else None
         )
-        prefetch = guard + speculative
-        desired_visible_keys = {self._cache_key(path, demand.size) for path in visible}
-        desired_guard_keys = {self._cache_key(path, demand.size) for path in guard}
-        desired_prefetch_keys = {
-            self._cache_key(path, demand.size) for path in prefetch
-        }
-        self._current_guard_keys = set(desired_guard_keys)
-        record_perf = perf_logging_enabled()
-        pending_before = set(self._pending_tasks) if record_perf else set()
-        resident = len(desired_visible_keys.intersection(self._memory_cache)) if record_perf else 0
-        if record_perf:
-            for path in visible:
-                emit_perf_event(
-                    "thumbnail_visible_entry",
-                    path=path,
-                    generation=demand.revision,
-                    phase=demand.phase,
-                    intent=self._current_intent,
-                    full=self._cache_key(path, demand.size) in self._memory_cache,
-                    miss_reason=self._visible_miss_reason(
-                        self._cache_key(path, demand.size)
+
+    def release_surface_demand(self, surface_id: str) -> None:
+        """Release one surface without disturbing keys leased by other surfaces."""
+
+        surface_id = str(surface_id)
+        self._surface_demands.pop(surface_id, None)
+        self._surface_activity.pop(surface_id, None)
+        self._reconcile_surface_demands(updated_surface=None)
+
+    @staticmethod
+    def _round_robin_requests(
+        lanes: list[list[ThumbnailRequest]],
+    ) -> list[ThumbnailRequest]:
+        ordered: list[ThumbnailRequest] = []
+        offsets = [0] * len(lanes)
+        while True:
+            emitted = False
+            for lane_index, lane in enumerate(lanes):
+                offset = offsets[lane_index]
+                if offset >= len(lane):
+                    continue
+                ordered.append(lane[offset])
+                offsets[lane_index] += 1
+                emitted = True
+            if not emitted:
+                return ordered
+
+    def _reconcile_surface_demands(self, *, updated_surface: str | None) -> None:
+        self._demand_revision += 1
+        revision = max(
+            self._current_generation + 1,
+            self._demand_revision,
+            *(int(demand.revision) for demand in self._surface_demands.values()),
+        )
+        self._demand_revision = revision
+        surfaces = sorted(
+            self._surface_demands,
+            key=lambda item: self._surface_activity.get(item, 0),
+            reverse=True,
+        )
+        if updated_surface in surfaces:
+            surfaces.remove(updated_surface)
+            surfaces.insert(0, updated_surface)
+
+        visible_lanes: list[list[ThumbnailRequest]] = []
+        guard_lanes: list[list[ThumbnailRequest]] = []
+        speculative_lanes: list[list[ThumbnailRequest]] = []
+        latest = self._surface_demands[surfaces[0]] if surfaces else None
+        self._current_phase = latest.phase if latest is not None else "settled"
+        self._current_intent = latest.intent if latest is not None else "idle"
+
+        for surface_id in surfaces:
+            demand = self._surface_demands[surface_id]
+            visible = list(dict.fromkeys(Path(path) for path in demand.visible_paths))
+            visible_set = set(visible)
+            candidate_by_path = {
+                Path(candidate.path): candidate for candidate in demand.candidates
+            }
+            guard = [
+                Path(path)
+                for path in dict.fromkeys(Path(path) for path in demand.guard_paths)
+                if Path(path) not in visible_set
+            ]
+            guard_set = set(guard)
+            speculative = [
+                Path(path)
+                for path in dict.fromkeys(Path(path) for path in demand.speculative_paths)
+                if Path(path) not in visible_set and Path(path) not in guard_set
+            ]
+            if self._motion_blocks_prefetch(demand.phase, demand.intent):
+                guard = []
+                speculative = []
+            guard, speculative = self._admit_prefetch_paths(
+                visible,
+                guard,
+                speculative,
+                demand.size,
+            )
+
+            def request(path: Path, kind: ThumbnailRequestKind, rank: int) -> ThumbnailRequest:
+                candidate = candidate_by_path.get(path)
+                return ThumbnailRequest(
+                    path,
+                    demand.size,
+                    kind,
+                    revision,
+                    l2_cache_key=(candidate.l2_cache_key if candidate is not None else None),
+                    rank=(candidate.rank if candidate is not None else rank),
+                    thumbnail_state=(
+                        candidate.thumbnail_state if candidate is not None else "ready"
                     ),
+                    thumb_revision=(candidate.thumb_revision if candidate is not None else None),
                 )
-        self._prefetch_key_order = [
-            self._cache_key(path, demand.size) for path in prefetch
-        ]
-        self._refresh_l1_for_demand(
-            desired_visible_keys,
-            desired_prefetch_keys,
+
+            visible_lanes.append(
+                [request(path, ThumbnailRequestKind.VISIBLE, rank) for rank, path in enumerate(visible)]
+            )
+            guard_lanes.append(
+                [request(path, ThumbnailRequestKind.GUARD, rank) for rank, path in enumerate(guard)]
+            )
+            speculative_lanes.append(
+                [
+                    request(path, ThumbnailRequestKind.PREFETCH, rank)
+                    for rank, path in enumerate(speculative)
+                ]
+            )
+
+        def strongest_unique(requests: list[ThumbnailRequest], excluded: set[str]) -> list[ThumbnailRequest]:
+            unique: list[ThumbnailRequest] = []
+            for request in requests:
+                key = self._cache_key(request.path, request.size)
+                if key in excluded:
+                    continue
+                excluded.add(key)
+                unique.append(request)
+            return unique
+
+        occupied: set[str] = set()
+        visible_requests = strongest_unique(self._round_robin_requests(visible_lanes), occupied)
+        guard_requests = strongest_unique(self._round_robin_requests(guard_lanes), occupied)
+        speculative_requests = strongest_unique(
+            self._round_robin_requests(speculative_lanes), occupied
         )
+        desired_visible_keys = {
+            self._cache_key(request.path, request.size) for request in visible_requests
+        }
+        desired_guard_keys = {
+            self._cache_key(request.path, request.size) for request in guard_requests
+        }
+        prefetch_requests = guard_requests + speculative_requests
+        desired_prefetch_keys = {
+            self._cache_key(request.path, request.size) for request in prefetch_requests
+        }
+        self._current_generation = revision
+        self._pinned_keys = set(desired_visible_keys)
+        self._current_guard_keys = set(desired_guard_keys)
+        self._prefetch_key_order = [
+            self._cache_key(request.path, request.size) for request in prefetch_requests
+        ]
+        self._refresh_l1_for_demand(desired_visible_keys, desired_prefetch_keys)
         self._apply_low_memory_pressure_if_needed()
         self._demote_stale_promotions(desired_visible_keys)
 
@@ -765,86 +865,32 @@ class ThumbnailCacheService(QObject):
         self._replace_prefetch_demand(
             desired_prefetch_keys,
             desired_visible_keys,
-            demand.revision,
+            revision,
         )
-
-        self.request_many(
-            (
-                ThumbnailRequest(
-                    path,
-                    demand.size,
-                    ThumbnailRequestKind.VISIBLE,
-                    demand.revision,
-                    l2_cache_key=(
-                        candidate_by_path[path].l2_cache_key
-                        if path in candidate_by_path
-                        else None
-                    ),
-                    thumbnail_state=(
-                        candidate_by_path[path].thumbnail_state
-                        if path in candidate_by_path
-                        else "ready"
-                    ),
-                    thumb_revision=(
-                        candidate_by_path[path].thumb_revision
-                        if path in candidate_by_path
-                        else None
-                    ),
-                )
-                for path in visible
-            ),
-            generation=demand.revision,
-        )
-        for rank, path in enumerate(prefetch):
-            candidate = candidate_by_path.get(path)
-            kind = (
-                ThumbnailRequestKind.GUARD
-                if path in guard
-                else ThumbnailRequestKind.PREFETCH
-            )
-            if (
-                kind is ThumbnailRequestKind.PREFETCH
-                and self._low_memory_pressure
-            ):
+        self.request_many(visible_requests, generation=revision)
+        for request in prefetch_requests:
+            if request.kind is ThumbnailRequestKind.PREFETCH and self._low_memory_pressure:
                 continue
-            self._queue_prefetch(
-                ThumbnailRequest(
-                    path,
-                    demand.size,
-                    kind,
-                    demand.revision,
-                    l2_cache_key=(candidate.l2_cache_key if candidate is not None else None),
-                    rank=(candidate.rank if candidate is not None else rank),
-                    thumbnail_state=(
-                        candidate.thumbnail_state if candidate is not None else "ready"
-                    ),
-                    thumb_revision=(
-                        candidate.thumb_revision if candidate is not None else None
-                    ),
-                )
-            )
+            self._queue_prefetch(request)
         self._discard_stale_staged_results(desired_visible_keys, desired_prefetch_keys)
-        if record_perf:
-            emit_perf_event(
-                "thumbnail_demand_reconciled",
-                generation=demand.revision,
-                visible=len(visible),
-                guard=len(guard),
-                speculative=len(speculative),
-                requested=len(
-                    (set(self._pending_tasks) - pending_before).intersection(desired_visible_keys)
-                ),
-                resident=resident,
-                canceled=len(drop_keys),
-                queued=len(self._queued_tasks),
-                active=self._active_tasks,
-                prefetch_queued=len(self._prefetch_queued),
-                prefetch_active=self._prefetch_active_tasks,
-                phase=demand.phase,
-                intent=self._current_intent,
-                guard_resident=len(desired_guard_keys.intersection(self._memory_cache)),
-                guard_total=len(desired_guard_keys),
-            )
+        emit_perf_event(
+            "thumbnail_demand_reconciled",
+            generation=revision,
+            surface_id=updated_surface,
+            surfaces=len(surfaces),
+            visible=len(visible_requests),
+            guard=len(guard_requests),
+            speculative=len(speculative_requests),
+            canceled=len(drop_keys),
+            queued=len(self._queued_tasks),
+            active=self._active_tasks,
+            prefetch_queued=len(self._prefetch_queued),
+            prefetch_active=self._prefetch_active_tasks,
+            phase=self._current_phase,
+            intent=self._current_intent,
+            guard_resident=len(desired_guard_keys.intersection(self._memory_cache)),
+            guard_total=len(desired_guard_keys),
+        )
         self._drain_generation_queue()
 
     def pin_visible(self, paths: Iterable[Path], size: QSize) -> None:

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -895,6 +895,40 @@ def test_window_loader_generation_is_isolated_per_surface(qapp) -> None:
     loader.shutdown()
 
 
+def test_window_loader_discards_only_released_surface_viewport_work(qapp) -> None:
+    del qapp
+    loader = GalleryWindowLoader()
+    loader._active_generation = 999
+    service = object()
+    dropped = []
+    loader.requestsDropped.connect(lambda generations: dropped.extend(generations))
+
+    def request(generation: int, surface_id: str, demand_generation: int) -> GalleryWindowRequest:
+        return GalleryWindowRequest(
+            generation=generation,
+            root=Path("."),
+            query=AssetQuery(),
+            query_service=service,
+            view_first=generation * 100,
+            raw_first=generation * 100,
+            limit=10,
+            demand_generation=demand_generation,
+            surface_id=surface_id,
+        )
+
+    loader.request(request(1, "gallery", 1))
+    loader.request(request(2, "filmstrip", 1))
+    loader.request(request(3, "filmstrip", 0))
+    loader.discard_queued("filmstrip")
+
+    assert [(item.surface_id, item.generation) for item in loader._queued_requests] == [
+        ("gallery", 1),
+        ("filmstrip", 3),
+    ]
+    assert dropped == [2]
+    loader.shutdown()
+
+
 def test_store_keeps_disjoint_surface_rows_relevant_and_reports_ranges() -> None:
     store = GalleryCollectionStore(None, library_root=Path("/library"))
     store._total_count = 2_000
@@ -939,6 +973,46 @@ def test_store_keeps_disjoint_surface_rows_relevant_and_reports_ranges() -> None
     store.release_viewport_demand("filmstrip")
     assert store._row_is_currently_relevant(10)
     assert not store._row_is_currently_relevant(1_000)
+
+
+def test_released_surface_rejects_inflight_viewport_result() -> None:
+    store = GalleryCollectionStore(None, library_root=Path("/library"))
+    store._total_count = 2_000
+    demand = build_viewport_demand(
+        surface_id="filmstrip",
+        generation=7,
+        row_count=2_000,
+        visible_first=1_000,
+        visible_last=1_005,
+        direction=0,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+    )
+    store.reconcile_viewport_demand(demand)
+    dto = scan_row_to_dto(
+        Path("/library"),
+        "1000.jpg",
+        {"id": "1000", "rel": "1000.jpg", "media_type": 0},
+    )
+    assert dto is not None
+    store._pending_window_generations.add(42)
+    store.release_viewport_demand("filmstrip")
+
+    applied = store.apply_window_result(
+        GalleryWindowResult(
+            generation=42,
+            first=1_000,
+            last=1_000,
+            rows={1_000: dto},
+            total_count=2_000,
+            collection_revision=0,
+            demand_generation=demand.generation,
+            surface_id="filmstrip",
+        )
+    )
+
+    assert applied is False
+    assert store.asset_at(1_000) is None
 
 
 def test_window_loader_drops_duplicate_of_active_query_window(qapp) -> None:

--- a/tests/gui/viewmodels/test_gallery_collection_store.py
+++ b/tests/gui/viewmodels/test_gallery_collection_store.py
@@ -865,6 +865,82 @@ def test_window_loader_keeps_explicit_row_request_when_viewport_generation_chang
     loader.shutdown()
 
 
+def test_window_loader_generation_is_isolated_per_surface(qapp) -> None:
+    del qapp
+    loader = GalleryWindowLoader()
+    loader._active_generation = 999
+    service = object()
+
+    def request(generation: int, surface_id: str, demand_generation: int) -> GalleryWindowRequest:
+        return GalleryWindowRequest(
+            generation=generation,
+            root=Path("."),
+            query=AssetQuery(),
+            query_service=service,
+            view_first=generation * 100,
+            raw_first=generation * 100,
+            limit=10,
+            demand_generation=demand_generation,
+            surface_id=surface_id,
+        )
+
+    loader.request(request(1, "gallery", 1))
+    loader.request(request(2, "filmstrip", 1))
+    loader.request(request(3, "gallery", 2))
+
+    assert [(item.surface_id, item.generation) for item in loader._queued_requests] == [
+        ("filmstrip", 2),
+        ("gallery", 3),
+    ]
+    loader.shutdown()
+
+
+def test_store_keeps_disjoint_surface_rows_relevant_and_reports_ranges() -> None:
+    store = GalleryCollectionStore(None, library_root=Path("/library"))
+    store._total_count = 2_000
+    gallery = build_viewport_demand(
+        surface_id="gallery",
+        generation=1,
+        row_count=2_000,
+        visible_first=10,
+        visible_last=19,
+        direction=0,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+    )
+    filmstrip = build_viewport_demand(
+        surface_id="filmstrip",
+        generation=1,
+        row_count=2_000,
+        visible_first=1_000,
+        visible_last=1_005,
+        direction=0,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+    )
+    store.reconcile_viewport_demand(gallery)
+    store.reconcile_viewport_demand(filmstrip)
+    first = scan_row_to_dto(
+        Path("/library"), "10.jpg", {"id": "10", "rel": "10.jpg", "media_type": 0}
+    )
+    second = scan_row_to_dto(
+        Path("/library"),
+        "1000.jpg",
+        {"id": "1000", "rel": "1000.jpg", "media_type": 0},
+    )
+    assert first is not None and second is not None
+    store._row_cache[10] = first
+    store._row_cache[1_000] = second
+
+    assert store._row_is_currently_relevant(10)
+    assert store._row_is_currently_relevant(1_000)
+    assert store.snapshot_signature()[1] == ((10, 10), (1_000, 1_000))
+
+    store.release_viewport_demand("filmstrip")
+    assert store._row_is_currently_relevant(10)
+    assert not store._row_is_currently_relevant(1_000)
+
+
 def test_window_loader_drops_duplicate_of_active_query_window(qapp) -> None:
     del qapp
     loader = GalleryWindowLoader()

--- a/tests/gui/viewmodels/test_gallery_demand_coordinator.py
+++ b/tests/gui/viewmodels/test_gallery_demand_coordinator.py
@@ -211,3 +211,37 @@ def test_revision_changes_only_for_scheduling_or_collection_changes() -> None:
     assert coordinator.revision == 5
     assert coordinator.viewport is not None
     assert coordinator.viewport.generation == 5
+
+
+def test_gallery_and_filmstrip_viewports_coexist() -> None:
+    coordinator = GalleryDemandCoordinator()
+    query = AssetQuery()
+    gallery = build_viewport_demand(
+        surface_id="gallery",
+        generation=1,
+        row_count=2_000,
+        visible_first=10,
+        visible_last=19,
+        direction=0,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+    )
+    filmstrip = build_viewport_demand(
+        surface_id="filmstrip",
+        generation=1,
+        row_count=2_000,
+        visible_first=1_000,
+        visible_last=1_005,
+        direction=1,
+        screens_per_second=4.0,
+        actively_scrolling=True,
+    )
+
+    coordinator.update_viewport(gallery, root=Path("/library"), query=query, collection_revision=1)
+    coordinator.update_viewport(filmstrip, root=Path("/library"), query=query, collection_revision=1)
+
+    assert coordinator.viewport_for("gallery").visible_range == (10, 19)
+    assert coordinator.viewport_for("filmstrip").visible_range == (1_000, 1_005)
+    coordinator.release_viewport("filmstrip")
+    assert coordinator.viewport_for("gallery") is not None
+    assert coordinator.viewport_for("filmstrip") is None

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PySide6.QtCore import QModelIndex, Qt, QTimer
+from PySide6.QtCore import QModelIndex, QSize, Qt, QTimer
 from PySide6.QtGui import QImage
 
 from iPhoto.application.dtos import AssetDTO
@@ -649,6 +649,21 @@ def test_tile_snapshot_is_micro_first_and_memory_only(adapter, mock_store, mock_
     assert snapshot.full_pixmap is None
     mock_store.ensure_row_loaded.assert_not_called()
     mock_thumb_service.request_many.assert_not_called()
+
+
+def test_surface_snapshots_peek_their_own_bucket(adapter, mock_store, mock_thumb_service):
+    micro = QImage(2, 2, QImage.Format.Format_RGB32)
+    mock_store.asset_at.return_value = _make_dto(micro_thumbnail=micro)
+    adapter._surface_sizes = {
+        "gallery": QSize(512, 512),
+        "filmstrip": QSize(256, 256),
+    }
+
+    adapter.tile_snapshot(0, "gallery")
+    adapter.tile_snapshot(0, "filmstrip")
+
+    sizes = [call.args[1] for call in mock_thumb_service.peek_full_thumbnail.call_args_list]
+    assert sizes == [QSize(512, 512), QSize(256, 256)]
 
 
 def test_stale_tile_never_exposes_old_full_or_micro_thumbnail(
@@ -1325,7 +1340,7 @@ def test_continuous_burst_discards_queued_thumbnail_hint(adapter):
     with patch.object(adapter._thumbnail_hint_loader, "discard_queued") as discard:
         adapter._request_thumbnail_hints(demand)
 
-    discard.assert_called_once_with()
+    discard.assert_called_once_with("gallery")
 
 
 def test_rebind_asset_query_service_updates_store(adapter, mock_store):

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -656,14 +656,14 @@ def test_surface_snapshots_peek_their_own_bucket(adapter, mock_store, mock_thumb
     mock_store.asset_at.return_value = _make_dto(micro_thumbnail=micro)
     adapter._surface_sizes = {
         "gallery": QSize(512, 512),
-        "filmstrip": QSize(256, 256),
+        "filmstrip": QSize(512, 512),
     }
 
     adapter.tile_snapshot(0, "gallery")
     adapter.tile_snapshot(0, "filmstrip")
 
     sizes = [call.args[1] for call in mock_thumb_service.peek_full_thumbnail.call_args_list]
-    assert sizes == [QSize(512, 512), QSize(256, 256)]
+    assert sizes == [QSize(512, 512), QSize(512, 512)]
 
 
 def test_release_surface_discards_queued_window_and_hint_work(

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -666,6 +666,23 @@ def test_surface_snapshots_peek_their_own_bucket(adapter, mock_store, mock_thumb
     assert sizes == [QSize(512, 512), QSize(256, 256)]
 
 
+def test_release_surface_discards_queued_window_and_hint_work(
+    adapter,
+    mock_store,
+    mock_thumb_service,
+):
+    with (
+        patch.object(adapter._window_loader, "discard_queued") as discard_windows,
+        patch.object(adapter._thumbnail_hint_loader, "discard_queued") as discard_hints,
+    ):
+        adapter.release_viewport_surface("filmstrip")
+
+    discard_windows.assert_called_once_with("filmstrip")
+    discard_hints.assert_called_once_with("filmstrip")
+    mock_store.release_viewport_demand.assert_called_once_with("filmstrip")
+    mock_thumb_service.release_surface_demand.assert_called_once_with("filmstrip")
+
+
 def test_stale_tile_never_exposes_old_full_or_micro_thumbnail(
     adapter,
     mock_store,

--- a/tests/gui/viewmodels/test_gallery_thumbnail_hint_loader.py
+++ b/tests/gui/viewmodels/test_gallery_thumbnail_hint_loader.py
@@ -66,10 +66,10 @@ def test_discard_queued_preserves_active_hint_request() -> None:
     queued = object()
     loader._active = True
     loader._signals = active
-    loader._queued = queued
+    loader._queued = {"gallery": queued}
 
     loader.discard_queued()
 
     assert loader._active is True
     assert loader._signals is active
-    assert loader._queued is None
+    assert loader._queued == {}

--- a/tests/test_gallery_demand.py
+++ b/tests/test_gallery_demand.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from iPhoto.gui.gallery_demand import (
+    CANONICAL_FULL_THUMBNAIL_BUCKET,
     MICRO_WARM_LIMIT,
     build_viewport_demand,
     resolve_display_thumbnail_bucket,
+    resolve_surface_thumbnail_bucket,
 )
 
 
@@ -228,3 +230,55 @@ def test_display_thumbnail_bucket_never_requires_new_disk_sizes() -> None:
     assert resolve_display_thumbnail_bucket(300) == 384
     assert resolve_display_thumbnail_bucket(500) == 512
     assert resolve_display_thumbnail_bucket(900) == 512
+
+
+def test_gallery_and_filmstrip_use_canonical_full_thumbnail_bucket() -> None:
+    for surface_id in ("gallery", "filmstrip"):
+        assert resolve_surface_thumbnail_bucket(surface_id, 120) == 512
+        assert resolve_surface_thumbnail_bucket(surface_id, 240) == 512
+        assert resolve_surface_thumbnail_bucket(surface_id, 900) == 512
+    assert CANONICAL_FULL_THUMBNAIL_BUCKET == 512
+    assert resolve_surface_thumbnail_bucket("future-surface", 192) == 256
+    assert resolve_surface_thumbnail_bucket("future-surface", 300) == 384
+    direct = build_viewport_demand(
+        surface_id="gallery",
+        generation=1,
+        row_count=10,
+        visible_first=0,
+        visible_last=1,
+        direction=0,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+        display_bucket=256,
+    )
+    assert direct.display_bucket == 512
+
+
+def test_filmstrip_keeps_guard_but_drops_far_full_speculation() -> None:
+    filmstrip = build_viewport_demand(
+        surface_id="filmstrip",
+        generation=1,
+        row_count=1_000,
+        visible_first=100,
+        visible_last=102,
+        direction=1,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+    )
+    gallery = build_viewport_demand(
+        surface_id="gallery",
+        generation=1,
+        row_count=1_000,
+        visible_first=100,
+        visible_last=102,
+        direction=1,
+        screens_per_second=0.0,
+        actively_scrolling=False,
+    )
+
+    assert filmstrip.display_bucket == 512
+    assert filmstrip.full_guard_range == (94, 108)
+    assert filmstrip.full_prefetch_range == filmstrip.full_guard_range
+    assert tuple(filmstrip.iter_full_speculative_rows()) == ()
+    assert gallery.full_prefetch_range == (85, 117)
+    assert tuple(gallery.iter_full_speculative_rows())

--- a/tests/test_thumbnail_cache_service.py
+++ b/tests/test_thumbnail_cache_service.py
@@ -443,33 +443,33 @@ def test_reconcile_demand_keeps_only_latest_visible_and_prefetch_queue(tmp_path:
     assert service._pinned_keys == {second_key}
 
 
-def test_surface_leases_keep_different_buckets_and_release_only_owner(tmp_path: Path) -> None:
+def test_surface_leases_support_future_different_bucket_without_aliasing(tmp_path: Path) -> None:
     service = ThumbnailCacheService(tmp_path / "thumbs")
     service._max_active_jobs = 0
     gallery_path = tmp_path / "gallery.jpg"
-    filmstrip_path = tmp_path / "filmstrip.jpg"
+    preview_path = tmp_path / "preview.jpg"
     gallery_size = QSize(512, 512)
-    filmstrip_size = QSize(256, 256)
+    preview_size = QSize(256, 256)
 
     service.upsert_surface_demand(
         "gallery",
         ThumbnailDemandSnapshot(1, gallery_size, (gallery_path,)),
     )
     service.upsert_surface_demand(
-        "filmstrip",
-        ThumbnailDemandSnapshot(1, filmstrip_size, (filmstrip_path,)),
+        "preview",
+        ThumbnailDemandSnapshot(1, preview_size, (preview_path,)),
     )
 
     gallery_key = service._cache_key(gallery_path, gallery_size)
-    filmstrip_key = service._cache_key(filmstrip_path, filmstrip_size)
-    assert service._pinned_keys == {gallery_key, filmstrip_key}
-    assert set(service._queued_tasks) == {gallery_key, filmstrip_key}
+    preview_key = service._cache_key(preview_path, preview_size)
+    assert service._pinned_keys == {gallery_key, preview_key}
+    assert set(service._queued_tasks) == {gallery_key, preview_key}
 
-    service.release_surface_demand("filmstrip")
+    service.release_surface_demand("preview")
 
     assert service._pinned_keys == {gallery_key}
     assert gallery_key in service._queued_tasks
-    assert filmstrip_key not in service._queued_tasks
+    assert preview_key not in service._queued_tasks
     service.shutdown()
 
 
@@ -477,7 +477,7 @@ def test_surface_leases_deduplicate_same_sized_visible_key(tmp_path: Path) -> No
     service = ThumbnailCacheService(tmp_path / "thumbs")
     service._max_active_jobs = 0
     path = tmp_path / "shared.jpg"
-    size = QSize(256, 256)
+    size = QSize(512, 512)
     snapshot = ThumbnailDemandSnapshot(1, size, (path,))
 
     service.upsert_surface_demand("gallery", snapshot)
@@ -499,11 +499,78 @@ def test_surface_bucket_change_does_not_release_l1_pool(tmp_path: Path) -> None:
             ThumbnailDemandSnapshot(1, QSize(512, 512), ()),
         )
         service.upsert_surface_demand(
-            "filmstrip",
+            "preview",
             ThumbnailDemandSnapshot(1, QSize(256, 256), ()),
         )
 
     release_slots.assert_not_called()
+    service.shutdown()
+
+
+def test_canonical_surface_handoff_reuses_one_resident_l1_slot(qapp, tmp_path: Path) -> None:
+    del qapp
+    service = ThumbnailCacheService(tmp_path / "thumbs")
+    path = tmp_path / "shared.jpg"
+    size = QSize(512, 512)
+    key = service._cache_key(path, size)
+    pixmap = QPixmap(512, 512)
+    pixmap.fill(QColor("blue"))
+    service._add_to_memory(key, pixmap)
+    allocations = service.memory_snapshot().slot_allocations
+    snapshot = ThumbnailDemandSnapshot(1, size, (path,))
+
+    with (
+        patch.object(service, "_start_generation") as start_generation,
+        patch.object(service, "_read_cached_thumbnail") as l2_read,
+        patch.object(service, "_store_image_in_l1") as publish_pixmap,
+        patch(
+            "iPhoto.infrastructure.services.thumbnail_cache_service.emit_perf_event"
+        ) as perf_event,
+    ):
+        service.upsert_surface_demand("gallery", snapshot)
+        service.upsert_surface_demand("filmstrip", snapshot)
+        gallery_pixmap = service.peek_full_thumbnail(path, size)
+        filmstrip_pixmap = service.peek_full_thumbnail(path, size)
+
+    assert start_generation.call_count == 0
+    l2_read.assert_not_called()
+    publish_pixmap.assert_not_called()
+    assert gallery_pixmap is filmstrip_pixmap
+    assert service._pinned_keys == {key}
+    assert service.memory_snapshot().slot_count == 1
+    assert service.memory_snapshot().slot_allocations == allocations
+    l1_hits = [
+        call
+        for call in perf_event.call_args_list
+        if call.args == ("thumbnail_cache_hit",)
+        and call.kwargs == {"tier": "L1", "key": key}
+    ]
+    assert len(l1_hits) == 2
+
+    service.release_surface_demand("gallery")
+    assert service._pinned_keys == {key}
+    service.release_surface_demand("filmstrip")
+    assert key not in service._pinned_keys
+    assert key not in (service._current_l1_demand_keys or set())
+    assert key in service._memory_cache
+    service.shutdown()
+
+
+def test_canonical_surface_concurrent_demand_starts_one_worker(tmp_path: Path) -> None:
+    service = ThumbnailCacheService(tmp_path / "thumbs")
+    path = tmp_path / "shared.jpg"
+    size = QSize(512, 512)
+    key = service._cache_key(path, size)
+    snapshot = ThumbnailDemandSnapshot(1, size, (path,))
+
+    with patch.object(service, "_start_generation", return_value=True) as start_generation:
+        service.upsert_surface_demand("gallery", snapshot)
+        service.upsert_surface_demand("filmstrip", snapshot)
+
+    start_generation.assert_called_once()
+    assert service._pending_tasks == {key}
+    assert service._queued_tasks == {}
+    assert service._publish_keys == set()
     service.shutdown()
 
 
@@ -1172,6 +1239,23 @@ def test_l2_512_file_decodes_directly_to_display_bucket_without_new_disk_file(
     assert image is not None
     assert image.size() == QSize(256, 256)
     assert not thumbnail_cache_file(tmp_path / "thumbs", path, (256, 256)).exists()
+
+
+def test_canonical_512_request_reuses_l2_without_variant_artifacts(tmp_path: Path) -> None:
+    service = ThumbnailCacheService(tmp_path / "thumbs")
+    path = tmp_path / "photo.jpg"
+    disk_file = thumbnail_cache_file(tmp_path / "thumbs", path, (512, 512))
+    disk_file.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (512, 512), "red").save(disk_file, format="JPEG")
+
+    image = service._load_cached_thumbnail_only(path, QSize(512, 512))
+
+    assert image is not None
+    assert image.size() == QSize(512, 512)
+    assert disk_file.exists()
+    assert not thumbnail_cache_file(tmp_path / "thumbs", path, (256, 256)).exists()
+    assert not thumbnail_cache_file(tmp_path / "thumbs", path, (384, 384)).exists()
+    service.shutdown()
 
 
 def test_known_l2_cache_key_drives_guard_request(tmp_path: Path) -> None:

--- a/tests/test_thumbnail_cache_service.py
+++ b/tests/test_thumbnail_cache_service.py
@@ -443,6 +443,70 @@ def test_reconcile_demand_keeps_only_latest_visible_and_prefetch_queue(tmp_path:
     assert service._pinned_keys == {second_key}
 
 
+def test_surface_leases_keep_different_buckets_and_release_only_owner(tmp_path: Path) -> None:
+    service = ThumbnailCacheService(tmp_path / "thumbs")
+    service._max_active_jobs = 0
+    gallery_path = tmp_path / "gallery.jpg"
+    filmstrip_path = tmp_path / "filmstrip.jpg"
+    gallery_size = QSize(512, 512)
+    filmstrip_size = QSize(256, 256)
+
+    service.upsert_surface_demand(
+        "gallery",
+        ThumbnailDemandSnapshot(1, gallery_size, (gallery_path,)),
+    )
+    service.upsert_surface_demand(
+        "filmstrip",
+        ThumbnailDemandSnapshot(1, filmstrip_size, (filmstrip_path,)),
+    )
+
+    gallery_key = service._cache_key(gallery_path, gallery_size)
+    filmstrip_key = service._cache_key(filmstrip_path, filmstrip_size)
+    assert service._pinned_keys == {gallery_key, filmstrip_key}
+    assert set(service._queued_tasks) == {gallery_key, filmstrip_key}
+
+    service.release_surface_demand("filmstrip")
+
+    assert service._pinned_keys == {gallery_key}
+    assert gallery_key in service._queued_tasks
+    assert filmstrip_key not in service._queued_tasks
+    service.shutdown()
+
+
+def test_surface_leases_deduplicate_same_sized_visible_key(tmp_path: Path) -> None:
+    service = ThumbnailCacheService(tmp_path / "thumbs")
+    service._max_active_jobs = 0
+    path = tmp_path / "shared.jpg"
+    size = QSize(256, 256)
+    snapshot = ThumbnailDemandSnapshot(1, size, (path,))
+
+    service.upsert_surface_demand("gallery", snapshot)
+    service.upsert_surface_demand("filmstrip", snapshot)
+
+    key = service._cache_key(path, size)
+    assert service._pinned_keys == {key}
+    assert list(service._queued_tasks) == [key]
+    service.release_surface_demand("filmstrip")
+    assert service._pinned_keys == {key}
+    service.shutdown()
+
+
+def test_surface_bucket_change_does_not_release_l1_pool(tmp_path: Path) -> None:
+    service = ThumbnailCacheService(tmp_path / "thumbs")
+    with patch.object(service, "_release_all_l1_slots") as release_slots:
+        service.upsert_surface_demand(
+            "gallery",
+            ThumbnailDemandSnapshot(1, QSize(512, 512), ()),
+        )
+        service.upsert_surface_demand(
+            "filmstrip",
+            ThumbnailDemandSnapshot(1, QSize(256, 256), ()),
+        )
+
+    release_slots.assert_not_called()
+    service.shutdown()
+
+
 def test_stale_worker_result_is_discarded_before_pixmap_conversion(tmp_path: Path) -> None:
     service = ThumbnailCacheService(tmp_path / "thumbs")
     path = tmp_path / "photo.jpg"

--- a/tests/ui/models/test_thumbnail_surface_proxy_model.py
+++ b/tests/ui/models/test_thumbnail_surface_proxy_model.py
@@ -1,0 +1,38 @@
+from PySide6.QtCore import QAbstractListModel, QModelIndex, QSize, Qt
+
+from iPhoto.gui.ui.models.roles import Roles
+from iPhoto.gui.ui.models.thumbnail_surface_proxy_model import ThumbnailSurfaceProxyModel
+
+
+class _Source(QAbstractListModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = []
+
+    def rowCount(self, parent=QModelIndex()):  # noqa: N802
+        return 0 if parent.isValid() else 1
+
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):  # noqa: N802
+        return "source" if index.isValid() else None
+
+    def tile_snapshot(self, row: int, surface_id: str):
+        self.calls.append(("snapshot", row, surface_id))
+        return "filmstrip-snapshot"
+
+    def full_thumbnail(self, row: int, surface_id: str):
+        self.calls.append(("full", row, surface_id))
+        return QSize(256, 256)
+
+
+def test_proxy_resolves_thumbnail_roles_for_its_surface() -> None:
+    source = _Source()
+    proxy = ThumbnailSurfaceProxyModel("filmstrip")
+    proxy.setSourceModel(source)
+    index = proxy.index(0, 0)
+
+    assert proxy.data(index, Roles.TILE_SNAPSHOT) == "filmstrip-snapshot"
+    assert proxy.data(index, Qt.ItemDataRole.DecorationRole) == QSize(256, 256)
+    assert source.calls == [
+        ("snapshot", 0, "filmstrip"),
+        ("full", 0, "filmstrip"),
+    ]

--- a/tests/ui/widgets/test_filmstrip_view.py
+++ b/tests/ui/widgets/test_filmstrip_view.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import QApplication
 
 from iPhoto.gui.ui.models.roles import Roles
 from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
+from iPhoto.gui.ui.models.thumbnail_surface_proxy_model import ThumbnailSurfaceProxyModel
 from iPhoto.gui.ui.widgets.asset_delegate import AssetGridDelegate
 from iPhoto.gui.ui.widgets.filmstrip_view import FilmstripView
 
@@ -190,6 +191,40 @@ def test_centering_settles_current_tile_geometry_before_scroll(qapp):
     qapp.processEvents()
 
     assert abs(int(view.visualRect(target).center().x()) - centered_x) <= 1
+
+
+def test_horizontal_viewport_demand_maps_through_two_proxies(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(1_200)]
+    source = _AssetListModel(paths, paths[10])
+    presentation = ThumbnailSurfaceProxyModel("filmstrip")
+    presentation.setSourceModel(source)
+    spacers = SpacerProxyModel()
+    spacers.setSourceModel(presentation)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(spacers)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    emitted = []
+    view.viewportStateChanged.connect(emitted.append)
+    target_source = source.index(1_000, 0)
+    target = spacers.mapFromSource(presentation.mapFromSource(target_source))
+    view.select_index_for_centering(target)
+    view.center_on_index(target)
+    qapp.processEvents()
+
+    assert emitted
+    demand = emitted[-1]
+    assert demand.surface_id == "filmstrip"
+    assert demand.visible_first <= 1_000 <= demand.visible_last
+    assert demand.visible_first > 900
+    assert demand.display_bucket == 256
+
+    view._scroll_controller._publish_idle_state()
+    view._emit_visible_rows()
+    assert emitted[-1].phase == "settled"
 
 
 def test_current_change_does_not_publish_transient_spacer_width(qapp):

--- a/tests/ui/widgets/test_filmstrip_view.py
+++ b/tests/ui/widgets/test_filmstrip_view.py
@@ -227,6 +227,67 @@ def test_horizontal_viewport_demand_maps_through_two_proxies(qapp):
     assert emitted[-1].phase == "settled"
 
 
+def test_hidden_filmstrip_cancels_delayed_viewport_publication(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(80)]
+    source = _AssetListModel(paths, paths[10])
+    presentation = ThumbnailSurfaceProxyModel("filmstrip")
+    presentation.setSourceModel(source)
+    spacers = SpacerProxyModel()
+    spacers.setSourceModel(presentation)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(spacers)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    emitted = []
+    view.viewportStateChanged.connect(emitted.append)
+    view.schedule_viewport_publish()
+    view._scroll_controller._idle_timer.start(0)
+    view._scroll_controller._dwell_timer.start(0)
+    view._scroll_controller._direction_expiry_timer.start(0)
+    view.hide()
+    qapp.processEvents()
+    view._emit_visible_rows()
+
+    assert emitted == []
+    assert not view._update_timer.isActive()
+    assert not view._scroll_controller._idle_timer.isActive()
+    assert not view._scroll_controller._dwell_timer.isActive()
+    assert not view._scroll_controller._direction_expiry_timer.isActive()
+
+
+def test_filmstrip_demand_bounds_use_source_count_without_spacers(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(1_200)]
+    source = _AssetListModel(paths, paths[-1])
+    presentation = ThumbnailSurfaceProxyModel("filmstrip")
+    presentation.setSourceModel(source)
+    spacers = SpacerProxyModel()
+    spacers.setSourceModel(presentation)
+    view = FilmstripView()
+    view.setItemDelegate(AssetGridDelegate(view, filmstrip_mode=True))
+    view.setModel(spacers)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    emitted = []
+    view.viewportStateChanged.connect(emitted.append)
+    source_index = source.index(1_199, 0)
+    target = spacers.mapFromSource(presentation.mapFromSource(source_index))
+    view.select_index_for_centering(target)
+    view.center_on_index(target)
+    qapp.processEvents()
+
+    assert emitted
+    demand = emitted[-1]
+    assert demand.visible_last <= 1_199
+    assert demand.full_guard_last <= 1_199
+    assert demand.full_prefetch_last <= 1_199
+    assert demand.warm_last <= 1_199
+
+
 def test_current_change_does_not_publish_transient_spacer_width(qapp):
     paths = [Path(f"/library/photo-{index}.jpg") for index in range(40)]
     model = _AssetListModel(paths, paths[5])

--- a/tests/ui/widgets/test_filmstrip_view.py
+++ b/tests/ui/widgets/test_filmstrip_view.py
@@ -5,11 +5,12 @@ from PySide6.QtCore import (
     QAbstractListModel,
     QItemSelectionModel,
     QModelIndex,
+    QSize,
     QStringListModel,
     Qt,
 )
 from PySide6.QtGui import QColor, QPalette
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QStyleOptionViewItem
 
 from iPhoto.gui.ui.models.roles import Roles
 from iPhoto.gui.ui.models.spacer_proxy_model import SpacerProxyModel
@@ -220,11 +221,35 @@ def test_horizontal_viewport_demand_maps_through_two_proxies(qapp):
     assert demand.surface_id == "filmstrip"
     assert demand.visible_first <= 1_000 <= demand.visible_last
     assert demand.visible_first > 900
-    assert demand.display_bucket == 256
+    assert demand.display_bucket == 512
 
     view._scroll_controller._publish_idle_state()
     view._emit_visible_rows()
-    assert emitted[-1].phase == "settled"
+    settled = emitted[-1]
+    assert settled.phase == "settled"
+    assert settled.full_prefetch_range == settled.full_guard_range
+    assert tuple(settled.iter_full_speculative_rows()) == ()
+
+
+def test_filmstrip_geometry_is_independent_from_thumbnail_bucket(qapp):
+    paths = [Path(f"/library/photo-{index}.jpg") for index in range(3)]
+    source = _AssetListModel(paths, paths[1])
+    view = FilmstripView()
+    delegate = AssetGridDelegate(view, filmstrip_mode=True)
+    view.setItemDelegate(delegate)
+    view.setModel(source)
+    view.resize(420, 132)
+    view.show()
+    qapp.processEvents()
+
+    option = QStyleOptionViewItem()
+    option.initFrom(view)
+    assert view.iconSize() == QSize(120, 120)
+    assert view.spacing() == 2
+    assert view.minimumHeight() == 132
+    assert view.maximumHeight() == 132
+    assert delegate.sizeHint(option, source.index(1, 0)) == QSize(120, 120)
+    assert delegate.sizeHint(option, source.index(0, 0)) == QSize(72, 120)
 
 
 def test_hidden_filmstrip_cancels_delayed_viewport_publication(qapp):


### PR DESCRIPTION
## Summary
- add geometry-aware horizontal Filmstrip viewport demand with proxy-safe source-row mapping
- support independent Gallery and Filmstrip sparse windows, hint generations, display buckets, and presentation snapshots
- replace the single active thumbnail bucket with multi-surface leases sharing one byte-budgeted L1 pool
- release surface-specific demand on visibility changes and document the new guardrails

## Validation
- full suite: 3144 passed, 20 skipped
- opt-in Gallery scroll benchmark: 13 passed
- architecture checks and compileall passed