### PR TITLE
Harden first-media composition for Windows

### DIFF
--- a/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
+++ b/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
@@ -50,6 +50,26 @@ powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_d
    collector window to stop it.
 5. Send back the single ZIP path printed in green. By default it is created on the Desktop.
 
+## First-media compositor A/B
+
+For the Windows-only first-open leak, run from a fresh process so no Detail
+QRhi surface has already been submitted. Test both configurations:
+
+```powershell
+$env:IPHOTO_RHI_BACKEND = "opengl"
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1
+
+$env:IPHOTO_RHI_BACKEND = "d3d11"
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1
+```
+
+For each backend, repeat first still, plain video, adjusted video, and Live
+Photo opening from 30 clean launches. Also exercise Edit, fullscreen, paused
+raw/adjusted switching, and opening/closing Maps. `stderr.log` must contain the
+`Main-window graphics contract` entry. OpenGL runs should report an alpha
+buffer greater than zero; a missing/zero value is a failed graphics contract,
+not a successful reproduction run.
+
 The default timeout is 30 minutes. Override it with `-MaxMinutes 60` if the scan takes longer.
 The expanded directory is retained beside the ZIP so its contents can be reviewed before
 sharing.

--- a/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
+++ b/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
@@ -50,7 +50,7 @@ powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_d
    collector window to stop it.
 5. Send back the single ZIP path printed in green. By default it is created on the Desktop.
 
-## First-media compositor A/B
+## First-media QRhi submission A/B
 
 For the Windows-only first-open leak, run from a fresh process so no Detail
 QRhi surface has already been submitted. Test both configurations:
@@ -64,11 +64,19 @@ powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_d
 ```
 
 For each backend, repeat first still, plain video, adjusted video, and Live
-Photo opening from 30 clean launches. Also exercise Edit, fullscreen, paused
-raw/adjusted switching, and opening/closing Maps. `stderr.log` must contain the
-`Main-window graphics contract` entry. OpenGL runs should report an alpha
-buffer greater than zero; a missing/zero value is a failed graphics contract,
-not a successful reproduction run.
+Photo opening from 30 clean launches. Exercise Edit, fullscreen, and paused
+raw/adjusted switching in both modes. Only the supported OpenGL baseline should
+exercise opening/closing Maps. The experimental D3D11 run is Detail-only and
+must not enter Location or create a GPU map widget.
+
+`stderr.log` must contain the `Main-window graphics contract` entry. OpenGL
+runs should report an alpha buffer greater than zero; a missing/zero value is a
+failed graphics contract, not a successful reproduction run.
+
+The extra active-surface `frameSubmitted` is a QRhi submission heuristic, not a
+DXGI/DWM presentation fence. It verifies the application state machine and an
+additional Qt composition submission; only the real Windows repetition matrix
+can determine whether it fixes the user-visible first-frame leak.
 
 The default timeout is 30 minutes. Override it with `-MaxMinutes 60` if the scan takes longer.
 The expanded directory is retained beside the ZIP so its contents can be reviewed before

--- a/docs/development.md
+++ b/docs/development.md
@@ -382,7 +382,8 @@ available.
 Media preview widgets use QRhi backend selection rather than a fixed raw-GL
 path. `IPHOTO_RHI_BACKEND=auto` selects Metal on macOS when Qt exposes it, and
 OpenGL elsewhere. Use `IPHOTO_RHI_BACKEND=opengl` to force the legacy OpenGL
-path for diagnostics.
+path for diagnostics. On Windows, `IPHOTO_RHI_BACKEND=d3d11` enables the
+pure-QRhi/HLSL path for A/B validation; it is not yet the `auto` default.
 
 ### Upstream sub-project: `PySide6-OsmAnd-SDK`
 
@@ -608,7 +609,7 @@ runtime binaries:
 | `IPHOTO_DISABLE_OPENGL` | Set to `1` to force CPU/fallback rendering where supported |
 | `IPHOTO_MAP_GL_DEBUG` | Set to `1` to print one-shot map GL surface diagnostics |
 | `IPHOTO_OSMAND_GL_PARTIAL_UPDATE` | Set to `1` to allow partial updates on platforms that default to full GL repaint |
-| `IPHOTO_RHI_BACKEND` | `auto`, `metal`, or `opengl` for media preview QRhi backend selection |
+| `IPHOTO_RHI_BACKEND` | `auto`, `metal`, `opengl`, or Windows-only `d3d11` for media preview QRhi backend selection |
 | `IPHOTO_ALLOW_PACKAGED_LINUX_WAYLAND` | Set to `1` only when deliberately testing packaged Linux maps outside the default XCB/GLX path |
 
 Example:

--- a/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
+++ b/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
@@ -45,8 +45,8 @@ The following pieces exist and are covered by code-level contracts:
 - Detail still, adjusted-video, and native-video QRhi paths have non-OpenGL
   renderer implementations.
 - Image, overlay, and video QSB assets contain HLSL Shader Model 5.0 variants.
-- First-media reveal is content-identity based and remains covered through the
-  Windows post-submit composition frame.
+- First-media reveal is content-identity based and waits for an additional
+  active-surface QRhi `frameSubmitted` before removing the cover on Windows.
 - Transition epochs reject delayed submissions from an older media request,
   resource generation, or raw/adjusted surface transition.
 - The Detail cover is persistent for the page lifetime and does not require
@@ -54,6 +54,14 @@ The following pieces exist and are covered by code-level contracts:
 
 This is sufficient for focused Detail compositor A/B experiments. It is not a
 complete application graphics contract.
+
+### Guarantee boundary of the extra submission
+
+The Windows reveal workaround proves that Qt/QRhi submitted an additional
+active-surface composition after the matching media content submission. It is
+a deterministic state-machine barrier, but it is **not** a DXGI presentation
+fence and does not prove that Windows DWM scanned either submission to the
+display. Real Windows repetition remains required to validate the visible bug.
 
 ## Unsupported and unsafe scenarios
 

--- a/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
+++ b/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
@@ -1,0 +1,199 @@
+# Windows D3D11 QRhi Status and Roadmap
+
+> **Status: experimental Detail-only A/B path.**
+>
+> Windows production behavior remains `IPHOTO_RHI_BACKEND=auto`, which currently
+> selects OpenGL. `IPHOTO_RHI_BACKEND=d3d11` does **not** mean that the entire
+> application supports D3D11. In particular, GPU Maps in the main window are not
+> compatible with the current D3D11 experiment.
+
+This document records what the Windows D3D11 QRhi path can do today, what is
+deliberately unsupported, and what must be completed before D3D11 can become a
+product backend. It is a maintenance contract, not an announcement of complete
+Windows D3D11 support.
+
+## Current production contract
+
+The supported Windows configuration is:
+
+```text
+IPHOTO_RHI_BACKEND=auto
+    -> media Detail QRhi backend: OpenGL
+    -> MainWindow graphics contract: OpenGL-compatible
+    -> Location GPU paths: MapGLWidget / native OsmAnd OpenGL allowed
+```
+
+The explicit `opengl` override selects the same media graphics API and is useful
+for diagnostics:
+
+```powershell
+$env:IPHOTO_RHI_BACKEND = "opengl"
+python .\src\entrypoint.py
+```
+
+The transparent, frameless Windows main window requests an 8-bit alpha buffer
+for the global OpenGL surface format. After the first main-window paint, startup
+logs a `Main-window graphics contract` entry containing the selected backend,
+actual `QSurface` type, actual alpha bits, and the translucent/frameless flags.
+
+## What the D3D11 experiment currently provides
+
+The following pieces exist and are covered by code-level contracts:
+
+- `IPHOTO_RHI_BACKEND=d3d11` selects `QRhiWidget.Api.Direct3D11` on Windows.
+- Startup recognizes and validates a `QSurface::Direct3DSurface` top-level.
+- Detail still, adjusted-video, and native-video QRhi paths have non-OpenGL
+  renderer implementations.
+- Image, overlay, and video QSB assets contain HLSL Shader Model 5.0 variants.
+- First-media reveal is content-identity based and remains covered through the
+  Windows post-submit composition frame.
+- Transition epochs reject delayed submissions from an older media request,
+  resource generation, or raw/adjusted surface transition.
+- The Detail cover is persistent for the page lifetime and does not require
+  widget deletion/recreation between media transitions.
+
+This is sufficient for focused Detail compositor A/B experiments. It is not a
+complete application graphics contract.
+
+## Unsupported and unsafe scenarios
+
+### GPU Maps in the same MainWindow
+
+The Location feature can lazily create either of these OpenGL-backed paths:
+
+- `MapGLWidget(QOpenGLWidget)` for the Python GPU renderer;
+- a native OsmAnd widget that hosts a native C++ OpenGL widget.
+
+Location is inserted into the same `MainWindow` widget hierarchy as the Detail
+QRhi widgets. A D3D11-owned top-level and an OpenGL composited child therefore
+do not form a supported single-window graphics contract.
+
+Until backend-aware Maps negotiation is implemented, do not treat this flow as
+safe under the D3D11 experiment:
+
+```text
+Detail (D3D11) -> Location (OpenGL) -> Detail (D3D11)
+```
+
+The current code does not yet prevent this navigation or automatically force
+the CPU `MapWidget`. Developers using `d3d11` must avoid GPU Maps and must not
+ship that configuration to users.
+
+### Global Desktop OpenGL initialization
+
+Windows startup still configures shared/Desktop OpenGL defaults because the
+production Maps architecture uses OpenGL. That means the current experiment can
+report:
+
+```text
+media QRhi selection = D3D11
+global map/OpenGL initialization = Desktop OpenGL
+```
+
+This is an intentional incomplete boundary, not the final design. Backend
+selection is not yet the single source of truth for all graphics initialization.
+
+### No runtime API fallback
+
+There is no supported hot fallback from a failed D3D11 `renderFailed` signal to
+OpenGL. A QRhi API affects the containing top-level window and must be selected
+before the native hierarchy is shown. Recreating or changing that contract at
+runtime would invalidate the startup and resource-lifecycle guarantees.
+
+To recover, close the application and restart with `auto` or `opengl`.
+
+### Validation gaps
+
+The repository has unit and offscreen state-machine contracts, but it does not
+yet establish production parity for all of the following on a real Windows
+compositor:
+
+- first still, plain video, adjusted video, and Live Photo after a cold launch;
+- rapid image/video navigation and paused raw/adjusted switching;
+- minimize/restore, resize, fullscreen, and Edit;
+- Location navigation and every map backend;
+- packaged/Nuitka builds across Intel, AMD, NVIDIA, and software adapters.
+
+## Support matrix
+
+| Platform/configuration | Detail media | GPU Maps in MainWindow | Status |
+|---|---|---|---|
+| Windows `auto` | OpenGL QRhi | Supported existing OpenGL paths | Production/default |
+| Windows `opengl` | OpenGL QRhi | Supported existing OpenGL paths | Supported diagnostic override |
+| Windows `d3d11` | D3D11 QRhi/HLSL | **Unsupported** | Developer Detail-only A/B experiment |
+| macOS `auto` | Metal QRhi | Existing platform-specific map contract | Unchanged |
+| Linux `auto` | OpenGL QRhi | Existing OpenGL/native paths | Unchanged |
+
+## Running a focused A/B experiment
+
+Always start a fresh process so no previous Detail surface or top-level graphics
+contract is reused.
+
+```powershell
+# Production baseline
+$env:IPHOTO_RHI_BACKEND = "opengl"
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1
+
+# Experimental Detail-only path; do not open GPU Maps
+$env:IPHOTO_RHI_BACKEND = "d3d11"
+powershell -ExecutionPolicy Bypass -File .\tools\collect_windows_scan_playback_diagnostics.ps1
+```
+
+The collector enables `qt.qpa.gl`, `qt.rhi.*`, multimedia, and application
+runtime diagnostics. Inspect `stderr.log` for `Main-window graphics contract`:
+
+- OpenGL should report an OpenGL-compatible surface and alpha bits greater than
+  zero for the translucent main window.
+- D3D11 should report `Direct3DSurface` and the Direct3D11 media backend.
+- Any pre-show surface contract failure, `renderFailed`, permanent cover, blank
+  media, or unexpected native-window recreation invalidates that run.
+
+The full reproduction procedure and privacy notes are in
+[WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md](../WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md).
+
+Return to the production path with either command:
+
+```powershell
+$env:IPHOTO_RHI_BACKEND = "opengl"
+# or
+Remove-Item Env:IPHOTO_RHI_BACKEND -ErrorAction SilentlyContinue
+```
+
+## Required work before full D3D11 support
+
+Complete these items in order:
+
+1. Introduce one graphics-backend capability policy used by Detail, Maps, and
+   startup configuration instead of reading backend/environment state in
+   separate subsystems.
+2. Under D3D11, force Location to a pure QWidget/CPU `MapWidget` and prevent
+   creation of `MapGLWidget`, native OsmAnd OpenGL widgets, and other OpenGL map
+   children in the D3D11-owned `MainWindow`.
+3. Make global Desktop OpenGL initialization backend-aware. D3D11 mode must not
+   configure OpenGL as though it owned the main top-level; any retained OpenGL
+   use must have an explicitly isolated and validated native contract.
+4. Add fail-fast capability reporting so the UI explains that GPU Maps are
+   unavailable in D3D11 mode rather than discovering the conflict during lazy
+   Location construction.
+5. Run the real Windows navigation matrix for OpenGL and D3D11, including at
+   least 30 clean launches per first-media category, Maps, Edit, fullscreen,
+   resource recreation, and packaged builds.
+6. Promote D3D11 to `auto` only after the complete matrix passes and the
+   documentation, diagnostics, packaging, and fallback policy agree on one
+   application-wide graphics contract.
+
+Longer-term alternatives, such as a D3D/QRhi map renderer or a separately owned
+native map window, require their own design and validation. They are not implied
+by the current experimental override.
+
+## Source-of-truth locations
+
+- Media QRhi selection: `src/iPhoto/gui/render_backend.py`
+- Top-level surface validation and diagnostics: `src/iPhoto/gui/main.py`
+- Detail still/video QRhi widgets: `src/iPhoto/gui/ui/widgets/`
+- Python OpenGL map widget: `src/maps/map_widget/map_gl_widget.py`
+- Native OsmAnd OpenGL host: `src/maps/map_widget/native_osmand_widget.py`
+- Location map construction: `src/iPhoto/gui/ui/widgets/photo_map_view.py`
+
+When these files change, update this document if the support matrix or any
+experimental restriction changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,8 @@ line-length = 100
 testpaths = ["tests"]
 addopts = "-ra -p no:pytestqt"
 markers = [
+    "gpu: requires a render-capable GPU/window-system integration environment",
+    "windows_compositor: requires a visible Windows compositor integration runner",
     "maps_scale_contract: large synthetic map marker clustering contract",
     "pets_model_contract: real official YOLOX model and image contract",
     "pets_scale_contract: large synthetic Pets incremental-index contract",

--- a/src/iPhoto/gui/main.py
+++ b/src/iPhoto/gui/main.py
@@ -366,7 +366,10 @@ def _map_gl_surface_format(platform: str | None = None) -> QSurfaceFormat:
     surface_format.setRenderableType(QSurfaceFormat.RenderableType.OpenGL)
     surface_format.setDepthBufferSize(24)
     surface_format.setStencilBufferSize(8)
-    surface_format.setAlphaBufferSize(8 if platform == "darwin" else 0)
+    # The frameless top-level uses WA_TranslucentBackground on macOS and
+    # Windows. OpenGL composition must not proactively request a zero-bit alpha
+    # surface on either platform.
+    surface_format.setAlphaBufferSize(8 if platform in {"darwin", "win32"} else 0)
     surface_format.setSamples(0)
     return surface_format
 
@@ -483,6 +486,8 @@ def _prepare_top_level_rhi_surface(window: object, backend_name: str) -> str:
 
     targets_by_backend = {
         "metal": (QSurface.SurfaceType.MetalSurface,),
+        "direct3d11": (QSurface.SurfaceType.Direct3DSurface,),
+        "d3d11": (QSurface.SurfaceType.Direct3DSurface,),
         "opengl": (
             QSurface.SurfaceType.OpenGLSurface,
             QSurface.SurfaceType.RasterGLSurface,
@@ -514,6 +519,62 @@ def _prepare_top_level_rhi_surface(window: object, backend_name: str) -> str:
             f"{', '.join(target.name for target in targets)}"
         )
     return actual_surface_type.name
+
+
+def _top_level_graphics_contract(
+    window: object,
+    backend_name: str,
+    *,
+    platform: str | None = None,
+) -> dict[str, object]:
+    """Inspect the created top-level graphics contract after its first paint."""
+
+    platform = sys.platform if platform is None else platform
+    handle_accessor = getattr(window, "windowHandle", None)
+    handle = handle_accessor() if callable(handle_accessor) else None
+    surface_type = "missing"
+    actual_alpha_bits = -1
+    if handle is not None:
+        surface_type_getter = getattr(handle, "surfaceType", None)
+        if callable(surface_type_getter):
+            surface_type_value = surface_type_getter()
+            surface_type = getattr(surface_type_value, "name", str(surface_type_value))
+        format_getter = getattr(handle, "format", None)
+        if callable(format_getter):
+            actual_format = format_getter()
+            alpha_getter = getattr(actual_format, "alphaBufferSize", None)
+            if callable(alpha_getter):
+                actual_alpha_bits = int(alpha_getter())
+
+    test_attribute = getattr(window, "testAttribute", None)
+    translucent = bool(
+        callable(test_attribute)
+        and test_attribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+    )
+    flags_getter = getattr(window, "windowFlags", None)
+    flags = flags_getter() if callable(flags_getter) else Qt.WindowType.Widget
+    frameless = bool(flags & Qt.WindowType.FramelessWindowHint)
+    payload = {
+        "backend": str(backend_name),
+        "surface_type": surface_type,
+        "actual_alpha_bits": actual_alpha_bits,
+        "translucent": translucent,
+        "frameless": frameless,
+    }
+    mark("main_window.graphics_contract", **payload)
+    _logger.info("Main-window graphics contract: %s", payload)
+    if (
+        platform == "win32"
+        and str(backend_name).strip().lower() == "opengl"
+        and translucent
+        and actual_alpha_bits <= 0
+    ):
+        _logger.warning(
+            "Windows translucent OpenGL top-level has no confirmed alpha buffer: %s. "
+            "Re-run with QT_LOGGING_RULES=qt.qpa.gl=true;qt.rhi.*=true",
+            payload,
+        )
+    return payload
 
 
 def _startup_timing_plan(platform: str | None = None) -> _StartupTimingPlan:
@@ -1171,6 +1232,16 @@ def main(argv: list[str] | None = None) -> int:
 
     def _continue_after_shell() -> None:
         startup_input_guard.release()
+        try:
+            _top_level_graphics_contract(
+                window,
+                selected_rhi_backend_name(),
+            )
+        except Exception:  # noqa: BLE001
+            _logger.warning(
+                "Failed to inspect the post-paint graphics contract",
+                exc_info=True,
+            )
         generation = startup.generation
         if startup_timing.first_post_paint_delay_ms > 0:
             QTimer.singleShot(

--- a/src/iPhoto/gui/render_backend.py
+++ b/src/iPhoto/gui/render_backend.py
@@ -35,17 +35,20 @@ def select_qrhi_widget_api() -> "QRhiWidget.Api":
     opengl_api = _qt_api("OpenGL")
     metal_api = _qt_api("Metal")
     d3d11_api = _qt_api("Direct3D11")
-    if opengl_api is None:
-        raise RuntimeError("This Qt build does not expose the QRhi OpenGL backend")
+
+    def require_opengl() -> "QRhiWidget.Api":
+        if opengl_api is None:
+            raise RuntimeError("This Qt build does not expose the QRhi OpenGL backend")
+        return opengl_api
 
     if override == "opengl":
-        return opengl_api
+        return require_opengl()
 
     if override == "metal":
         if metal_api is not None:
             return metal_api
         _LOGGER.warning("IPHOTO_RHI_BACKEND=metal requested but this Qt build has no Metal QRhi backend")
-        return opengl_api
+        return require_opengl()
 
     if override == "d3d11":
         if sys.platform == "win32" and d3d11_api is not None:
@@ -54,11 +57,11 @@ def select_qrhi_widget_api() -> "QRhiWidget.Api":
             "IPHOTO_RHI_BACKEND=d3d11 requested outside a compatible Windows Qt build; "
             "falling back to OpenGL"
         )
-        return opengl_api
+        return require_opengl()
 
     if sys.platform == "darwin" and metal_api is not None:
         return metal_api
-    return opengl_api
+    return require_opengl()
 
 
 def selected_rhi_backend_name() -> str:

--- a/src/iPhoto/gui/render_backend.py
+++ b/src/iPhoto/gui/render_backend.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QRhiWidget
 
 _LOGGER = logging.getLogger(__name__)
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
-_VALID_BACKENDS = {"auto", "metal", "opengl"}
+_VALID_BACKENDS = {"auto", "metal", "opengl", "d3d11"}
 
 
 def _normalised_backend_override() -> str:
@@ -18,7 +18,7 @@ def _normalised_backend_override() -> str:
     if raw_value in _VALID_BACKENDS:
         return raw_value
     _LOGGER.warning(
-        "Ignoring unsupported IPHOTO_RHI_BACKEND=%r; expected auto, metal, or opengl",
+        "Ignoring unsupported IPHOTO_RHI_BACKEND=%r; expected auto, metal, opengl, or d3d11",
         raw_value,
     )
     return "auto"
@@ -34,6 +34,7 @@ def select_qrhi_widget_api() -> "QRhiWidget.Api":
     override = _normalised_backend_override()
     opengl_api = _qt_api("OpenGL")
     metal_api = _qt_api("Metal")
+    d3d11_api = _qt_api("Direct3D11")
     if opengl_api is None:
         raise RuntimeError("This Qt build does not expose the QRhi OpenGL backend")
 
@@ -44,6 +45,15 @@ def select_qrhi_widget_api() -> "QRhiWidget.Api":
         if metal_api is not None:
             return metal_api
         _LOGGER.warning("IPHOTO_RHI_BACKEND=metal requested but this Qt build has no Metal QRhi backend")
+        return opengl_api
+
+    if override == "d3d11":
+        if sys.platform == "win32" and d3d11_api is not None:
+            return d3d11_api
+        _LOGGER.warning(
+            "IPHOTO_RHI_BACKEND=d3d11 requested outside a compatible Windows Qt build; "
+            "falling back to OpenGL"
+        )
         return opengl_api
 
     if sys.platform == "darwin" and metal_api is not None:

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -558,7 +558,7 @@ class PlayerViewController(QObject):
         epoch: int,
         kind: Literal["image", "video"],
     ) -> None:
-        """Request the additional composed frame used by Windows reveal."""
+        """Request the additional active-surface QRhi submission heuristic."""
 
         if (
             epoch != self._surface_transition_epoch
@@ -827,48 +827,6 @@ class PlayerViewController(QObject):
         if not self._player_stack.isVisible():
             self._player_stack.show()
         self._video_area.video_view().setFocus()
-
-    def show_video_surface(self, *, interactive: bool) -> None:
-        """Switch the stacked widget to the video surface.
-
-        Parameters
-        ----------
-        interactive:
-            ``True`` enables the floating playback controls (used for regular
-            videos). ``False`` keeps the controls hidden so Live Photos can play
-            unobstructed while still allowing the badge to trigger replays.
-        """
-
-        if self._pending_video_generation is not None:
-            raise RuntimeError(
-                "show_video_surface() cannot cancel an active video transition; "
-                "wait for the matching surface submission"
-            )
-        self._advance_surface_transition_epoch()
-        self._pending_video_generation = None
-        self._pending_video_content_serial = None
-        self._cancel_image_transition()
-        self._video_interactive_when_ready = bool(interactive)
-        self._configure_video_controls(interactive)
-
-        # If the video renderer has never rendered, its QRhiWidget backing
-        # texture is still uninitialised (transparent).  Re-show the opaque
-        # init cover *before* switching the stack so the user never sees a
-        # transparent frame.
-        if not self._video_renderer_rendered:
-            self._show_detail_init_cover()
-
-        if self._player_stack.currentWidget() is not self._video_area:
-            self._player_stack.setCurrentWidget(self._video_area)
-        if not self._player_stack.isVisible():
-            self._player_stack.show()
-
-        # Hand focus to the graphics view so space/arrow shortcuts continue to
-        # target the media surface, matching the ergonomics of the legacy
-        # QWidget-based implementation.
-        self._video_area.video_view().setFocus()
-        if self._video_renderer_rendered:
-            self._sync_detail_surface_cover()
 
     # ------------------------------------------------------------------
     # Content helpers

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -544,8 +544,10 @@ class PlayerViewController(QObject):
         if (
             self._post_submit_epoch == epoch
             and self._post_submit_kind == kind
-            and self._post_submit_payload == candidate_payload
         ):
+            # The first valid content submission anchors this transition.
+            # Continuous video frames must not move the target forward and
+            # repeatedly disarm the one-extra-submission barrier.
             return
         self._post_submit_epoch = epoch
         self._post_submit_kind = kind

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from collections import OrderedDict
 from collections.abc import Callable, Mapping
@@ -474,6 +475,12 @@ class PlayerViewController(QObject):
         self._pending_video_generation: int | None = None
         self._pending_video_content_serial: int | None = None
         self._video_interactive_when_ready = False
+        self._requires_post_submit_frame = sys.platform == "win32"
+        self._surface_transition_epoch = 0
+        self._post_submit_epoch: int | None = None
+        self._post_submit_kind: Literal["image", "video"] | None = None
+        self._post_submit_payload: tuple[object, ...] = ()
+        self._post_submit_armed = False
 
         self._image_viewer.firstFrameReady.connect(self._on_image_first_render)
         self._video_area.firstFrameReady.connect(self._on_video_first_render)
@@ -493,6 +500,12 @@ class PlayerViewController(QObject):
             still_presented = getattr(self._image_viewer, "stillFramePresented", None)
             if still_presented is not None:
                 still_presented.connect(self._on_still_frame_presented)
+        image_composed = getattr(self._image_viewer, "frameSubmitted", None)
+        if image_composed is not None:
+            image_composed.connect(self._on_image_composition_submitted)
+        video_composed = getattr(self._video_area, "surfaceCompositionSubmitted", None)
+        if video_composed is not None:
+            video_composed.connect(self._on_video_composition_submitted)
         texture_failed = getattr(
             self._image_viewer,
             "stillTextureAllocationFailed",
@@ -509,6 +522,80 @@ class PlayerViewController(QObject):
             return tr("DetailPage", "Select a photo or video to preview.")
         return self._placeholder_default_text
 
+    def _advance_surface_transition_epoch(self) -> int:
+        """Invalidate delayed cover releases owned by an older transition."""
+
+        self._surface_transition_epoch += 1
+        self._post_submit_epoch = None
+        self._post_submit_kind = None
+        self._post_submit_payload = ()
+        self._post_submit_armed = False
+        return self._surface_transition_epoch
+
+    def _schedule_post_submit_release(
+        self,
+        kind: Literal["image", "video"],
+        *payload: object,
+    ) -> None:
+        """Arm Windows cover release only after the current signal turn ends."""
+
+        epoch = self._surface_transition_epoch
+        candidate_payload = tuple(payload)
+        if (
+            self._post_submit_epoch == epoch
+            and self._post_submit_kind == kind
+            and self._post_submit_payload == candidate_payload
+        ):
+            return
+        self._post_submit_epoch = epoch
+        self._post_submit_kind = kind
+        self._post_submit_payload = candidate_payload
+        self._post_submit_armed = False
+        QTimer.singleShot(0, lambda: self._arm_post_submit_release(epoch, kind))
+
+    def _arm_post_submit_release(
+        self,
+        epoch: int,
+        kind: Literal["image", "video"],
+    ) -> None:
+        """Request the additional composed frame used by Windows reveal."""
+
+        if (
+            epoch != self._surface_transition_epoch
+            or epoch != self._post_submit_epoch
+            or kind != self._post_submit_kind
+        ):
+            return
+        if kind == "image":
+            if self._player_stack.currentWidget() is not self._image_viewer:
+                return
+            self._post_submit_armed = True
+            self._image_viewer.update()
+            return
+        if self._player_stack.currentWidget() is not self._video_area:
+            return
+        request_update = getattr(self._video_area, "request_active_surface_update", None)
+        if callable(request_update):
+            self._post_submit_armed = True
+            request_update()
+
+    def _take_post_submit_payload(
+        self,
+        kind: Literal["image", "video"],
+    ) -> tuple[object, ...] | None:
+        if (
+            not self._post_submit_armed
+            or self._post_submit_epoch != self._surface_transition_epoch
+            or self._post_submit_kind != kind
+        ):
+            return None
+        payload = self._post_submit_payload
+        self._post_submit_epoch = None
+        self._post_submit_kind = None
+        self._post_submit_payload = ()
+        self._post_submit_armed = False
+        return payload
+
     def _on_image_first_render(self) -> None:
         """Mark image viewer as initialised; hide cover if it is visible."""
         self._image_viewer_rendered = True
@@ -523,6 +610,8 @@ class PlayerViewController(QObject):
         """Re-arm the image RHI barrier after its resource generation changes."""
 
         self._image_viewer_rendered = False
+        if self._player_stack.currentWidget() is self._image_viewer:
+            self._advance_surface_transition_epoch()
         if (
             self._player_stack.currentWidget() is self._image_viewer
             and self._pending_image_generation is None
@@ -536,6 +625,7 @@ class PlayerViewController(QObject):
     def _arm_image_transition(self, generation: int, content_key: object) -> None:
         """Cover the still surface until the identified content is submitted."""
 
+        self._advance_surface_transition_epoch()
         self._pending_image_generation = int(generation)
         self._pending_image_key = content_key
         self._show_detail_init_cover()
@@ -553,6 +643,7 @@ class PlayerViewController(QObject):
 
         self._video_renderer_rendered = False
         if self._player_stack.currentWidget() is self._video_area and generation > 0:
+            self._advance_surface_transition_epoch()
             self._pending_video_generation = int(generation)
             self._pending_video_content_serial = (
                 int(content_serial) if content_serial > 0 else None
@@ -573,11 +664,37 @@ class PlayerViewController(QObject):
             return
         if self._player_stack.currentWidget() is not self._video_area:
             return
+        if self._requires_post_submit_frame:
+            self._schedule_post_submit_release(
+                "video",
+                int(generation),
+                int(content_serial),
+            )
+            return
+        self._finalize_video_surface_submission()
+
+    def _finalize_video_surface_submission(self) -> None:
+        """Reveal video after all platform presentation barriers are satisfied."""
+
         self._pending_video_generation = None
         self._pending_video_content_serial = None
         self._video_renderer_rendered = True
         self._configure_video_controls(self._video_interactive_when_ready)
         self._sync_detail_surface_cover()
+
+    def _on_video_composition_submitted(self) -> None:
+        payload = self._take_post_submit_payload("video")
+        if payload is None or len(payload) != 2:
+            return
+        generation, content_serial = (int(payload[0]), int(payload[1]))
+        if generation != self._pending_video_generation:
+            return
+        required_serial = self._pending_video_content_serial
+        if required_serial is not None and content_serial < required_serial:
+            return
+        if self._player_stack.currentWidget() is not self._video_area:
+            return
+        self._finalize_video_surface_submission()
 
     def _sync_detail_surface_cover(self) -> None:
         """Show the cover while the current surface has an unsatisfied barrier."""
@@ -625,6 +742,7 @@ class PlayerViewController(QObject):
 
     def show_placeholder(self, message: str | None = None) -> None:
         """Display the placeholder widget and clear any previous image."""
+        self._advance_surface_transition_epoch()
         if isinstance(self._placeholder, QLabel):
             self._placeholder.setText(
                 self._default_placeholder_text() if message is None else message
@@ -683,6 +801,7 @@ class PlayerViewController(QObject):
     ) -> None:
         """Expose the loading surface behind a generation-bound opaque cover."""
 
+        self._advance_surface_transition_epoch()
         self._pending_video_generation = int(request_generation)
         self._pending_video_content_serial = None
         self._cancel_image_transition()
@@ -706,6 +825,7 @@ class PlayerViewController(QObject):
             unobstructed while still allowing the badge to trigger replays.
         """
 
+        self._advance_surface_transition_epoch()
         self._pending_video_generation = None
         self._pending_video_content_serial = None
         self._cancel_image_transition()
@@ -1404,9 +1524,15 @@ class PlayerViewController(QObject):
                 return
             if source != self._pending_image_key:
                 return
-            self._cancel_image_transition()
-            self._image_viewer_rendered = True
-            self._sync_detail_surface_cover()
+            if self._requires_post_submit_frame:
+                self._schedule_post_submit_release(
+                    "image",
+                    source,
+                    int(generation),
+                )
+                return
+            self._finalize_image_surface_submission(source, int(generation))
+            return
         elif int(generation) != self._present_generation:
             return
         self._accept_still_frame_presented(source, int(generation))
@@ -1415,10 +1541,41 @@ class PlayerViewController(QObject):
         """Compatibility path for viewers without content-aware submission."""
 
         if source == self._pending_image_key:
-            self._cancel_image_transition()
-            self._image_viewer_rendered = True
-            self._sync_detail_surface_cover()
+            if self._requires_post_submit_frame:
+                self._schedule_post_submit_release(
+                    "image",
+                    source,
+                    self._present_generation,
+                )
+                return
+            self._finalize_image_surface_submission(source, self._present_generation)
+            return
         self._accept_still_frame_presented(source, self._present_generation)
+
+    def _finalize_image_surface_submission(
+        self,
+        source: object,
+        generation: int,
+    ) -> None:
+        """Reveal still content after all platform barriers are satisfied."""
+
+        self._cancel_image_transition()
+        self._image_viewer_rendered = True
+        self._sync_detail_surface_cover()
+        self._accept_still_frame_presented(source, generation)
+
+    def _on_image_composition_submitted(self) -> None:
+        payload = self._take_post_submit_payload("image")
+        if payload is None or len(payload) != 2:
+            return
+        source, generation = payload[0], int(payload[1])
+        if generation != self._pending_image_generation:
+            return
+        if source != self._pending_image_key:
+            return
+        if self._player_stack.currentWidget() is not self._image_viewer:
+            return
+        self._finalize_image_surface_submission(source, generation)
 
     def _accept_still_frame_presented(self, source: object, generation: int) -> None:
         if isinstance(source, DetailDecodeKey):
@@ -1963,6 +2120,7 @@ class PlayerViewController(QObject):
     def cancel_pending_image_requests(self) -> None:
         """Invalidate still work when Detail or the current library is left."""
 
+        self._advance_surface_transition_epoch()
         self._request_generation += 1
         self._residency_window_generation += 1
         self._preparation_prefetch_queue.clear()
@@ -2009,6 +2167,7 @@ class PlayerViewController(QObject):
     def clear_image(self) -> None:
         """Remove any pixmap currently shown in the image viewer."""
         # 清空而非传空图像，避免一帧“空绘制/空上传”
+        self._advance_surface_transition_epoch()
         self._current_full_image = None
         self._cancel_image_transition()
         self._image_viewer.set_image(None, {})

--- a/src/iPhoto/gui/ui/controllers/player_view_controller.py
+++ b/src/iPhoto/gui/ui/controllers/player_view_controller.py
@@ -579,22 +579,34 @@ class PlayerViewController(QObject):
             self._post_submit_armed = True
             request_update()
 
-    def _take_post_submit_payload(
+    def _peek_post_submit_payload(
         self,
         kind: Literal["image", "video"],
     ) -> tuple[object, ...] | None:
+        """Return an armed payload without consuming the reveal barrier."""
+
         if (
             not self._post_submit_armed
             or self._post_submit_epoch != self._surface_transition_epoch
             or self._post_submit_kind != kind
         ):
             return None
-        payload = self._post_submit_payload
+        return self._post_submit_payload
+
+    def _consume_post_submit_payload(
+        self,
+        kind: Literal["image", "video"],
+        expected_payload: tuple[object, ...],
+    ) -> bool:
+        """Consume the barrier only if it still owns the validated payload."""
+
+        if self._peek_post_submit_payload(kind) != expected_payload:
+            return False
         self._post_submit_epoch = None
         self._post_submit_kind = None
         self._post_submit_payload = ()
         self._post_submit_armed = False
-        return payload
+        return True
 
     def _on_image_first_render(self) -> None:
         """Mark image viewer as initialised; hide cover if it is visible."""
@@ -683,7 +695,7 @@ class PlayerViewController(QObject):
         self._sync_detail_surface_cover()
 
     def _on_video_composition_submitted(self) -> None:
-        payload = self._take_post_submit_payload("video")
+        payload = self._peek_post_submit_payload("video")
         if payload is None or len(payload) != 2:
             return
         generation, content_serial = (int(payload[0]), int(payload[1]))
@@ -693,6 +705,8 @@ class PlayerViewController(QObject):
         if required_serial is not None and content_serial < required_serial:
             return
         if self._player_stack.currentWidget() is not self._video_area:
+            return
+        if not self._consume_post_submit_payload("video", payload):
             return
         self._finalize_video_surface_submission()
 
@@ -825,6 +839,11 @@ class PlayerViewController(QObject):
             unobstructed while still allowing the badge to trigger replays.
         """
 
+        if self._pending_video_generation is not None:
+            raise RuntimeError(
+                "show_video_surface() cannot cancel an active video transition; "
+                "wait for the matching surface submission"
+            )
         self._advance_surface_transition_epoch()
         self._pending_video_generation = None
         self._pending_video_content_serial = None
@@ -1565,7 +1584,7 @@ class PlayerViewController(QObject):
         self._accept_still_frame_presented(source, generation)
 
     def _on_image_composition_submitted(self) -> None:
-        payload = self._take_post_submit_payload("image")
+        payload = self._peek_post_submit_payload("image")
         if payload is None or len(payload) != 2:
             return
         source, generation = payload[0], int(payload[1])
@@ -1574,6 +1593,8 @@ class PlayerViewController(QObject):
         if source != self._pending_image_key:
             return
         if self._player_stack.currentWidget() is not self._image_viewer:
+            return
+        if not self._consume_post_submit_payload("image", payload):
             return
         self._finalize_image_surface_submission(source, generation)
 

--- a/src/iPhoto/gui/ui/widgets/detail_page.py
+++ b/src/iPhoto/gui/ui/widgets/detail_page.py
@@ -579,14 +579,15 @@ class DetailPageWidget(QWidget):
         player_layout.addWidget(self.player_stack, 0, 0)
         self.player_container = player_container
 
-        # Opaque cover that hides the QRhiWidget area until its first frame
-        # has been rendered.  QRhiWidget replaces its backing-store region
+        # Persistent opaque cover that hides the QRhiWidget area until its
+        # current content has passed the platform submission barriers.
+        # QRhiWidget replaces its backing-store region
         # with its own texture; before the first render() call that texture
         # is uninitialised / transparent.  This cover occupies the same
         # grid cell as the player_stack and is raised above it so it
-        # visually hides any transparent texture.  It is removed by
-        # ``hide_rhi_init_cover()`` once any QRhiWidget child signals
-        # ``firstFrameReady``.
+        # visually hides any transparent texture. It remains in the layout for
+        # the page lifetime and is only hidden/shown, avoiding layout and
+        # stacking churn during later media transitions.
         self._rhi_init_cover = QWidget(player_container)
         self._configure_rhi_init_cover(self._rhi_init_cover)
         player_layout.addWidget(self._rhi_init_cover, 0, 0)
@@ -786,15 +787,13 @@ class DetailPageWidget(QWidget):
     # ------------------------------------------------------------------
 
     def hide_rhi_init_cover(self) -> None:
-        """Remove the opaque cover once the first QRhiWidget frame is ready."""
+        """Hide the persistent opaque cover once presentation is safe."""
         if self._rhi_init_cover is not None:
             self._rhi_init_cover.hide()
-            self._rhi_init_cover.deleteLater()
-            self._rhi_init_cover = None
         self._raise_player_overlays()
 
     def show_rhi_init_cover(self) -> None:
-        """Re-create and show the opaque init cover.
+        """Show the persistent opaque init cover.
 
         Called when the player stack is about to switch to a QRhiWidget
         that has never rendered.  The backing texture of an uninitialised
@@ -803,7 +802,6 @@ class DetailPageWidget(QWidget):
         renders its first opaque frame.
         """
         if self._rhi_init_cover is not None:
-            # Cover still exists – just make sure it is visible and on top.
             self._rhi_init_cover.show()
             self._rhi_init_cover.raise_()
             self._raise_player_overlays()

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -12,7 +12,7 @@ import logging
 import sys
 import time
 import weakref
-from collections import OrderedDict, deque
+from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any
 
@@ -261,9 +261,9 @@ class GLImageViewer(QRhiWidget):
         self._still_generation_by_key: dict[object, int] = {}
         self._pending_resident_activation: object | None = None
         self._still_presentation_pending = False
-        self._frame_submission_queue: deque[
-            tuple[str, object, int] | None
-        ] = deque()
+        self._content_revision = 0
+        self._rendered_content_identity: tuple[str, object, int, int] | None = None
+        self._last_composed_content_identity: tuple[str, object, int, int] | None = None
         self._source_image_dimensions: tuple[int, int] | None = None
         self._video_frame = None
         self._pending_video_image: QImage | None = None
@@ -547,6 +547,7 @@ class GLImageViewer(QRhiWidget):
         if image is None or image.isNull():
             self._source_image_dimensions = None
             self._still_presentation_pending = False
+            self._rendered_content_identity = None
         elif source_size is not None and min(source_size) > 0:
             self._source_image_dimensions = (int(source_size[0]), int(source_size[1]))
         elif not self._texture_manager.should_reuse_texture(image_source):
@@ -766,6 +767,7 @@ class GLImageViewer(QRhiWidget):
             self._texture_manager.clear_image()
             self._source_image_dimensions = None
             self._still_presentation_pending = False
+            self._rendered_content_identity = None
         self._using_video_frame_source = True
         self._video_frame_content_generation = max(0, int(content_generation))
         self._video_frame_content_serial = max(0, int(content_serial))
@@ -1510,7 +1512,9 @@ class GLImageViewer(QRhiWidget):
         self._first_render_done = False
         self._first_render_submission_pending = False
         self._video_frame_presentation_pending = False
-        self._frame_submission_queue.clear()
+        self._content_revision = 0
+        self._rendered_content_identity = None
+        self._last_composed_content_identity = None
         if self._runtime_ready:
             source = self._texture_manager.get_current_image_source()
             if source is not None and not self._using_video_frame_source:
@@ -1538,7 +1542,7 @@ class GLImageViewer(QRhiWidget):
             )
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
         gf = self._gl_funcs
         if gf is None or self._renderer is None:
@@ -1549,7 +1553,7 @@ class GLImageViewer(QRhiWidget):
             )
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
 
         output_size = self.renderTarget().pixelSize()
@@ -1681,7 +1685,7 @@ class GLImageViewer(QRhiWidget):
             cb.endExternal()
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
 
         effective_scale = self._transform_controller.get_effective_scale()
@@ -1760,9 +1764,9 @@ class GLImageViewer(QRhiWidget):
         cb.endExternal()
         cb.endPass()
         self._queue_first_frame_ready()
-        self._frame_submission_queue.append(
-            self._take_pending_content_submission()
-        )
+        rendered_identity = self._take_pending_content_submission()
+        if rendered_identity is not None:
+            self._rendered_content_identity = rendered_identity
         if uploaded_new_still_texture:
             self._schedule_post_load_view_transform()
 
@@ -1777,7 +1781,7 @@ class GLImageViewer(QRhiWidget):
             )
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
 
         output_size = self.renderTarget().pixelSize()
@@ -1848,7 +1852,7 @@ class GLImageViewer(QRhiWidget):
             )
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
 
         effective_scale = self._transform_controller.get_effective_scale()
@@ -1894,9 +1898,9 @@ class GLImageViewer(QRhiWidget):
         )
 
         self._queue_first_frame_ready()
-        self._frame_submission_queue.append(
-            self._take_pending_content_submission()
-        )
+        rendered_identity = self._take_pending_content_submission()
+        if rendered_identity is not None:
+            self._rendered_content_identity = rendered_identity
         if uploaded_new_still_texture:
             self._schedule_post_load_view_transform()
 
@@ -1906,7 +1910,7 @@ class GLImageViewer(QRhiWidget):
 
     def _take_pending_content_submission(
         self,
-    ) -> tuple[str, object, int] | None:
+    ) -> tuple[str, object, int, int] | None:
         """Bind the content drawn by this render call to its submission event."""
 
         if self._still_presentation_pending:
@@ -1914,13 +1918,16 @@ class GLImageViewer(QRhiWidget):
             if source is not None:
                 self._still_presentation_pending = False
                 generation = self._still_generation_by_key.get(source, 0)
-                return ("still", source, generation)
+                self._content_revision += 1
+                return ("still", source, generation, self._content_revision)
         if self._video_frame_presentation_pending:
             self._video_frame_presentation_pending = False
+            self._content_revision += 1
             return (
                 "video",
                 self._video_frame_content_generation,
                 self._video_frame_content_serial,
+                self._content_revision,
             )
         return None
 
@@ -2040,11 +2047,10 @@ class GLImageViewer(QRhiWidget):
             self._first_render_submission_pending = False
             self._first_render_done = True
             self.firstFrameReady.emit()
-        if self._frame_submission_queue:
-            submission = self._frame_submission_queue.popleft()
-            if submission is None:
-                return
-            kind, identity, serial = submission
+        submission = self._rendered_content_identity
+        if submission is not None and submission != self._last_composed_content_identity:
+            self._last_composed_content_identity = submission
+            kind, identity, serial, _revision = submission
             if kind == "still":
                 self.stillFrameSubmitted.emit(identity, serial)
                 self.stillFramePresented.emit(identity)

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -175,6 +175,7 @@ class VideoArea(QWidget):
     mediaFirstFrameReady = Signal(int)
     surfaceFrameSubmitted = Signal(int, int)
     surfaceInvalidated = Signal(int, int)
+    surfaceCompositionSubmitted = Signal()
     displaySizeChanged = Signal(QSizeF)
     SHORTCUT_VOLUME_STEP = 5
 
@@ -1806,11 +1807,22 @@ class VideoArea(QWidget):
                 if owner is not None and child is not None:
                     owner._on_surface_resources_invalidated(child)
 
+            def _handle_composed(*, bound_surface=surface_ref) -> None:
+                owner = owner_ref()
+                child = bound_surface()
+                if (
+                    owner is not None
+                    and child is not None
+                    and owner._surface_stack.currentWidget() is child
+                ):
+                    owner.surfaceCompositionSubmitted.emit()
+
             self._surface_lifecycle_handlers.extend(
-                (_handle_ready, _handle_invalidated)
+                (_handle_ready, _handle_invalidated, _handle_composed)
             )
             surface.firstFrameReady.connect(_handle_ready)
             surface.renderResourcesInvalidated.connect(_handle_invalidated)
+            surface.frameSubmitted.connect(_handle_composed)
 
     def _on_surface_first_frame_ready(self, surface: QWidget) -> None:
         """Publish readiness only for the currently visible QRhi child."""
@@ -1906,6 +1918,13 @@ class VideoArea(QWidget):
         """Return the currently active video surface for focus/event handling."""
 
         return self._edit_viewer if self._adjusted_preview_enabled else self._renderer
+
+    def request_active_surface_update(self) -> None:
+        """Request another composition from the currently visible QRhi child."""
+
+        surface = self._surface_stack.currentWidget()
+        if surface is not None:
+            surface.update()
 
     def video_viewport(self) -> QWidget:
         """Return the widget that accepts keyboard focus."""

--- a/src/iPhoto/gui/ui/widgets/video_renderer_widget.py
+++ b/src/iPhoto/gui/ui/widgets/video_renderer_widget.py
@@ -22,7 +22,6 @@ import os
 import struct
 import sys
 import weakref
-from collections import deque
 from pathlib import Path
 from typing import Optional
 
@@ -324,7 +323,9 @@ class VideoRendererWidget(QRhiWidget):
         self._frame_presentation_pending = False
         self._frame_content_generation = 0
         self._frame_content_serial = 0
-        self._frame_submission_queue: deque[tuple[int, int] | None] = deque()
+        self._frame_content_revision = 0
+        self._rendered_content_identity: tuple[int, int, int] | None = None
+        self._last_composed_content_identity: tuple[int, int, int] | None = None
         self._viewport_fill_enabled = False
         self._zoom_factor = 1.0
         self._transparent_rounded_clip_enabled = False
@@ -474,6 +475,7 @@ class VideoRendererWidget(QRhiWidget):
         self._frame_presentation_pending = True
         self._frame_content_generation = max(0, int(content_generation))
         self._frame_content_serial = max(0, int(content_serial))
+        self._frame_content_revision += 1
 
         # Check for resolution change
         fmt = frame.surfaceFormat()
@@ -524,6 +526,7 @@ class VideoRendererWidget(QRhiWidget):
         self._frame_presentation_pending = False
         self._frame_content_generation = 0
         self._frame_content_serial = 0
+        self._rendered_content_identity = None
         self._user_rotate90_steps = 0
         if self._zoom_factor != 1.0:
             self._zoom_factor = 1.0
@@ -762,7 +765,7 @@ class VideoRendererWidget(QRhiWidget):
             )
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
 
         rhi = self.rhi()
@@ -785,7 +788,7 @@ class VideoRendererWidget(QRhiWidget):
             )
             cb.endPass()
             self._queue_first_frame_ready()
-            self._frame_submission_queue.append(None)
+            self._rendered_content_identity = None
             return
 
         ru = rhi.nextResourceUpdateBatch()
@@ -821,14 +824,13 @@ class VideoRendererWidget(QRhiWidget):
         cb.draw(6)  # 6 vertices = 2 triangles
         cb.endPass()
         self._queue_first_frame_ready()
-        submission: tuple[int, int] | None = None
         if self._frame_presentation_pending and not self._frame_dirty:
             self._frame_presentation_pending = False
-            submission = (
+            self._rendered_content_identity = (
                 self._frame_content_generation,
                 self._frame_content_serial,
+                self._frame_content_revision,
             )
-        self._frame_submission_queue.append(submission)
 
     def _queue_first_frame_ready(self) -> None:
         """Record that an opaque frame is waiting for window submission."""
@@ -842,11 +844,11 @@ class VideoRendererWidget(QRhiWidget):
             self._first_render_submission_pending = False
             self._first_render_done = True
             self.firstFrameReady.emit()
-        if self._frame_submission_queue:
-            submission = self._frame_submission_queue.popleft()
-            if submission is not None:
-                generation, serial = submission
-                self.videoFramePresented.emit(generation, serial)
+        identity = self._rendered_content_identity
+        if identity is not None and identity != self._last_composed_content_identity:
+            self._last_composed_content_identity = identity
+            generation, serial, _revision = identity
+            self.videoFramePresented.emit(generation, serial)
 
     def _pass_clear_color(self, fallback: QColor) -> QColor:
         """Return the render-pass clear colour for the current opacity mode."""
@@ -885,7 +887,9 @@ class VideoRendererWidget(QRhiWidget):
         self._frame_presentation_pending = False
         self._frame_content_generation = 0
         self._frame_content_serial = 0
-        self._frame_submission_queue.clear()
+        self._frame_content_revision = 0
+        self._rendered_content_identity = None
+        self._last_composed_content_identity = None
         self._current_frame = None
         self._frame_dirty = False
         self._has_frame = False

--- a/tests/contracts/test_windows_scan_playback_diagnostics.py
+++ b/tests/contracts/test_windows_scan_playback_diagnostics.py
@@ -41,3 +41,12 @@ def test_windows_collector_documentation_describes_reproduction_marker() -> None
     assert "press `R` once" in documentation
     assert "single ZIP" in documentation
     assert "does not copy photos" in documentation
+
+
+def test_d3d11_ab_protocol_excludes_unsupported_gpu_maps() -> None:
+    documentation = DOCUMENTATION.read_text(encoding="utf-8")
+
+    assert "Only the supported OpenGL baseline should" in documentation
+    assert "exercise opening/closing Maps" in documentation
+    assert "D3D11 run is Detail-only" in documentation
+    assert "must not enter Location or create a GPU map widget" in documentation

--- a/tests/gui/coordinators/test_playback_coordinator.py
+++ b/tests/gui/coordinators/test_playback_coordinator.py
@@ -915,7 +915,6 @@ def test_render_presentation_defers_video_load_during_location_file_write() -> N
     )
     coordinator._player_view = Mock(
         show_placeholder=Mock(),
-        show_video_surface=Mock(),
         video_area=video_area,
     )
     parent = Mock()
@@ -947,7 +946,6 @@ def test_render_presentation_defers_video_load_during_location_file_write() -> N
         call.show_placeholder(playback_coordinator_module._LOCATION_VIDEO_WRITE_PLACEHOLDER),
         call.stop(),
     ]
-    coordinator._player_view.show_video_surface.assert_not_called()
     video_area.present_video.assert_not_called()
     video_area.play.assert_not_called()
     coordinator._player_bar.setEnabled.assert_called_once_with(False)
@@ -1271,7 +1269,7 @@ def test_live_motion_first_frame_completes_current_transaction() -> None:
         ),
         live_motion_abs=Path("/fake/photo.mov"),
     )
-    coordinator._player_view = Mock(show_video_surface=Mock())
+    coordinator._player_view = Mock()
 
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
 
@@ -1279,7 +1277,6 @@ def test_live_motion_first_frame_completes_current_transaction() -> None:
         7,
         "live_motion_frame",
     )
-    coordinator._player_view.show_video_surface.assert_not_called()
 
 
 def test_regular_video_first_frame_enables_interactive_controls() -> None:
@@ -1293,7 +1290,7 @@ def test_regular_video_first_frame_enables_interactive_controls() -> None:
     coordinator._detail_request_generation = 7
     coordinator._active_live_motion = None
     coordinator._current_presentation = _make_presentation(request_generation=7)
-    coordinator._player_view = Mock(show_video_surface=Mock())
+    coordinator._player_view = Mock()
 
     PlaybackCoordinator._on_video_first_frame_presented(coordinator, 7)
 
@@ -1301,7 +1298,6 @@ def test_regular_video_first_frame_enables_interactive_controls() -> None:
         7,
         "video_frame",
     )
-    coordinator._player_view.show_video_surface.assert_not_called()
 
 
 def test_live_motion_deferred_still_frame_does_not_complete_transaction() -> None:
@@ -1399,7 +1395,6 @@ def test_live_photo_motion_to_still_runs_overlay_and_prefetch(
         defer_still_updates=Mock(),
         apply_pending_still=Mock(return_value=has_pending_still),
         display_image=Mock(),
-        show_video_surface=Mock(),
         show_live_badge=Mock(),
         set_live_replay_enabled=Mock(),
     )
@@ -1471,7 +1466,6 @@ def test_live_photo_second_replay_restores_overlay_without_reopening_transaction
         defer_still_updates=Mock(),
         apply_pending_still=Mock(return_value=False),
         display_image=Mock(),
-        show_video_surface=Mock(),
         show_live_badge=Mock(),
         set_live_replay_enabled=Mock(),
     )
@@ -1553,7 +1547,6 @@ def test_live_photo_replay_preparation_failure_restores_overlay() -> None:
         defer_still_updates=Mock(),
         apply_pending_still=Mock(return_value=False),
         display_image=Mock(),
-        show_video_surface=Mock(),
         show_live_badge=Mock(),
         set_live_replay_enabled=Mock(),
         show_placeholder=Mock(),

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -6,15 +6,17 @@ from types import SimpleNamespace
 
 import pytest
 from PySide6.QtCore import QCoreApplication, QEvent, Qt
-from PySide6.QtGui import QCloseEvent, QSurface
+from PySide6.QtGui import QCloseEvent, QSurface, QSurfaceFormat
 
 from iPhoto.gui.main import (
     _bootstrap_macos_external_tool_path,
     _configure_qt_opengl_defaults,
+    _map_gl_surface_format,
     _prepare_qt_runtime_for_maps,
     _prepare_top_level_rhi_surface,
     _startup_feature_plan,
     _startup_timing_plan,
+    _top_level_graphics_contract,
     _StartupInputGuard,
 )
 from iPhoto.gui.ui import main_window as main_window_module
@@ -185,6 +187,17 @@ def test_configure_qt_opengl_defaults_keeps_map_gl_contexts_on_macos_auto(monkey
     assert default_formats[0].samples() == 0
 
 
+@pytest.mark.parametrize(
+    ("platform", "alpha_bits"),
+    (("darwin", 8), ("win32", 8), ("linux", 0)),
+)
+def test_global_opengl_format_matches_top_level_translucency(
+    platform: str,
+    alpha_bits: int,
+) -> None:
+    assert _map_gl_surface_format(platform).alphaBufferSize() == alpha_bits
+
+
 def test_configure_qt_opengl_defaults_still_routes_shader_cache_when_opengl_is_disabled(monkeypatch) -> None:
     helper_calls: list[bool] = []
     attributes: list[tuple[object, bool]] = []
@@ -307,6 +320,8 @@ def test_startup_timing_plan_has_no_fixed_platform_delay(
     ("backend", "surface_type"),
     (
         ("metal", QSurface.SurfaceType.MetalSurface),
+        ("direct3d11", QSurface.SurfaceType.Direct3DSurface),
+        ("d3d11", QSurface.SurfaceType.Direct3DSurface),
         ("opengl", QSurface.SurfaceType.OpenGLSurface),
     ),
 )
@@ -353,6 +368,43 @@ def test_prepare_top_level_rhi_surface_allows_platform_deferred_handle() -> None
         _prepare_top_level_rhi_surface(_FakeWindow(), "opengl")
         == "deferred:OpenGLSurface"
     )
+
+
+def test_windows_graphics_contract_reports_actual_surface_alpha(caplog) -> None:
+    actual_format = QSurfaceFormat()
+    actual_format.setAlphaBufferSize(0)
+
+    class _Handle:
+        def surfaceType(self):  # noqa: N802
+            return QSurface.SurfaceType.OpenGLSurface
+
+        def format(self):
+            return actual_format
+
+    class _Window:
+        def windowHandle(self):  # noqa: N802
+            return _Handle()
+
+        def testAttribute(self, attribute):  # noqa: N802
+            return attribute == Qt.WidgetAttribute.WA_TranslucentBackground
+
+        def windowFlags(self):  # noqa: N802
+            return Qt.WindowType.FramelessWindowHint
+
+    payload = _top_level_graphics_contract(
+        _Window(),
+        "opengl",
+        platform="win32",
+    )
+
+    assert payload == {
+        "backend": "opengl",
+        "surface_type": "OpenGLSurface",
+        "actual_alpha_bits": 0,
+        "translucent": True,
+        "frameless": True,
+    }
+    assert "has no confirmed alpha buffer" in caplog.text
 
 
 def test_startup_input_guard_filters_only_window_startup_input() -> None:

--- a/tests/gui/test_render_backend.py
+++ b/tests/gui/test_render_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from PySide6.QtGui import QShader
 from PySide6.QtWidgets import QRhiWidget
 
@@ -15,6 +16,19 @@ def test_auto_selects_metal_on_macos_when_available(monkeypatch) -> None:
     expected = getattr(QRhiWidget.Api, "Metal", QRhiWidget.Api.OpenGL)
 
     assert render_backend.select_qrhi_widget_api() == expected
+
+
+def test_metal_override_does_not_require_opengl(monkeypatch) -> None:
+    monkeypatch.setattr(render_backend.sys, "platform", "darwin")
+    monkeypatch.setenv("IPHOTO_RHI_BACKEND", "metal")
+    metal_api = QRhiWidget.Api.Metal
+    monkeypatch.setattr(
+        render_backend,
+        "_qt_api",
+        lambda name: None if name == "OpenGL" else metal_api if name == "Metal" else None,
+    )
+
+    assert render_backend.select_qrhi_widget_api() == metal_api
 
 
 def test_auto_keeps_opengl_on_linux(monkeypatch) -> None:
@@ -37,6 +51,44 @@ def test_windows_override_can_select_d3d11(monkeypatch) -> None:
 
     expected = getattr(QRhiWidget.Api, "Direct3D11", QRhiWidget.Api.OpenGL)
     assert render_backend.select_qrhi_widget_api() == expected
+
+
+def test_d3d11_override_does_not_require_opengl(monkeypatch) -> None:
+    monkeypatch.setattr(render_backend.sys, "platform", "win32")
+    monkeypatch.setenv("IPHOTO_RHI_BACKEND", "d3d11")
+    d3d11_api = QRhiWidget.Api.Direct3D11
+    monkeypatch.setattr(
+        render_backend,
+        "_qt_api",
+        lambda name: None if name == "OpenGL" else d3d11_api if name == "Direct3D11" else None,
+    )
+
+    assert render_backend.select_qrhi_widget_api() == d3d11_api
+
+
+def test_explicit_opengl_requires_available_opengl_backend(monkeypatch) -> None:
+    monkeypatch.setenv("IPHOTO_RHI_BACKEND", "opengl")
+    monkeypatch.setattr(
+        render_backend,
+        "_qt_api",
+        lambda name: None if name == "OpenGL" else getattr(QRhiWidget.Api, name, None),
+    )
+
+    with pytest.raises(RuntimeError, match="does not expose the QRhi OpenGL backend"):
+        render_backend.select_qrhi_widget_api()
+
+
+def test_auto_opengl_platform_requires_available_opengl_backend(monkeypatch) -> None:
+    monkeypatch.setattr(render_backend.sys, "platform", "linux")
+    monkeypatch.delenv("IPHOTO_RHI_BACKEND", raising=False)
+    monkeypatch.setattr(
+        render_backend,
+        "_qt_api",
+        lambda name: None if name == "OpenGL" else getattr(QRhiWidget.Api, name, None),
+    )
+
+    with pytest.raises(RuntimeError, match="does not expose the QRhi OpenGL backend"):
+        render_backend.select_qrhi_widget_api()
 
 
 def test_d3d11_override_falls_back_to_opengl_off_windows(monkeypatch) -> None:

--- a/tests/gui/test_render_backend.py
+++ b/tests/gui/test_render_backend.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from PySide6.QtGui import QShader
 from PySide6.QtWidgets import QRhiWidget
 
 from iPhoto.gui import render_backend
@@ -21,8 +24,51 @@ def test_auto_keeps_opengl_on_linux(monkeypatch) -> None:
     assert render_backend.select_qrhi_widget_api() == QRhiWidget.Api.OpenGL
 
 
+def test_auto_keeps_opengl_on_windows_during_staged_migration(monkeypatch) -> None:
+    monkeypatch.setattr(render_backend.sys, "platform", "win32")
+    monkeypatch.delenv("IPHOTO_RHI_BACKEND", raising=False)
+
+    assert render_backend.select_qrhi_widget_api() == QRhiWidget.Api.OpenGL
+
+
+def test_windows_override_can_select_d3d11(monkeypatch) -> None:
+    monkeypatch.setattr(render_backend.sys, "platform", "win32")
+    monkeypatch.setenv("IPHOTO_RHI_BACKEND", "d3d11")
+
+    expected = getattr(QRhiWidget.Api, "Direct3D11", QRhiWidget.Api.OpenGL)
+    assert render_backend.select_qrhi_widget_api() == expected
+
+
+def test_d3d11_override_falls_back_to_opengl_off_windows(monkeypatch) -> None:
+    monkeypatch.setattr(render_backend.sys, "platform", "linux")
+    monkeypatch.setenv("IPHOTO_RHI_BACKEND", "d3d11")
+
+    assert render_backend.select_qrhi_widget_api() == QRhiWidget.Api.OpenGL
+
+
 def test_backend_override_can_force_opengl_on_macos(monkeypatch) -> None:
     monkeypatch.setattr(render_backend.sys, "platform", "darwin")
     monkeypatch.setenv("IPHOTO_RHI_BACKEND", "opengl")
 
     assert render_backend.select_qrhi_widget_api() == QRhiWidget.Api.OpenGL
+
+
+def test_media_qsb_assets_include_hlsl_50_for_d3d11() -> None:
+    shader_dir = Path(render_backend.__file__).parent / "ui" / "widgets"
+    shader_names = (
+        "image_viewer_rhi.vert.qsb",
+        "image_viewer_rhi.frag.qsb",
+        "image_viewer_overlay.vert.qsb",
+        "image_viewer_overlay.frag.qsb",
+        "video_renderer.vert.qsb",
+        "video_renderer.frag.qsb",
+    )
+
+    for shader_name in shader_names:
+        shader = QShader.fromSerialized((shader_dir / shader_name).read_bytes())
+        hlsl_versions = {
+            key.sourceVersion().version()
+            for key in shader.availableShaders()
+            if key.source() == QShader.Source.HlslShader
+        }
+        assert 50 in hlsl_versions, shader_name

--- a/tests/ui/controllers/test_player_view_init_cover.py
+++ b/tests/ui/controllers/test_player_view_init_cover.py
@@ -1088,6 +1088,16 @@ class TestInitCoverTracking:
         controller.show_video_surface(interactive=True)
         mock_show_cover.assert_not_called()
 
+    def test_show_video_surface_rejects_active_video_transition(self, controller):
+        controller.begin_video_transition(16, interactive_when_ready=True)
+        epoch = controller._surface_transition_epoch
+
+        with pytest.raises(RuntimeError, match="cannot cancel an active video transition"):
+            controller.show_video_surface(interactive=True)
+
+        assert controller._pending_video_generation == 16
+        assert controller._surface_transition_epoch == epoch
+
     def test_video_transition_waits_for_matching_submitted_generation(
         self,
         controller,
@@ -1215,6 +1225,36 @@ class TestInitCoverTracking:
         assert controller._pending_video_content_serial is None
         controls_enabled.assert_called_with(True)
         hide_cover.assert_called_once()
+
+    def test_invalid_composition_does_not_consume_post_submit_payload(
+        self,
+        controller,
+        qapp,
+        mocker,
+    ):
+        controller._requires_post_submit_frame = True
+        mocker.patch.object(
+            controller._video_area,
+            "request_active_surface_update",
+        )
+        controller.begin_video_transition(44, interactive_when_ready=False)
+        controller._video_area.surfaceFrameSubmitted.emit(44, 9)
+        qapp.processEvents()
+        payload = (44, 9)
+        assert controller._peek_post_submit_payload("video") == payload
+
+        # Simulate a future caller changing ownership without advancing epoch.
+        controller._pending_video_generation = 45
+        controller._video_area.surfaceCompositionSubmitted.emit()
+
+        assert controller._peek_post_submit_payload("video") == payload
+        assert controller._post_submit_armed is True
+
+        controller._pending_video_generation = 44
+        controller._video_area.surfaceCompositionSubmitted.emit()
+
+        assert controller._peek_post_submit_payload("video") is None
+        assert controller._pending_video_generation is None
 
     def test_new_transition_cancels_deferred_windows_cover_release(
         self,

--- a/tests/ui/controllers/test_player_view_init_cover.py
+++ b/tests/ui/controllers/test_player_view_init_cover.py
@@ -1074,30 +1074,6 @@ class TestInitCoverTracking:
             ),
         ]
 
-    def test_show_video_surface_shows_cover_if_not_rendered(self, controller, mocker):
-        """show_video_surface should re-show the init cover when video hasn't rendered."""
-        mock_show_cover = mocker.patch.object(controller, "_show_detail_init_cover")
-        controller._video_renderer_rendered = False
-        controller.show_video_surface(interactive=True)
-        mock_show_cover.assert_called_once()
-
-    def test_show_video_surface_skips_cover_if_rendered(self, controller, mocker):
-        """show_video_surface should NOT re-show cover when video has already rendered."""
-        mock_show_cover = mocker.patch.object(controller, "_show_detail_init_cover")
-        controller._video_renderer_rendered = True
-        controller.show_video_surface(interactive=True)
-        mock_show_cover.assert_not_called()
-
-    def test_show_video_surface_rejects_active_video_transition(self, controller):
-        controller.begin_video_transition(16, interactive_when_ready=True)
-        epoch = controller._surface_transition_epoch
-
-        with pytest.raises(RuntimeError, match="cannot cancel an active video transition"):
-            controller.show_video_surface(interactive=True)
-
-        assert controller._pending_video_generation == 16
-        assert controller._surface_transition_epoch == epoch
-
     def test_video_transition_waits_for_matching_submitted_generation(
         self,
         controller,

--- a/tests/ui/controllers/test_player_view_init_cover.py
+++ b/tests/ui/controllers/test_player_view_init_cover.py
@@ -123,6 +123,7 @@ class _FakeImageViewer(QWidget):
     firstFrameReady = Signal()
     renderResourcesInvalidated = Signal()
     stillFrameSubmitted = Signal(object, int)
+    frameSubmitted = Signal()
     replayRequested = Signal()
     viewTransformChanged = Signal()
 
@@ -186,6 +187,7 @@ class _FakeVideoArea(QWidget):
     firstFrameReady = Signal()
     surfaceFrameSubmitted = Signal(int, int)
     surfaceInvalidated = Signal(int, int)
+    surfaceCompositionSubmitted = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -202,6 +204,9 @@ class _FakeVideoArea(QWidget):
 
     def video_view(self) -> QWidget:
         return self
+
+    def request_active_surface_update(self) -> None:
+        pass
 
 
 @pytest.fixture(scope="module")
@@ -1148,6 +1153,120 @@ class TestInitCoverTracking:
         assert controller._pending_video_content_serial is None
         mock_hide_cover.assert_called_once()
 
+    def test_windows_image_reveal_waits_for_next_composition(
+        self,
+        controller,
+        qapp,
+        mocker,
+    ):
+        controller._requires_post_submit_frame = True
+        update = mocker.patch.object(controller._image_viewer, "update")
+        hide_cover = mocker.patch.object(controller, "_hide_detail_init_cover")
+        controller._arm_image_transition(40, "image-40")
+        controller.show_image_surface()
+        update.reset_mock()
+
+        controller._image_viewer.stillFrameSubmitted.emit("image-40", 40)
+        controller._image_viewer.frameSubmitted.emit()
+
+        assert controller._pending_image_generation == 40
+        hide_cover.assert_not_called()
+
+        qapp.processEvents()
+        update.assert_called()
+        hide_cover.assert_not_called()
+
+        controller._image_viewer.frameSubmitted.emit()
+
+        assert controller._pending_image_generation is None
+        hide_cover.assert_called_once()
+
+    def test_windows_video_reveal_waits_for_next_active_surface_composition(
+        self,
+        controller,
+        qapp,
+        mocker,
+    ):
+        controller._requires_post_submit_frame = True
+        request_update = mocker.patch.object(
+            controller._video_area,
+            "request_active_surface_update",
+        )
+        hide_cover = mocker.patch.object(controller, "_hide_detail_init_cover")
+        controls_enabled = mocker.patch.object(
+            controller._video_area,
+            "set_controls_enabled",
+        )
+        controller.begin_video_transition(41, interactive_when_ready=True)
+
+        controller._video_area.surfaceFrameSubmitted.emit(41, 7)
+        controller._video_area.surfaceCompositionSubmitted.emit()
+
+        assert controller._pending_video_generation == 41
+        hide_cover.assert_not_called()
+
+        qapp.processEvents()
+        request_update.assert_called_once_with()
+        hide_cover.assert_not_called()
+
+        controller._video_area.surfaceCompositionSubmitted.emit()
+
+        assert controller._pending_video_generation is None
+        assert controller._pending_video_content_serial is None
+        controls_enabled.assert_called_with(True)
+        hide_cover.assert_called_once()
+
+    def test_new_transition_cancels_deferred_windows_cover_release(
+        self,
+        controller,
+        qapp,
+        mocker,
+    ):
+        controller._requires_post_submit_frame = True
+        update = mocker.patch.object(controller._image_viewer, "update")
+        controller._arm_image_transition(42, "image-42")
+        controller.show_image_surface()
+        update.reset_mock()
+        controller._image_viewer.stillFrameSubmitted.emit("image-42", 42)
+
+        controller.show_placeholder("cancelled")
+        qapp.processEvents()
+        controller._image_viewer.frameSubmitted.emit()
+
+        update.assert_not_called()
+        assert controller._pending_image_generation is None
+
+    def test_video_invalidation_replaces_deferred_windows_release_epoch(
+        self,
+        controller,
+        qapp,
+        mocker,
+    ):
+        controller._requires_post_submit_frame = True
+        request_update = mocker.patch.object(
+            controller._video_area,
+            "request_active_surface_update",
+        )
+        hide_cover = mocker.patch.object(controller, "_hide_detail_init_cover")
+        controller.begin_video_transition(43, interactive_when_ready=False)
+        controller._video_area.surfaceFrameSubmitted.emit(43, 8)
+
+        controller._video_area.surfaceInvalidated.emit(43, 8)
+        qapp.processEvents()
+        controller._video_area.surfaceCompositionSubmitted.emit()
+
+        request_update.assert_not_called()
+        hide_cover.assert_not_called()
+        assert controller._pending_video_generation == 43
+
+        controller._video_area.surfaceFrameSubmitted.emit(43, 8)
+        qapp.processEvents()
+        request_update.assert_called_once_with()
+        controller._video_area.surfaceCompositionSubmitted.emit()
+
+        assert controller._pending_video_generation is None
+        hide_cover.assert_called_once()
+
     def test_image_first_render_hides_cover_when_image_visible(self, controller, mocker):
         """_on_image_first_render should hide cover when image is current widget."""
         mock_hide = mocker.patch.object(controller, "_hide_detail_init_cover")
@@ -1223,6 +1342,9 @@ def test_init_cover_stays_below_face_name_overlay_and_does_not_take_mouse(
     assert detail._rhi_init_cover is not None
     assert detail._rhi_init_cover.testAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
     assert detail.face_name_overlay.isVisible() is True
+    persistent_cover = detail._rhi_init_cover
+    player_layout = detail.player_container.layout()
+    layout_count = player_layout.count()
 
     margin_point = _chip_margin_point(detail.face_name_overlay)
     _send_mouse_move_to_overlay_point(detail._rhi_init_cover, detail.face_name_overlay, margin_point)
@@ -1235,7 +1357,8 @@ def test_init_cover_stays_below_face_name_overlay_and_does_not_take_mouse(
     detail.show_rhi_init_cover()
     qapp.processEvents()
 
-    assert detail._rhi_init_cover is not None
+    assert detail._rhi_init_cover is persistent_cover
+    assert player_layout.count() == layout_count
     assert detail._rhi_init_cover.testAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
     _send_mouse_move_to_overlay_point(image_viewer, detail.face_name_overlay, margin_point)
     qapp.processEvents()

--- a/tests/ui/controllers/test_player_view_init_cover.py
+++ b/tests/ui/controllers/test_player_view_init_cover.py
@@ -1195,6 +1195,11 @@ class TestInitCoverTracking:
         request_update.assert_called_once_with()
         hide_cover.assert_not_called()
 
+        # Real QRhi ordering: the next decoded-frame acknowledgement arrives
+        # before that frame's generic composition acknowledgement.
+        controller._video_area.surfaceFrameSubmitted.emit(41, 8)
+        assert controller._peek_post_submit_payload("video") == (41, 7)
+        assert controller._post_submit_armed is True
         controller._video_area.surfaceCompositionSubmitted.emit()
 
         assert controller._pending_video_generation is None

--- a/tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
+++ b/tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
@@ -5,7 +5,6 @@ import pytest
 pytest.importorskip("PySide6", reason="PySide6 is required for GL image viewer tests")
 
 import os
-from collections import deque
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -195,7 +194,9 @@ def test_rhi_render_presents_video_uploaded_before_render() -> None:
     viewer._video_frame_presentation_pending = True
     viewer._video_frame_content_generation = 6
     viewer._video_frame_content_serial = 12
-    viewer._frame_submission_queue = deque()
+    viewer._content_revision = 0
+    viewer._rendered_content_identity = None
+    viewer._last_composed_content_identity = None
     viewer._take_pending_content_submission = lambda: (
         GLImageViewer._take_pending_content_submission(viewer)
     )
@@ -225,25 +226,27 @@ def test_rhi_render_presents_video_uploaded_before_render() -> None:
     viewer._renderer.render.assert_called_once()
     viewer.videoFramePresented.emit.assert_not_called()
     assert viewer._video_frame_presentation_pending is False
-    assert list(viewer._frame_submission_queue) == [("video", 6, 12)]
+    assert viewer._rendered_content_identity == ("video", 6, 12, 1)
 
     GLImageViewer._on_frame_submitted(viewer)
 
     viewer.videoFramePresented.emit.assert_called_once_with(6, 12)
-    assert not viewer._frame_submission_queue
+    assert viewer._last_composed_content_identity == ("video", 6, 12, 1)
 
 
 def test_still_submission_carries_content_identity_and_generation() -> None:
     viewer = Mock()
     viewer._first_render_submission_pending = False
-    viewer._frame_submission_queue = deque()
+    viewer._content_revision = 0
+    viewer._rendered_content_identity = None
+    viewer._last_composed_content_identity = None
     viewer._still_presentation_pending = True
     viewer._video_frame_presentation_pending = False
     viewer._texture_manager.get_current_image_source.return_value = "image-b-key"
     viewer._still_generation_by_key = {"image-b-key": 22}
 
     submission = GLImageViewer._take_pending_content_submission(viewer)
-    viewer._frame_submission_queue.append(submission)
+    viewer._rendered_content_identity = submission
 
     viewer.stillFrameSubmitted.emit.assert_not_called()
     viewer.stillFramePresented.emit.assert_not_called()
@@ -254,15 +257,29 @@ def test_still_submission_carries_content_identity_and_generation() -> None:
     viewer.stillFramePresented.emit.assert_called_once_with("image-b-key")
 
 
-def test_empty_submission_cannot_acknowledge_later_video_content() -> None:
+def test_empty_compositions_cannot_delay_later_video_content() -> None:
     viewer = Mock()
     viewer._first_render_submission_pending = False
-    viewer._frame_submission_queue = deque([None, ("video", 9, 14)])
+    viewer._rendered_content_identity = None
+    viewer._last_composed_content_identity = None
 
-    GLImageViewer._on_frame_submitted(viewer)
+    for _ in range(20):
+        GLImageViewer._on_frame_submitted(viewer)
     viewer.videoFramePresented.emit.assert_not_called()
 
+    viewer._rendered_content_identity = ("video", 9, 14, 21)
     GLImageViewer._on_frame_submitted(viewer)
+    viewer.videoFramePresented.emit.assert_called_once_with(9, 14)
+
+
+def test_replayed_gl_video_serial_gets_new_composition_acknowledgement() -> None:
+    viewer = Mock()
+    viewer._first_render_submission_pending = False
+    viewer._last_composed_content_identity = ("video", 9, 14, 1)
+    viewer._rendered_content_identity = ("video", 9, 14, 2)
+
+    GLImageViewer._on_frame_submitted(viewer)
+
     viewer.videoFramePresented.emit.assert_called_once_with(9, 14)
 
 

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -655,9 +655,13 @@ class TestVideoRendererWidget:
         assert not w._frame_submission_queue
         invalidated.assert_called_once_with()
 
+    @pytest.mark.gpu
+    @pytest.mark.windows_compositor
     def test_visible_qrhi_submission_releases_cover_contract(self, qapp):
         """Exercise the real QRhiWidget render -> composition submission order."""
 
+        if sys.platform != "win32":
+            pytest.skip("requires a visible Windows compositor integration runner")
         if QApplication.platformName().lower() in {"offscreen", "minimal"}:
             pytest.skip("requires a visible platform QRhi compositor")
 

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import struct
+import sys
 import time
 import weakref
 from unittest.mock import Mock, call, patch
@@ -15,7 +16,7 @@ pytest.importorskip("PySide6.QtMultimedia", reason="QtMultimedia is required")
 
 from pathlib import Path
 
-from PySide6.QtCore import QPointF, QRectF, QSize, QSizeF, Qt
+from PySide6.QtCore import QPointF, QRectF, QSize, QSizeF, Qt, QTimer
 from PySide6.QtGui import QColor, QImage, QKeyEvent, QRhiCommandBuffer, QShowEvent
 from PySide6.QtMultimedia import QMediaPlayer, QVideoFrame, QVideoFrameFormat
 from PySide6.QtWidgets import (
@@ -671,13 +672,33 @@ class TestVideoRendererWidget:
         cover.raise_()
         failures = []
         cover_visible_at_submission = []
+        waiting_for_second_submission = False
 
         def _release_cover() -> None:
+            nonlocal waiting_for_second_submission
+            cover_visible_at_submission.append(cover.isVisible())
+            if sys.platform != "win32":
+                cover.hide()
+                return
+
+            def _arm_second_submission() -> None:
+                nonlocal waiting_for_second_submission
+                waiting_for_second_submission = True
+                renderer.update()
+
+            QTimer.singleShot(0, _arm_second_submission)
+
+        def _on_composed() -> None:
+            nonlocal waiting_for_second_submission
+            if not waiting_for_second_submission:
+                return
+            waiting_for_second_submission = False
             cover_visible_at_submission.append(cover.isVisible())
             cover.hide()
 
         renderer.renderFailed.connect(lambda: failures.append(True))
         renderer.firstFrameReady.connect(_release_cover)
+        renderer.frameSubmitted.connect(_on_composed)
 
         host.resize(320, 180)
         host.show()
@@ -694,8 +715,9 @@ class TestVideoRendererWidget:
         cover_released = not cover.isVisible()
         host.close()
         if failures:
-            pytest.skip("platform could not create a QRhi for the contract test")
-        assert cover_visible_at_submission == [True]
+            pytest.fail("visible platform could not create a QRhi for the contract test")
+        expected_visibility = [True, True] if sys.platform == "win32" else [True]
+        assert cover_visible_at_submission == expected_visibility
         assert cover_released
 
     def test_transparent_rounded_clip_toggles_widget_attributes(self, qapp):
@@ -1250,6 +1272,28 @@ class TestVideoArea:
         va._gpu_video_frame_presented_handler(va._media_generation, 4)
 
         surface_spy.assert_called_once_with(42, 4)
+
+    def test_only_active_inner_surface_forwards_composition_submission(
+        self,
+        qapp,
+        mocker,
+    ) -> None:
+        va = VideoArea()
+        composed = mocker.Mock()
+        va.surfaceCompositionSubmitted.connect(composed)
+
+        va._edit_viewer.frameSubmitted.emit()
+        composed.assert_not_called()
+
+        va._renderer.frameSubmitted.emit()
+        composed.assert_called_once_with()
+
+        va.set_adjusted_preview_enabled(True)
+        composed.reset_mock()
+        va._renderer.frameSubmitted.emit()
+        composed.assert_not_called()
+        va._edit_viewer.frameSubmitted.emit()
+        composed.assert_called_once_with()
 
     def test_hidden_surface_resource_loss_does_not_invalidate_visible_surface(
         self,

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -596,7 +596,7 @@ class TestVideoRendererWidget:
         w.videoFramePresented.connect(video_presented)
 
         w._queue_first_frame_ready()
-        w._frame_submission_queue.append((5, 7))
+        w._rendered_content_identity = (5, 7, 1)
 
         first_ready.assert_not_called()
         video_presented.assert_not_called()
@@ -606,7 +606,7 @@ class TestVideoRendererWidget:
         first_ready.assert_called_once_with()
         video_presented.assert_called_once_with(5, 7)
 
-    def test_clear_submission_cannot_acknowledge_a_later_video_draw(
+    def test_clear_compositions_cannot_delay_a_later_video_acknowledgement(
         self,
         qapp,
         mocker,
@@ -614,12 +614,25 @@ class TestVideoRendererWidget:
         w = VideoRendererWidget()
         video_presented = mocker.Mock()
         w.videoFramePresented.connect(video_presented)
-        w._frame_submission_queue.extend([None, (8, 13)])
 
-        w._on_frame_submitted()
+        for _ in range(20):
+            w._rendered_content_identity = None
+            w._on_frame_submitted()
         video_presented.assert_not_called()
 
+        w._rendered_content_identity = (8, 13, 21)
         w._on_frame_submitted()
+        video_presented.assert_called_once_with(8, 13)
+
+    def test_replayed_serial_gets_a_new_composition_acknowledgement(self, qapp, mocker):
+        w = VideoRendererWidget()
+        video_presented = mocker.Mock()
+        w.videoFramePresented.connect(video_presented)
+        w._last_composed_content_identity = (8, 13, 1)
+        w._rendered_content_identity = (8, 13, 2)
+
+        w._on_frame_submitted()
+
         video_presented.assert_called_once_with(8, 13)
 
     def test_release_resources_destroys_owned_qrhi_objects(self, qapp, mocker):
@@ -643,16 +656,18 @@ class TestVideoRendererWidget:
         w.renderResourcesInvalidated.connect(invalidated)
         w._initialized = True
         w._first_render_done = True
-        w._frame_submission_queue.append((1, 11))
+        w._rendered_content_identity = (1, 11, 1)
+        w._last_composed_content_identity = (1, 10, 0)
 
         w.releaseResources()
 
         for name, resource in resources.items():
             resource.destroy.assert_called_once_with()
-            assert getattr(w, name) is None
+        assert getattr(w, name) is None
         assert w._initialized is False
         assert w._first_render_done is False
-        assert not w._frame_submission_queue
+        assert w._rendered_content_identity is None
+        assert w._last_composed_content_identity is None
         invalidated.assert_called_once_with()
 
     @pytest.mark.gpu


### PR DESCRIPTION

This pull request introduces experimental support for a Windows-only D3D11 QRhi (Qt Rendering Hardware Interface) backend for media preview, alongside significant improvements to diagnostics, documentation, and graphics contract validation. The main goal is to enable focused A/B testing of the new D3D11 path in the media Detail view, while maintaining OpenGL as the production/default backend. The changes include new documentation, backend selection logic, alpha buffer handling for translucent windows, and enhanced diagnostics for graphics contracts.

**Experimental D3D11 QRhi Backend for Windows (Detail View Only):**

- Added support for `IPHOTO_RHI_BACKEND=d3d11` as a valid backend override, enabling the D3D11 QRhi path for media Detail widgets on Windows. This is strictly experimental and does not support GPU Maps or full application-wide D3D11 usage. [[1]](diffhunk://#diff-1c886171f9ee1f23905d753c5e0a4a994669c666fa8c09ad3cad696b27f2ce1cL13-R21) [[2]](diffhunk://#diff-1c886171f9ee1f23905d753c5e0a4a994669c666fa8c09ad3cad696b27f2ce1cR37-R64)
- Improved backend selection logic to ensure D3D11 is only used on compatible Windows builds, with fallback and warnings if not available.
- Updated backend documentation and environment variable descriptions to reflect D3D11 support and its experimental status. [[1]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL385-R386) [[2]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL611-R612) [[3]](diffhunk://#diff-ec1bffea3a2e037b073b179ed8bf39501a711d2fa7f42c1b7d99469af6b3c648R1-R207)

**Graphics Contract Diagnostics and Validation:**

- Introduced `_top_level_graphics_contract()` in `main.py` to inspect and log the main window's graphics contract (backend, surface type, alpha bits, translucency, framelessness) after first paint. This helps validate correct backend and surface configuration, especially for translucent OpenGL and D3D11 windows. [[1]](diffhunk://#diff-47234ac6ad771546a20a4bc730f7cd70e208677f89f6d61cdd3e15b09c549a61R524-R579) [[2]](diffhunk://#diff-47234ac6ad771546a20a4bc730f7cd70e208677f89f6d61cdd3e15b09c549a61R1235-R1244)
- Ensured that on Windows and macOS, an 8-bit alpha buffer is requested for OpenGL surfaces to support translucent, frameless windows.
- Extended the backend-to-surface-type mapping to include D3D11 in the surface preparation logic.

**Player View Controller: D3D11 First-Frame Submission Heuristic:**

- Added logic in `PlayerViewController` to track and respond to an extra `frameSubmitted` (for images) or `surfaceCompositionSubmitted` (for videos) event on Windows. This is used as a heuristic for the first-frame leak workaround in the D3D11 path, ensuring the application waits for an additional composition before revealing media. [[1]](diffhunk://#diff-b99efea15826edee5b12292631d289d6106730d65f327ac990342970e375849dR478-R483) [[2]](diffhunk://#diff-b99efea15826edee5b12292631d289d6106730d65f327ac990342970e375849dR503-R508) [[3]](diffhunk://#diff-b99efea15826edee5b12292631d289d6106730d65f327ac990342970e375849dR5)

**Documentation and Testing:**

- Added comprehensive documentation in `WINDOWS_D3D11_QRHI_STATUS.md` outlining the current status, limitations, and roadmap for D3D11 QRhi support on Windows, including a support matrix and required steps before promoting D3D11 to default.
- Updated the Windows scan/playback diagnostics guide with instructions for running A/B tests between OpenGL and D3D11, including what to look for in logs and how to interpret results.
- Added new pytest markers for GPU and Windows compositor requirements to facilitate targeted test execution.

**Summary of Most Important Changes:**

**1. Experimental D3D11 Backend Support (Windows-only, Detail View)**
- Added D3D11 as a valid backend override, with logic to restrict usage to Windows and fallback to OpenGL on other platforms. [[1]](diffhunk://#diff-1c886171f9ee1f23905d753c5e0a4a994669c666fa8c09ad3cad696b27f2ce1cL13-R21) [[2]](diffhunk://#diff-1c886171f9ee1f23905d753c5e0a4a994669c666fa8c09ad3cad696b27f2ce1cR37-R64)
- Updated documentation and environment variable descriptions for D3D11 support and usage instructions. [[1]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL385-R386) [[2]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL611-R612) [[3]](diffhunk://#diff-ec1bffea3a2e037b073b179ed8bf39501a711d2fa7f42c1b7d99469af6b3c648R1-R207)

**2. Graphics Contract Validation and Diagnostics**
- Implemented `_top_level_graphics_contract()` to log and validate main window graphics contract after first paint, including backend, surface type, and alpha buffer. [[1]](diffhunk://#diff-47234ac6ad771546a20a4bc730f7cd70e208677f89f6d61cdd3e15b09c549a61R524-R579) [[2]](diffhunk://#diff-47234ac6ad771546a20a4bc730f7cd70e208677f89f6d61cdd3e15b09c549a61R1235-R1244)
- Ensured 8-bit alpha buffer for translucent OpenGL windows on both Windows and macOS.
- Mapped D3D11 backend to the correct Qt surface type in surface preparation logic.

**3. First-Frame Submission Heuristic for D3D11**
- Added Windows-specific logic in `PlayerViewController` to require and track an extra frame submission event before revealing media, addressing the first-frame leak in D3D11 Detail views. [[1]](diffhunk://#diff-b99efea15826edee5b12292631d289d6106730d65f327ac990342970e375849dR478-R483) [[2]](diffhunk://#diff-b99efea15826edee5b12292631d289d6106730d65f327ac990342970e375849dR503-R508) [[3]](diffhunk://#diff-b99efea15826edee5b12292631d289d6106730d65f327ac990342970e375849dR5)

**4. Documentation and Test Infrastructure**
- Added `WINDOWS_D3D11_QRHI_STATUS.md` for status, limitations, and roadmap of D3D11 QRhi support.
- Enhanced Windows scan/playback diagnostics guide for A/B backend testing.
- Introduced new pytest markers for GPU and Windows compositor requirements.