### PR TITLE
Codex/progress UI playback shadow

### DIFF
--- a/src/iPhoto/bootstrap/library_asset_query_service.py
+++ b/src/iPhoto/bootstrap/library_asset_query_service.py
@@ -90,6 +90,7 @@ class LibraryAssetQueryService:
         self._thumbnail_backfill_pending: set[tuple[str, int, int, str]] = set()
         self._thumbnail_backfill_shutdown = False
         self.thumbnail_backfill_completed = _CallbackSignal()
+        self.thumbnail_backfill_failed = _CallbackSignal()
         self.thumbnail_backfill_progress = _CallbackSignal()
 
     def count_assets(
@@ -549,9 +550,12 @@ class LibraryAssetQueryService:
                 self.album_path_for(root),
                 candidates,
             )
-        except Exception:
+        except Exception as exc:
             with self._thumbnail_backfill_lock:
                 self._thumbnail_backfill_pending.discard(request_key)
+                should_emit = not self._thumbnail_backfill_shutdown
+            if should_emit:
+                self.thumbnail_backfill_failed.emit(root, str(exc))
             raise
 
     def find_row_by_path(self, query: CollectionQuery | AssetQuery, path: Path) -> int | None:

--- a/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
+++ b/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
@@ -706,6 +706,9 @@ class DesktopCoordinatorRuntime(QObject):
         self._asset_list_vm.thumbnailBackfillCompleted.connect(
             self._status_bar.handle_thumbnail_backfill_completed
         )
+        self._asset_list_vm.thumbnailBackfillFailed.connect(
+            self._status_bar.handle_thumbnail_backfill_failed
+        )
 
         self._facade.loadStarted.connect(self._status_bar.handle_load_started)
         self._facade.loadProgress.connect(self._status_bar.handle_load_progress)

--- a/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
+++ b/src/iPhoto/gui/coordinators/desktop_coordinator_runtime.py
@@ -703,6 +703,9 @@ class DesktopCoordinatorRuntime(QObject):
         self._asset_list_vm.thumbnailBackfillProgress.connect(
             self._status_bar.handle_thumbnail_backfill_progress
         )
+        self._asset_list_vm.thumbnailBackfillCompleted.connect(
+            self._status_bar.handle_thumbnail_backfill_completed
+        )
 
         self._facade.loadStarted.connect(self._status_bar.handle_load_started)
         self._facade.loadProgress.connect(self._status_bar.handle_load_progress)

--- a/src/iPhoto/gui/ui/controllers/edit_view_transition.py
+++ b/src/iPhoto/gui/ui/controllers/edit_view_transition.py
@@ -72,6 +72,11 @@ class EditViewTransitionManager(QObject):
         self._detail_header_opacity = QGraphicsOpacityEffect(ui.detail_chrome_container)
         self._detail_header_opacity.setOpacity(1.0)
         ui.detail_chrome_container.setGraphicsEffect(self._detail_header_opacity)
+        detail_page = getattr(ui, "detail_page", None)
+        detail_header_shadow = getattr(detail_page, "detail_header_shadow", None)
+        bind_shadow_opacity = getattr(detail_header_shadow, "bind_opacity_effect", None)
+        if callable(bind_shadow_opacity):
+            bind_shadow_opacity(self._detail_header_opacity)
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/iPhoto/gui/ui/controllers/status_bar_controller.py
+++ b/src/iPhoto/gui/ui/controllers/status_bar_controller.py
@@ -33,6 +33,8 @@ class StatusBarController(QObject):
         self._rescan_action = rescan_action
         self._progress_context: Optional[str] = None
         self._scan_active: bool = False
+        self._thumbnail_backfill_active_requests: int = 0
+        self._thumbnail_backfill_session_failed: bool = False
         # ``_move_context_delete`` keeps track of whether the current move feedback refers
         # to a deletion into Recently Deleted so we can surface "Delete" specific copy.
         self._move_context_delete: bool = False
@@ -130,11 +132,25 @@ class StatusBarController(QObject):
     ) -> None:
         """Surface lazy thumbnail migration/backfill progress."""
 
+        # Every service request publishes one 0/N discovery event before its
+        # worker begins. Count those requests independently from the visible
+        # status-bar context so an older delayed terminal event cannot close a
+        # newer request that has already started.
+        if current == 0:
+            if self._thumbnail_backfill_active_requests == 0:
+                self._thumbnail_backfill_session_failed = False
+            self._thumbnail_backfill_active_requests += 1
+        elif self._thumbnail_backfill_active_requests == 0:
+            # Compatibility for embedders/tests that attach after discovery
+            # and therefore first observe an in-flight non-zero update.
+            self._thumbnail_backfill_active_requests = 1
+            self._thumbnail_backfill_session_failed = False
+
         if self._progress_context not in {"thumbnail", None}:
             return
         # The producer reports the exact candidate count, so (0, 0) means
-        # there is no work.  Treating it as an unknown total would start an
-        # indeterminate progress bar with nothing left to stop it.
+        # there is no work.  Track the request for terminal ordering, but do
+        # not show an indeterminate progress bar for an empty batch.
         if current == 0 and total == 0:
             return
         self._progress_context = "thumbnail"
@@ -154,24 +170,44 @@ class StatusBarController(QObject):
         self._progress_bar.setVisible(True)
 
     def handle_thumbnail_backfill_completed(self, _root: Path) -> None:
-        """End thumbnail feedback when the service reports terminal completion."""
+        """End thumbnail feedback once the whole active backfill session is idle."""
 
-        if self._progress_context != "thumbnail":
-            return
-        self._progress_bar.setVisible(False)
-        self._progress_bar.setRange(0, 0)
-        self._progress_context = None
-        self.show_message(self._tr("Thumbnails updated."), 3000)
+        self._finish_thumbnail_backfill_request(failed=False)
 
     def handle_thumbnail_backfill_failed(self, _root: Path, _error: str) -> None:
-        """End thumbnail feedback when background backfill fails."""
+        """Record a failed request and finish feedback when the session is idle."""
 
+        self._finish_thumbnail_backfill_request(failed=True)
+
+    def _finish_thumbnail_backfill_request(self, *, failed: bool) -> None:
+        """Consume one terminal event without hiding newer in-flight work."""
+
+        if failed:
+            self._thumbnail_backfill_session_failed = True
+
+        if self._thumbnail_backfill_active_requests > 0:
+            self._thumbnail_backfill_active_requests -= 1
+        elif self._progress_context != "thumbnail":
+            # No observed request and no thumbnail UI to finish. This covers
+            # empty/foreign terminal events without manufacturing feedback.
+            self._thumbnail_backfill_session_failed = False
+            return
+
+        if self._thumbnail_backfill_active_requests > 0:
+            return
+
+        session_failed = self._thumbnail_backfill_session_failed
+        self._thumbnail_backfill_session_failed = False
         if self._progress_context != "thumbnail":
             return
+
         self._progress_bar.setVisible(False)
         self._progress_bar.setRange(0, 0)
         self._progress_context = None
-        self.show_message(self._tr("Thumbnail update failed."), 5000)
+        if session_failed:
+            self.show_message(self._tr("Thumbnail update failed."), 5000)
+        else:
+            self.show_message(self._tr("Thumbnails updated."), 3000)
 
     def handle_load_started(self, root: Path) -> None:
         """Show an indeterminate progress indicator while assets load."""

--- a/src/iPhoto/gui/ui/controllers/status_bar_controller.py
+++ b/src/iPhoto/gui/ui/controllers/status_bar_controller.py
@@ -132,6 +132,11 @@ class StatusBarController(QObject):
 
         if self._progress_context not in {"thumbnail", None}:
             return
+        # The producer reports the exact candidate count, so (0, 0) means
+        # there is no work.  Treating it as an unknown total would start an
+        # indeterminate progress bar with nothing left to stop it.
+        if current == 0 and total == 0:
+            return
         self._progress_context = "thumbnail"
         if total <= 0:
             self._progress_bar.setRange(0, 0)
@@ -152,6 +157,16 @@ class StatusBarController(QObject):
             self._progress_bar.setRange(0, 0)
             self._progress_context = None
             self.show_message(self._tr("Thumbnails updated."), 3000)
+
+    def handle_thumbnail_backfill_completed(self, _root: Path) -> None:
+        """End thumbnail feedback when the service reports terminal completion."""
+
+        if self._progress_context != "thumbnail":
+            return
+        self._progress_bar.setVisible(False)
+        self._progress_bar.setRange(0, 0)
+        self._progress_context = None
+        self.show_message(self._tr("Thumbnails updated."), 3000)
 
     def handle_load_started(self, root: Path) -> None:
         """Show an indeterminate progress indicator while assets load."""

--- a/src/iPhoto/gui/ui/controllers/status_bar_controller.py
+++ b/src/iPhoto/gui/ui/controllers/status_bar_controller.py
@@ -152,11 +152,6 @@ class StatusBarController(QObject):
                 )
             )
         self._progress_bar.setVisible(True)
-        if total > 0 and current >= total:
-            self._progress_bar.setVisible(False)
-            self._progress_bar.setRange(0, 0)
-            self._progress_context = None
-            self.show_message(self._tr("Thumbnails updated."), 3000)
 
     def handle_thumbnail_backfill_completed(self, _root: Path) -> None:
         """End thumbnail feedback when the service reports terminal completion."""
@@ -167,6 +162,16 @@ class StatusBarController(QObject):
         self._progress_bar.setRange(0, 0)
         self._progress_context = None
         self.show_message(self._tr("Thumbnails updated."), 3000)
+
+    def handle_thumbnail_backfill_failed(self, _root: Path, _error: str) -> None:
+        """End thumbnail feedback when background backfill fails."""
+
+        if self._progress_context != "thumbnail":
+            return
+        self._progress_bar.setVisible(False)
+        self._progress_bar.setRange(0, 0)
+        self._progress_context = None
+        self.show_message(self._tr("Thumbnail update failed."), 5000)
 
     def handle_load_started(self, root: Path) -> None:
         """Show an indeterminate progress indicator while assets load."""

--- a/src/iPhoto/gui/ui/widgets/detail_page.py
+++ b/src/iPhoto/gui/ui/widgets/detail_page.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
-from PySide6.QtCore import QSize, Qt
-from PySide6.QtGui import QAction, QActionGroup, QColor, QFont
+from PySide6.QtCore import QEvent, QPoint, QSize, Qt
+from PySide6.QtGui import (
+    QAction,
+    QActionGroup,
+    QColor,
+    QFont,
+    QLinearGradient,
+    QPainter,
+)
 from PySide6.QtWidgets import (
     QFrame,
-    QGraphicsDropShadowEffect,
+    QGraphicsOpacityEffect,
     QGridLayout,
     QHBoxLayout,
     QLabel,
@@ -35,6 +42,88 @@ from .main_window_metrics import (
     HEADER_ICON_GLYPH_SIZE,
 )
 from .video_area import VideoArea
+
+
+class _PlaybackHeaderShadow(QWidget):
+    """Paint a downward shadow without taking space in the page layout."""
+
+    SHADOW_HEIGHT = 28
+
+    def __init__(
+        self,
+        anchor: QWidget,
+        visibility_source: QWidget,
+        parent: QWidget,
+    ) -> None:
+        super().__init__(parent)
+        self._anchor = anchor
+        self._visibility_source = visibility_source
+        self._header_opacity = 1.0
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        anchor.installEventFilter(self)
+        visibility_source.installEventFilter(self)
+        parent.installEventFilter(self)
+        self._sync_to_anchor()
+
+    def bind_opacity_effect(self, effect: QGraphicsOpacityEffect) -> None:
+        """Keep the overlay in step with the existing header fade animation."""
+
+        self._set_header_opacity(effect.opacity())
+        effect.opacityChanged.connect(self._set_header_opacity)
+
+    def eventFilter(self, watched, event) -> bool:  # noqa: N802
+        if event.type() in {
+            QEvent.Type.Move,
+            QEvent.Type.Resize,
+            QEvent.Type.Show,
+            QEvent.Type.Hide,
+        }:
+            self._sync_to_anchor()
+        return super().eventFilter(watched, event)
+
+    def _sync_to_anchor(self) -> None:
+        parent = self.parentWidget()
+        if parent is None:
+            return
+        origin = self._anchor.mapTo(parent, QPoint(0, 0))
+        available_height = max(0, parent.height() - origin.y())
+        self.setGeometry(
+            origin.x(),
+            origin.y(),
+            self._anchor.width(),
+            min(self.SHADOW_HEIGHT, available_height),
+        )
+        self.setVisible(not self._visibility_source.isHidden())
+        self.raise_()
+
+    def _set_header_opacity(self, opacity: float) -> None:
+        self._header_opacity = max(0.0, min(1.0, float(opacity)))
+        self.update()
+
+    def paintEvent(self, event) -> None:  # noqa: N802
+        if self.height() <= 1:
+            return
+        painter = QPainter(self)
+        painter.setOpacity(self._header_opacity)
+        painter.fillRect(
+            0,
+            0,
+            self.width(),
+            1,
+            QColor(0, 0, 0, 30),
+        )
+
+        gradient = QLinearGradient(0, 1, 0, self.height())
+        gradient.setColorAt(0.00, QColor(0, 0, 0, 46))
+        gradient.setColorAt(0.08, QColor(0, 0, 0, 35))
+        gradient.setColorAt(0.22, QColor(0, 0, 0, 22))
+        gradient.setColorAt(0.42, QColor(0, 0, 0, 11))
+        gradient.setColorAt(0.68, QColor(0, 0, 0, 4))
+        gradient.setColorAt(1.00, QColor(0, 0, 0, 0))
+        painter.fillRect(self.rect().adjusted(0, 1, 0, 0), gradient)
 
 
 class DetailPageWidget(QWidget):
@@ -97,8 +186,11 @@ class DetailPageWidget(QWidget):
         self.detail_header: QWidget | None = None
         self.detail_chrome_container: QWidget | None = None
         self.detail_header_separator: QFrame | None = None
+        self.detail_header_shadow: _PlaybackHeaderShadow | None = None
         self.player_container: QWidget | None = None
         self.player_column: QWidget | None = None
+        self.detail_playback_container: QWidget | None = None
+        self._detail_playback_layout: QVBoxLayout | None = None
 
         self._root_layout = QVBoxLayout(self)
         self._root_layout.setContentsMargins(0, 0, 0, 0)
@@ -161,7 +253,7 @@ class DetailPageWidget(QWidget):
         self.badge_host = self.player_container
 
         self.filmstrip_view = FilmstripView(self)
-        self._build_header(self._main_window, self._root_layout)
+        self._build_header(self._main_window)
         self._root_layout.addWidget(self.filmstrip_view)
         self._feature_completed = True
         self._raise_player_overlays()
@@ -239,7 +331,7 @@ class DetailPageWidget(QWidget):
             if callable(method):
                 method()
 
-    def _build_header(self, main_window: QWidget, parent_layout: QVBoxLayout) -> None:
+    def _build_header(self, main_window: QWidget) -> None:
         """Create the header row containing navigation and metadata controls."""
 
         header = QWidget(self)
@@ -397,24 +489,23 @@ class DetailPageWidget(QWidget):
         header_separator.setFrameShape(QFrame.Shape.HLine)
         header_separator.setFrameShadow(QFrame.Shadow.Plain)
         header_separator.setFixedHeight(2)
-        base_surface = viewer_surface_color(self)
-        separator_tint = QColor(base_surface).darker(108)
         header_separator.setStyleSheet(
             "QFrame#detailHeaderSeparator {"
-            f"  background-color: {separator_tint.name()};"
+            "  background-color: transparent;"
             "  border: none;"
             "}"
         )
-        separator_shadow = QGraphicsDropShadowEffect(header_separator)
-        separator_shadow.setBlurRadius(14)
-        separator_shadow.setColor(QColor(0, 0, 0, 45))
-        separator_shadow.setOffset(0, 1)
-        header_separator.setGraphicsEffect(separator_shadow)
         detail_chrome_layout.addWidget(header_separator)
         self.detail_header_separator = header_separator
 
-        parent_layout.insertWidget(0, detail_chrome_container)
+        assert self._detail_playback_layout is not None
+        self._detail_playback_layout.insertWidget(0, detail_chrome_container)
         self.detail_chrome_container = detail_chrome_container
+        self.detail_header_shadow = _PlaybackHeaderShadow(
+            header_separator,
+            detail_chrome_container,
+            self,
+        )
 
     def _build_player_area(self) -> None:
         """Create the stacked media viewer inside its container."""
@@ -499,7 +590,15 @@ class DetailPageWidget(QWidget):
         self._edit_layout = edit_layout
         self._edit_body_layout = edit_body_layout
 
-        parent_layout.addWidget(edit_container, 1)
+        detail_playback_container = QWidget(self)
+        detail_playback_layout = QVBoxLayout(detail_playback_container)
+        detail_playback_layout.setContentsMargins(0, 0, 0, 0)
+        detail_playback_layout.setSpacing(0)
+        detail_playback_layout.addWidget(edit_container, 1)
+        self.detail_playback_container = detail_playback_container
+        self._detail_playback_layout = detail_playback_layout
+
+        parent_layout.addWidget(detail_playback_container, 1)
 
     def ensure_edit_bundle(self) -> None:
         """Create edit-only controls immediately before the first edit session."""

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -73,6 +73,7 @@ class GalleryListModelAdapter(QAbstractListModel):
 
     _scan_batch_received = QtSignal(object)
     thumbnailBackfillProgress = QtSignal(Path, int, int)
+    thumbnailBackfillCompleted = QtSignal(Path)
     startupGalleryReady = QtSignal()
     startupFirstFrameReady = QtSignal()
 
@@ -1644,7 +1645,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         old_disconnect = getattr(old_signal, "disconnect", None)
         if callable(old_disconnect):
             try:
-                old_disconnect(self.handle_scan_batch)
+                old_disconnect(self._handle_thumbnail_backfill_completed)
             except (RuntimeError, TypeError, ValueError):
                 pass
         old_progress = getattr(
@@ -1663,7 +1664,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         new_signal = getattr(asset_query_service, "thumbnail_backfill_completed", None)
         new_connect = getattr(new_signal, "connect", None)
         if callable(new_connect):
-            new_connect(self.handle_scan_batch)
+            new_connect(self._handle_thumbnail_backfill_completed)
         new_progress = getattr(asset_query_service, "thumbnail_backfill_progress", None)
         new_progress_connect = getattr(new_progress, "connect", None)
         if callable(new_progress_connect):
@@ -1676,6 +1677,14 @@ class GalleryListModelAdapter(QAbstractListModel):
         total: int,
     ) -> None:
         self.thumbnailBackfillProgress.emit(Path(root), int(current), int(total))
+
+    def _handle_thumbnail_backfill_completed(self, batch: object) -> None:
+        """Refresh changed rows and relay the backfill's terminal event."""
+
+        self.handle_scan_batch(batch)
+        root = getattr(batch, "root", None)
+        if root is not None:
+            self.thumbnailBackfillCompleted.emit(Path(root))
 
     def _snapshot_hash(self, count: int) -> bytes:
         del count

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -72,8 +72,10 @@ class GalleryListModelAdapter(QAbstractListModel):
     """Expose a pure Python collection store to Qt item views."""
 
     _scan_batch_received = QtSignal(object)
+    _thumbnail_backfill_completion_received = QtSignal(object)
     thumbnailBackfillProgress = QtSignal(Path, int, int)
     thumbnailBackfillCompleted = QtSignal(Path)
+    thumbnailBackfillFailed = QtSignal(Path, str)
     startupGalleryReady = QtSignal()
     startupFirstFrameReady = QtSignal()
 
@@ -110,6 +112,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._thumbnail_hint_loader.resultReady.connect(self._on_thumbnail_hint_result)
         self._thumbnail_hint_request_id = 0
         self._pending_scan_batch_count = 0
+        self._pending_thumbnail_backfill_completions: dict[Path, None] = {}
         self._pending_selection_anchor_retry: (
             GallerySelectionAnchorRetryTicket | None
         ) = None
@@ -172,6 +175,10 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._startup_first_frame_heartbeat_timer = self._startup_gallery_heartbeat_timer
         self._scan_batch_received.connect(
             self._enqueue_scan_batch_on_ui_thread,
+            Qt.ConnectionType.QueuedConnection,
+        )
+        self._thumbnail_backfill_completion_received.connect(
+            self._enqueue_thumbnail_backfill_completion_on_ui_thread,
             Qt.ConnectionType.QueuedConnection,
         )
         self._store.set_window_request_handler(self._window_loader.request)
@@ -625,7 +632,7 @@ class GalleryListModelAdapter(QAbstractListModel):
             self._scan_batch_received.emit(batch)
 
     @Slot(object)
-    def _enqueue_scan_batch_on_ui_thread(self, batch: object) -> None:
+    def _enqueue_scan_batch_on_ui_thread(self, batch: object) -> bool:
         rows = getattr(batch, "rows", None)
         emit_perf_event(
             "gallery_scan_batch_received",
@@ -640,11 +647,30 @@ class GalleryListModelAdapter(QAbstractListModel):
                 self._pending_scan_batch_count += 1
                 if not self._scan_batch_timer.isActive():
                     self._scan_batch_timer.start()
-            return
+                return True
+            return False
 
         handle_batch = getattr(self._store, "handle_scan_batch", None)
         if callable(handle_batch):
             handle_batch(batch)
+        return False
+
+    @Slot(object)
+    def _enqueue_thumbnail_backfill_completion_on_ui_thread(
+        self,
+        batch: object,
+    ) -> None:
+        """Apply a terminal backfill batch before publishing UI completion."""
+
+        refresh_pending = self._enqueue_scan_batch_on_ui_thread(batch)
+        root = getattr(batch, "root", None)
+        if root is None:
+            return
+        path = Path(root)
+        if refresh_pending:
+            self._pending_thumbnail_backfill_completions[path] = None
+        else:
+            self.thumbnailBackfillCompleted.emit(path)
 
     @Slot()
     def _flush_pending_scan_batches(self) -> None:
@@ -661,6 +687,10 @@ class GalleryListModelAdapter(QAbstractListModel):
             flush()
         else:
             self._on_source_changed()
+        completed_roots = tuple(self._pending_thumbnail_backfill_completions)
+        self._pending_thumbnail_backfill_completions.clear()
+        for root in completed_roots:
+            self.thumbnailBackfillCompleted.emit(root)
 
     def _schedule_thumbnail_backfill_refresh(self) -> None:
         """Compatibility no-op for old tests/fakes that emit this signal."""
@@ -1659,6 +1689,17 @@ class GalleryListModelAdapter(QAbstractListModel):
                 old_progress_disconnect(self._handle_thumbnail_backfill_progress)
             except (RuntimeError, TypeError, ValueError):
                 pass
+        old_failed = getattr(
+            self._backfill_completion_source,
+            "thumbnail_backfill_failed",
+            None,
+        )
+        old_failed_disconnect = getattr(old_failed, "disconnect", None)
+        if callable(old_failed_disconnect):
+            try:
+                old_failed_disconnect(self._handle_thumbnail_backfill_failed)
+            except (RuntimeError, TypeError, ValueError):
+                pass
 
         self._backfill_completion_source = asset_query_service
         new_signal = getattr(asset_query_service, "thumbnail_backfill_completed", None)
@@ -1669,6 +1710,10 @@ class GalleryListModelAdapter(QAbstractListModel):
         new_progress_connect = getattr(new_progress, "connect", None)
         if callable(new_progress_connect):
             new_progress_connect(self._handle_thumbnail_backfill_progress)
+        new_failed = getattr(asset_query_service, "thumbnail_backfill_failed", None)
+        new_failed_connect = getattr(new_failed, "connect", None)
+        if callable(new_failed_connect):
+            new_failed_connect(self._handle_thumbnail_backfill_failed)
 
     def _handle_thumbnail_backfill_progress(
         self,
@@ -1679,12 +1724,15 @@ class GalleryListModelAdapter(QAbstractListModel):
         self.thumbnailBackfillProgress.emit(Path(root), int(current), int(total))
 
     def _handle_thumbnail_backfill_completed(self, batch: object) -> None:
-        """Refresh changed rows and relay the backfill's terminal event."""
+        """Queue completion so it follows the Gallery's model refresh."""
 
-        self.handle_scan_batch(batch)
-        root = getattr(batch, "root", None)
-        if root is not None:
-            self.thumbnailBackfillCompleted.emit(Path(root))
+        if QThread.currentThread() is self.thread():
+            self._enqueue_thumbnail_backfill_completion_on_ui_thread(batch)
+        else:
+            self._thumbnail_backfill_completion_received.emit(batch)
+
+    def _handle_thumbnail_backfill_failed(self, root: Path, error: str) -> None:
+        self.thumbnailBackfillFailed.emit(Path(root), str(error))
 
     def _snapshot_hash(self, count: int) -> bytes:
         del count

--- a/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
+++ b/src/iPhoto/gui/viewmodels/gallery_list_model_adapter.py
@@ -112,7 +112,7 @@ class GalleryListModelAdapter(QAbstractListModel):
         self._thumbnail_hint_loader.resultReady.connect(self._on_thumbnail_hint_result)
         self._thumbnail_hint_request_id = 0
         self._pending_scan_batch_count = 0
-        self._pending_thumbnail_backfill_completions: dict[Path, None] = {}
+        self._pending_thumbnail_backfill_completions: list[Path] = []
         self._pending_selection_anchor_retry: (
             GallerySelectionAnchorRetryTicket | None
         ) = None
@@ -668,7 +668,7 @@ class GalleryListModelAdapter(QAbstractListModel):
             return
         path = Path(root)
         if refresh_pending:
-            self._pending_thumbnail_backfill_completions[path] = None
+            self._pending_thumbnail_backfill_completions.append(path)
         else:
             self.thumbnailBackfillCompleted.emit(path)
 

--- a/src/iPhoto/resources/i18n/iPhoto_de.ts
+++ b/src/iPhoto/resources/i18n/iPhoto_de.ts
@@ -424,6 +424,10 @@
             <translation>Miniaturen aktualisiert.</translation>
         </message>
         <message>
+            <source>Thumbnail update failed.</source>
+            <translation>Miniaturen konnten nicht aktualisiert werden.</translation>
+        </message>
+        <message>
             <source>Loading items…</source>
             <translation>Elemente werden geladen …</translation>
         </message>

--- a/src/iPhoto/resources/i18n/iPhoto_zh_CN.ts
+++ b/src/iPhoto/resources/i18n/iPhoto_zh_CN.ts
@@ -424,6 +424,10 @@
             <translation>缩略图已更新。</translation>
         </message>
         <message>
+            <source>Thumbnail update failed.</source>
+            <translation>缩略图更新失败。</translation>
+        </message>
+        <message>
             <source>Loading items…</source>
             <translation>正在加载项目…</translation>
         </message>

--- a/tests/application/test_library_asset_query_service.py
+++ b/tests/application/test_library_asset_query_service.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from iPhoto.bootstrap.library_asset_query_service import LibraryAssetQueryService
 from iPhoto.cache.index_store import IndexStore
 from iPhoto.config import RECENTLY_DELETED_DIR_NAME
@@ -537,6 +539,35 @@ def test_thumbnail_backfill_failed_rows_publish_empty_completion_batch(tmp_path:
     assert len(batches) == 1
     assert batches[0].ready_count == 0
     assert batches[0].rows == []
+    assert service.thumbnail_backfill_pending() is False
+
+
+def test_thumbnail_backfill_exception_emits_failed_terminal_event(tmp_path: Path) -> None:
+    library_root = tmp_path / "Library"
+    album_root = library_root / "Trip"
+    album_root.mkdir(parents=True)
+    repo = _BackfillRepository()
+    service = LibraryAssetQueryService(library_root, repository_factory=lambda _root: repo)
+    executor = _DeferredExecutor()
+    service._thumbnail_backfill_executor = executor  # type: ignore[assignment]
+    failures: list[tuple[Path, str]] = []
+    batches = []
+    service.thumbnail_backfill_failed.connect(
+        lambda root, error: failures.append((root, error))
+    )
+    service.thumbnail_backfill_completed.connect(batches.append)
+
+    with patch(
+        "iPhoto.bootstrap.library_asset_query_service.ensure_scan_thumbnail",
+        side_effect=RuntimeError("thumbnail decode crashed"),
+    ):
+        assert service.request_thumbnail_backfill(album_root, AssetQuery(), 0, 100) == 1
+        fn, args = executor.submitted[0]
+        with pytest.raises(RuntimeError, match="thumbnail decode crashed"):
+            fn(*args)
+
+    assert failures == [(album_root, "thumbnail decode crashed")]
+    assert batches == []
     assert service.thumbnail_backfill_pending() is False
 
 

--- a/tests/gui/viewmodels/test_gallery_backfill_completion_order.py
+++ b/tests/gui/viewmodels/test_gallery_backfill_completion_order.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from iPhoto.gui.viewmodels.gallery_collection_store import GalleryCollectionStore
+from iPhoto.gui.viewmodels.gallery_list_model_adapter import GalleryListModelAdapter
+from iPhoto.infrastructure.services.thumbnail_cache_service import ThumbnailCacheService
+
+
+def test_same_root_backfill_completions_are_not_deduplicated(qapp) -> None:
+    store = MagicMock(spec=GalleryCollectionStore)
+    store.data_changed = MagicMock()
+    store.window_changed = MagicMock()
+    store.row_changed = MagicMock()
+    store.count.return_value = 0
+    store.asset_query_service = None
+    store.record_scan_batch.return_value = True
+
+    thumbnails = MagicMock(spec=ThumbnailCacheService)
+    adapter = GalleryListModelAdapter(store, thumbnails)
+    adapter._scan_batch_timer.setInterval(60_000)
+
+    root = Path("/library")
+    first_batch = SimpleNamespace(root=root, rows=[{"rel": "a.jpg"}])
+    second_batch = SimpleNamespace(root=root, rows=[{"rel": "b.jpg"}])
+    completed: list[Path] = []
+    adapter.thumbnailBackfillCompleted.connect(completed.append)
+
+    adapter._enqueue_thumbnail_backfill_completion_on_ui_thread(first_batch)
+    adapter._enqueue_thumbnail_backfill_completion_on_ui_thread(second_batch)
+
+    assert completed == []
+    assert store.record_scan_batch.call_count == 2
+
+    adapter._flush_pending_scan_batches()
+
+    store.flush_pending_scan_refresh.assert_called_once_with()
+    assert completed == [root, root]

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -52,6 +53,7 @@ class _Signal:
 class _BackfillService:
     def __init__(self) -> None:
         self.thumbnail_backfill_completed = _Signal()
+        self.thumbnail_backfill_failed = _Signal()
         self.thumbnail_backfill_progress = _Signal()
 
 
@@ -434,9 +436,45 @@ def test_backfill_completion_event_queues_scan_batch(mock_thumb_service):
     adapter.thumbnailBackfillCompleted.connect(completed.append)
 
     service.thumbnail_backfill_completed.emit(batch)
+    assert completed == []
+
     adapter._flush_pending_scan_batches()
 
     store.record_scan_batch.assert_called_once_with(batch)
+    store.flush_pending_scan_refresh.assert_called_once_with()
+    assert completed == [Path("/library")]
+
+
+def test_worker_backfill_completion_waits_for_ui_refresh(qapp, mock_thumb_service):
+    service = _BackfillService()
+    store = MagicMock(spec=GalleryCollectionStore)
+    store.data_changed = MagicMock()
+    store.window_changed = MagicMock()
+    store.row_changed = MagicMock()
+    store.count.return_value = 0
+    store.asset_query_service = service
+    store.record_scan_batch.return_value = True
+    adapter = GalleryListModelAdapter(store, mock_thumb_service)
+    adapter._scan_batch_timer.setInterval(60_000)
+    batch = SimpleNamespace(root=Path("/library"), rows=[{"rel": "ready.jpg"}])
+    completed: list[Path] = []
+    adapter.thumbnailBackfillCompleted.connect(completed.append)
+
+    worker = threading.Thread(
+        target=service.thumbnail_backfill_completed.emit,
+        args=(batch,),
+    )
+    worker.start()
+    worker.join()
+
+    store.record_scan_batch.assert_not_called()
+    assert completed == []
+
+    qapp.processEvents()
+    store.record_scan_batch.assert_called_once_with(batch)
+    assert completed == []
+
+    adapter._flush_pending_scan_batches()
     store.flush_pending_scan_refresh.assert_called_once_with()
     assert completed == [Path("/library")]
 
@@ -565,6 +603,14 @@ def test_rebind_asset_query_service_moves_backfill_completion_signal(
         adapter._handle_thumbnail_backfill_progress
         in new_service.thumbnail_backfill_progress.handlers
     )
+    assert (
+        adapter._handle_thumbnail_backfill_failed
+        not in old_service.thumbnail_backfill_failed.handlers
+    )
+    assert (
+        adapter._handle_thumbnail_backfill_failed
+        in new_service.thumbnail_backfill_failed.handlers
+    )
     mock_store.rebind_asset_query_service.assert_called_once_with(
         new_service,
         Path("/library"),
@@ -588,6 +634,25 @@ def test_backfill_progress_is_relayed_from_query_service(mock_thumb_service):
     service.thumbnail_backfill_progress.emit(Path("/library"), 2, 5)
 
     assert progress == [(Path("/library"), 2, 5)]
+
+
+def test_backfill_failure_is_relayed_from_query_service(mock_thumb_service):
+    service = _BackfillService()
+    store = MagicMock(spec=GalleryCollectionStore)
+    store.data_changed = MagicMock()
+    store.window_changed = MagicMock()
+    store.row_changed = MagicMock()
+    store.count.return_value = 0
+    store.asset_query_service = service
+    adapter = GalleryListModelAdapter(store, mock_thumb_service)
+    failures: list[tuple[Path, str]] = []
+    adapter.thumbnailBackfillFailed.connect(
+        lambda root, error: failures.append((root, error))
+    )
+
+    service.thumbnail_backfill_failed.emit(Path("/library"), "decode crashed")
+
+    assert failures == [(Path("/library"), "decode crashed")]
 
 
 def test_decoration_role_uses_full_size_thumbnail_even_with_micro_fallback(

--- a/tests/gui/viewmodels/test_gallery_list_model_adapter.py
+++ b/tests/gui/viewmodels/test_gallery_list_model_adapter.py
@@ -429,13 +429,16 @@ def test_backfill_completion_event_queues_scan_batch(mock_thumb_service):
     store.asset_query_service = service
     store.record_scan_batch.return_value = True
     adapter = GalleryListModelAdapter(store, mock_thumb_service)
-    batch = SimpleNamespace(rows=[{"rel": "ready.jpg"}])
+    batch = SimpleNamespace(root=Path("/library"), rows=[{"rel": "ready.jpg"}])
+    completed: list[Path] = []
+    adapter.thumbnailBackfillCompleted.connect(completed.append)
 
     service.thumbnail_backfill_completed.emit(batch)
     adapter._flush_pending_scan_batches()
 
     store.record_scan_batch.assert_called_once_with(batch)
     store.flush_pending_scan_refresh.assert_called_once_with()
+    assert completed == [Path("/library")]
 
 
 def test_startup_window_backfill_and_thumbnail_publish_keep_event_loop_responsive(
@@ -546,8 +549,14 @@ def test_rebind_asset_query_service_moves_backfill_completion_signal(
 
     adapter.rebind_asset_query_service(new_service, Path("/library"))
 
-    assert adapter.handle_scan_batch not in old_service.thumbnail_backfill_completed.handlers
-    assert adapter.handle_scan_batch in new_service.thumbnail_backfill_completed.handlers
+    assert (
+        adapter._handle_thumbnail_backfill_completed
+        not in old_service.thumbnail_backfill_completed.handlers
+    )
+    assert (
+        adapter._handle_thumbnail_backfill_completed
+        in new_service.thumbnail_backfill_completed.handlers
+    )
     assert (
         adapter._handle_thumbnail_backfill_progress
         not in old_service.thumbnail_backfill_progress.handlers

--- a/tests/ui/controllers/test_status_bar_controller.py
+++ b/tests/ui/controllers/test_status_bar_controller.py
@@ -100,3 +100,33 @@ def test_album_load_progress_still_hides_when_no_scan_is_active(qapp: QApplicati
     assert progress.minimum() == 0
     assert progress.maximum() == 0
     assert status_bar.currentMessage() == "Album loaded."
+
+
+def test_empty_thumbnail_backfill_does_not_show_progress(qapp: QApplication) -> None:
+    controller, status_bar, _action = _make_controller(qapp)
+    progress = status_bar.progress_bar
+
+    controller.handle_thumbnail_backfill_progress(Path("/library"), 0, 0)
+    controller.handle_thumbnail_backfill_completed(Path("/library"))
+
+    assert progress.isHidden()
+    assert controller._progress_context is None
+    assert status_bar.currentMessage() == ""
+
+
+def test_thumbnail_completion_hides_progress_before_count_reaches_total(
+    qapp: QApplication,
+) -> None:
+    controller, status_bar, _action = _make_controller(qapp)
+    progress = status_bar.progress_bar
+
+    controller.handle_thumbnail_backfill_progress(Path("/library"), 2, 5)
+    assert not progress.isHidden()
+
+    controller.handle_thumbnail_backfill_completed(Path("/library"))
+
+    assert progress.isHidden()
+    assert progress.minimum() == 0
+    assert progress.maximum() == 0
+    assert controller._progress_context is None
+    assert status_bar.currentMessage() == "Thumbnails updated."

--- a/tests/ui/controllers/test_status_bar_controller.py
+++ b/tests/ui/controllers/test_status_bar_controller.py
@@ -130,3 +130,35 @@ def test_thumbnail_completion_hides_progress_before_count_reaches_total(
     assert progress.maximum() == 0
     assert controller._progress_context is None
     assert status_bar.currentMessage() == "Thumbnails updated."
+
+
+def test_thumbnail_final_progress_waits_for_model_completion(qapp: QApplication) -> None:
+    controller, status_bar, _action = _make_controller(qapp)
+    progress = status_bar.progress_bar
+
+    controller.handle_thumbnail_backfill_progress(Path("/library"), 5, 5)
+
+    assert not progress.isHidden()
+    assert progress.value() == 5
+    assert controller._progress_context == "thumbnail"
+    assert status_bar.currentMessage() == "Updating thumbnails… (5/5)"
+
+    controller.handle_thumbnail_backfill_completed(Path("/library"))
+
+    assert progress.isHidden()
+    assert controller._progress_context is None
+    assert status_bar.currentMessage() == "Thumbnails updated."
+
+
+def test_thumbnail_failure_hides_in_progress_feedback(qapp: QApplication) -> None:
+    controller, status_bar, _action = _make_controller(qapp)
+    progress = status_bar.progress_bar
+
+    controller.handle_thumbnail_backfill_progress(Path("/library"), 2, 5)
+    controller.handle_thumbnail_backfill_failed(Path("/library"), "decode crashed")
+
+    assert progress.isHidden()
+    assert progress.minimum() == 0
+    assert progress.maximum() == 0
+    assert controller._progress_context is None
+    assert status_bar.currentMessage() == "Thumbnail update failed."

--- a/tests/ui/controllers/test_status_bar_controller.py
+++ b/tests/ui/controllers/test_status_bar_controller.py
@@ -111,6 +111,7 @@ def test_empty_thumbnail_backfill_does_not_show_progress(qapp: QApplication) -> 
 
     assert progress.isHidden()
     assert controller._progress_context is None
+    assert controller._thumbnail_backfill_active_requests == 0
     assert status_bar.currentMessage() == ""
 
 
@@ -148,6 +149,64 @@ def test_thumbnail_final_progress_waits_for_model_completion(qapp: QApplication)
     assert progress.isHidden()
     assert controller._progress_context is None
     assert status_bar.currentMessage() == "Thumbnails updated."
+
+
+def test_stale_thumbnail_completion_does_not_hide_newer_backfill(
+    qapp: QApplication,
+) -> None:
+    controller, status_bar, _action = _make_controller(qapp)
+    progress = status_bar.progress_bar
+    root = Path("/library")
+
+    # Request A reaches its final progress update, but its model-refresh-backed
+    # completion is delayed. Request B starts before that terminal event lands.
+    controller.handle_thumbnail_backfill_progress(root, 0, 5)
+    controller.handle_thumbnail_backfill_progress(root, 5, 5)
+    controller.handle_thumbnail_backfill_progress(root, 0, 8)
+    controller.handle_thumbnail_backfill_progress(root, 1, 8)
+
+    controller.handle_thumbnail_backfill_completed(root)
+
+    assert controller._thumbnail_backfill_active_requests == 1
+    assert controller._progress_context == "thumbnail"
+    assert not progress.isHidden()
+    assert progress.maximum() == 8
+    assert progress.value() == 1
+    assert status_bar.currentMessage() == "Updating thumbnails… (1/8)"
+
+    controller.handle_thumbnail_backfill_completed(root)
+
+    assert controller._thumbnail_backfill_active_requests == 0
+    assert controller._progress_context is None
+    assert progress.isHidden()
+    assert status_bar.currentMessage() == "Thumbnails updated."
+
+
+def test_overlapping_thumbnail_failure_waits_for_remaining_request(
+    qapp: QApplication,
+) -> None:
+    controller, status_bar, _action = _make_controller(qapp)
+    progress = status_bar.progress_bar
+    root = Path("/library")
+
+    controller.handle_thumbnail_backfill_progress(root, 0, 5)
+    controller.handle_thumbnail_backfill_progress(root, 0, 8)
+    controller.handle_thumbnail_backfill_progress(root, 1, 8)
+
+    controller.handle_thumbnail_backfill_failed(root, "decode crashed")
+
+    assert controller._thumbnail_backfill_active_requests == 1
+    assert controller._progress_context == "thumbnail"
+    assert not progress.isHidden()
+    assert progress.maximum() == 8
+    assert progress.value() == 1
+
+    controller.handle_thumbnail_backfill_completed(root)
+
+    assert controller._thumbnail_backfill_active_requests == 0
+    assert controller._progress_context is None
+    assert progress.isHidden()
+    assert status_bar.currentMessage() == "Thumbnail update failed."
 
 
 def test_thumbnail_failure_hides_in_progress_feedback(qapp: QApplication) -> None:

--- a/tests/ui/widgets/test_detail_page_shadow.py
+++ b/tests/ui/widgets/test_detail_page_shadow.py
@@ -5,6 +5,11 @@ from PySide6.QtWidgets import QFrame, QMainWindow, QStackedWidget, QWidget
 from iPhoto.gui.ui.widgets.detail_page import DetailPageWidget, _PlaybackHeaderShadow
 
 
+class _StubPlayerBar(QWidget):
+    def retranslate_ui(self) -> None:
+        pass
+
+
 def test_playback_header_shadow_extends_beyond_chrome_without_changing_layout(qapp):
     root = QWidget()
     root.resize(200, 80)
@@ -36,13 +41,24 @@ def test_playback_header_shadow_extends_beyond_chrome_without_changing_layout(qa
     assert below == 255
 
 
-def test_playback_surface_touches_header_separator_but_keeps_filmstrip_gap(qapp):
+def test_playback_surface_touches_header_separator_but_keeps_filmstrip_gap(
+    qapp,
+    monkeypatch,
+):
     window = QMainWindow()
     window.resize(1200, 800)
     stack = QStackedWidget(window)
     window.setCentralWidget(stack)
     detail = DetailPageWidget(window, parent=stack, staged=True)
     stack.addWidget(detail)
+
+    # This is a layout contract, not a multimedia integration test. Keep the
+    # staged native surfaces in place but avoid constructing QMediaPlayer /
+    # QAudioOutput / QVideoSink on headless Linux CI.
+    monkeypatch.setattr(detail.image_viewer, "complete_runtime", lambda: None)
+    monkeypatch.setattr(detail.video_area, "complete_runtime", lambda: None)
+    detail.video_area._player_bar = _StubPlayerBar(detail.video_area)
+
     detail.complete_feature()
     window.show()
     qapp.processEvents()

--- a/tests/ui/widgets/test_detail_page_shadow.py
+++ b/tests/ui/widgets/test_detail_page_shadow.py
@@ -1,0 +1,74 @@
+from PySide6.QtCore import QRect, Qt
+from PySide6.QtGui import QColor, QImage
+from PySide6.QtWidgets import QFrame, QMainWindow, QStackedWidget, QWidget
+
+from iPhoto.gui.ui.widgets.detail_page import DetailPageWidget, _PlaybackHeaderShadow
+
+
+def test_playback_header_shadow_extends_beyond_chrome_without_changing_layout(qapp):
+    root = QWidget()
+    root.resize(200, 80)
+    root.setStyleSheet("background: white;")
+
+    chrome = QWidget(root)
+    chrome.setGeometry(0, 0, 200, 22)
+    separator = QFrame(chrome)
+    separator.setGeometry(0, 20, 200, 2)
+    separator.setStyleSheet("background: transparent; border: none;")
+
+    shadow = _PlaybackHeaderShadow(separator, chrome, root)
+    root.show()
+    qapp.processEvents()
+
+    assert separator.geometry() == QRect(0, 20, 200, 2)
+    assert shadow.geometry() == QRect(0, 20, 200, 28)
+    assert shadow.testAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+
+    image = QImage(root.size(), QImage.Format.Format_ARGB32_Premultiplied)
+    image.fill(QColor("white"))
+    root.render(image)
+
+    top = image.pixelColor(100, 21).red()
+    middle = image.pixelColor(100, 30).red()
+    tail = image.pixelColor(100, 47).red()
+    below = image.pixelColor(100, 48).red()
+    assert top < middle < tail <= below
+    assert below == 255
+
+
+def test_playback_surface_touches_header_separator_but_keeps_filmstrip_gap(qapp):
+    window = QMainWindow()
+    window.resize(1200, 800)
+    stack = QStackedWidget(window)
+    window.setCentralWidget(stack)
+    detail = DetailPageWidget(window, parent=stack, staged=True)
+    stack.addWidget(detail)
+    detail.complete_feature()
+    window.show()
+    qapp.processEvents()
+
+    separator_bottom = (
+        detail.detail_header_separator.mapTo(
+            detail,
+            detail.detail_header_separator.rect().bottomLeft(),
+        ).y()
+        + 1
+    )
+    player_top = detail.player_container.mapTo(
+        detail,
+        detail.player_container.rect().topLeft(),
+    ).y()
+    player_bottom = (
+        detail.player_container.mapTo(
+            detail,
+            detail.player_container.rect().bottomLeft(),
+        ).y()
+        + 1
+    )
+    filmstrip_top = detail.filmstrip_view.mapTo(
+        detail,
+        detail.filmstrip_view.rect().topLeft(),
+    ).y()
+
+    assert player_top == separator_bottom
+    assert filmstrip_top - player_bottom == 6


### PR DESCRIPTION
This pull request introduces several improvements to the thumbnail backfill progress feedback and refines the detail page header shadow implementation in the UI. Notably, it adds a completion signal for thumbnail backfill, ensures the progress bar is correctly hidden when work is complete or unnecessary, and replaces the old drop shadow effect with a custom painted shadow overlay. New tests are included to verify these behaviors.

**Thumbnail backfill progress and completion handling:**

* Added a new `thumbnailBackfillCompleted` signal in `GalleryListModelAdapter`, relayed from the asset query service, and connected it through the coordinator and status bar to ensure the progress bar is hidden and a completion message is shown when backfill is done. Also, empty backfill (0/0) no longer shows the progress bar. [[1]](diffhunk://#diff-6c8535bb4590d3705b845e4ac70fdc337b58bb92582e0c8c3d3545db52903ff2R76) [[2]](diffhunk://#diff-6c8535bb4590d3705b845e4ac70fdc337b58bb92582e0c8c3d3545db52903ff2R1681-R1688) [[3]](diffhunk://#diff-a3c177731928001664cc267556065595f95377732817d73bd29d0e9c86914815R706-R708) [[4]](diffhunk://#diff-8b13ce72a201f5799a345416af6937c290560469ed1b4f108b2028e0e0208f95R135-R139) [[5]](diffhunk://#diff-8b13ce72a201f5799a345416af6937c290560469ed1b4f108b2028e0e0208f95R161-R170)
* Updated tests to verify that the progress bar behaves correctly for empty and completed backfills, and that the new signal is properly connected/disconnected. [[1]](diffhunk://#diff-9756256a23ffcda81d28ce9fa51ba1ef71b4188274f0e1eb951fb695aeb82571L432-R441) [[2]](diffhunk://#diff-9756256a23ffcda81d28ce9fa51ba1ef71b4188274f0e1eb951fb695aeb82571L549-R559) [[3]](diffhunk://#diff-21ff502280602e7f6ca05d0a5ad38a9fd81550eb496b9fab58cefb0ceb6a411cR103-R132)

**Detail page header shadow improvements:**

* Replaced the old `QGraphicsDropShadowEffect` on the header separator with a new `_PlaybackHeaderShadow` widget that paints a custom shadow overlay, follows the header's fade animation, and does not affect layout. [[1]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fL5-R16) [[2]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fR47-R128) [[3]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fL400-R508) [[4]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fL242-R334) [[5]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fR189-R193) [[6]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fL164-R256) [[7]](diffhunk://#diff-b8c71ae6f4681865a24050321cc060feeb7b92d39b8a270ccaaa49d24a021d5fL502-R601) [[8]](diffhunk://#diff-9b017a1fb58fb30d480ea1abff6758b109aa4b7242e73d0473dfec485ede169aR75-R79)
* Added tests to verify the shadow overlay's geometry, rendering, and integration with the detail page layout.

These changes collectively improve user feedback during thumbnail generation and enhance the visual polish and maintainability of the detail page header area.