### PR TITLE
Fix viewport relayout and playback framing after fullscreen

### DIFF
--- a/src/iPhoto/gui/coordinators/edit_coordinator.py
+++ b/src/iPhoto/gui/coordinators/edit_coordinator.py
@@ -162,6 +162,7 @@ class EditCoordinator(QObject):
             self._ui,
             window,
             parent=self,
+            active_viewport_provider=self._active_edit_viewport,
         )
 
         self._update_throttler = QTimer(self)

--- a/src/iPhoto/gui/ui/controllers/edit_fullscreen_manager.py
+++ b/src/iPhoto/gui/ui/controllers/edit_fullscreen_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Optional
 
 from PySide6.QtCore import QObject
@@ -20,10 +21,13 @@ class EditFullscreenManager(QObject):
         ui: Ui_MainWindow,
         window: Optional[QObject],
         parent: Optional[QObject] = None,
+        *,
+        active_viewport_provider: Callable[[], object] | None = None,
     ) -> None:
         super().__init__(parent)
         self._ui = ui
         self._window: Optional[QObject] = window
+        self._active_viewport_provider = active_viewport_provider
 
         # Track whether the immersive layout is currently active so callers can
         # avoid re-entering the workflow while a session is already running.
@@ -126,7 +130,11 @@ class EditFullscreenManager(QObject):
 
         self._fullscreen_active = True
 
-        self._ui.edit_image_viewer.reset_zoom()
+        viewport = self._active_viewport()
+        reset_zoom = getattr(viewport, "reset_zoom", None)
+        if callable(reset_zoom):
+            reset_zoom()
+        self._request_viewport_relayout(viewport)
 
         return True
 
@@ -166,12 +174,26 @@ class EditFullscreenManager(QObject):
         self._fullscreen_splitter_sizes = None
 
         self._fullscreen_active = False
+        self._request_viewport_relayout(self._active_viewport())
 
         return True
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+    def _active_viewport(self) -> object:
+        """Return the still or adjusted-video viewport owned by Edit."""
+
+        if self._active_viewport_provider is not None:
+            return self._active_viewport_provider()
+        return self._ui.edit_image_viewer
+
+    @staticmethod
+    def _request_viewport_relayout(viewport: object) -> None:
+        request_relayout = getattr(viewport, "request_viewport_relayout", None)
+        if callable(request_relayout):
+            request_relayout()
+
     def _sanitise_splitter_sizes(
         self,
         sizes,

--- a/src/iPhoto/gui/ui/controllers/edit_fullscreen_manager.py
+++ b/src/iPhoto/gui/ui/controllers/edit_fullscreen_manager.py
@@ -174,7 +174,10 @@ class EditFullscreenManager(QObject):
         self._fullscreen_splitter_sizes = None
 
         self._fullscreen_active = False
-        self._request_viewport_relayout(self._active_viewport())
+        self._request_viewport_relayout(
+            self._active_viewport(),
+            reset_view=True,
+        )
 
         return True
 
@@ -189,10 +192,17 @@ class EditFullscreenManager(QObject):
         return self._ui.edit_image_viewer
 
     @staticmethod
-    def _request_viewport_relayout(viewport: object) -> None:
+    def _request_viewport_relayout(
+        viewport: object,
+        *,
+        reset_view: bool = False,
+    ) -> None:
         request_relayout = getattr(viewport, "request_viewport_relayout", None)
         if callable(request_relayout):
-            request_relayout()
+            if reset_view:
+                request_relayout(reset_view=True)
+            else:
+                request_relayout()
 
     def _sanitise_splitter_sizes(
         self,

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/input_handler.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/input_handler.py
@@ -83,7 +83,6 @@ class InputEventHandler:
             if self._live_replay_enabled:
                 self._on_replay_requested()
             else:
-                self._on_cancel_auto_crop_lock()
                 self._transform_controller.handle_mouse_press(event)
         
         return False
@@ -101,7 +100,9 @@ class InputEventHandler:
             return True
         
         if not self._live_replay_enabled:
-            self._transform_controller.handle_mouse_move(event)
+            transform_changed = self._transform_controller.handle_mouse_move(event)
+            if transform_changed:
+                self._on_cancel_auto_crop_lock()
         
         return False
     
@@ -161,5 +162,6 @@ class InputEventHandler:
             self._crop_controller.handle_wheel(event)
             return
         
-        self._on_cancel_auto_crop_lock()
-        self._transform_controller.handle_wheel(event)
+        transform_changed = self._transform_controller.handle_wheel(event)
+        if transform_changed:
+            self._on_cancel_auto_crop_lock()

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -308,6 +308,12 @@ class GLImageViewer(QRhiWidget):
         self._source_rotate90_steps = 0
         self._pending_source_rotate90_steps: int | None = None
         self._last_render_target_size = QSize()
+        # Crop framing must be derived from the QRhi render target that will
+        # consume it. QWidget resize events can arrive before QRhi replaces
+        # its target, so keep a separate dirty bit and synchronised target
+        # size instead of calculating pan against the previous frame here.
+        self._viewport_relayout_pending = False
+        self._last_layout_target_size = QSize()
         self._diag_video_frame_set_count = 0
         self._diag_video_render_count = 0
         self._adjustments: dict[str, Any] = {}
@@ -564,6 +570,44 @@ class GLImageViewer(QRhiWidget):
             float(self._last_render_target_size.width()),
             float(self._last_render_target_size.height()),
         )
+
+    def request_viewport_relayout(self) -> None:
+        """Rebuild automatic media framing against the next real render target."""
+
+        self._viewport_relayout_pending = True
+        self.update()
+
+    def _sync_view_transform_for_render_target(self, output_size: QSize) -> None:
+        """Synchronise crop-aware zoom and pan with *output_size* once.
+
+        ``resizeEvent`` cannot safely do this work because
+        :meth:`_render_target_device_size` may still describe the previous
+        fullscreen/windowed frame. Both render backends call this helper only
+        after publishing their current target size, keeping fit scale and crop
+        pan in one coordinate space.
+        """
+
+        target_size = QSize(output_size)
+        if target_size.isEmpty():
+            return
+        if (
+            not self._viewport_relayout_pending
+            and target_size == self._last_layout_target_size
+        ):
+            return
+
+        self._viewport_relayout_pending = False
+        self._last_layout_target_size = target_size
+
+        straighten, rotate_steps, _ = self._rotation_parameters()
+        self._update_cover_scale(straighten, rotate_steps)
+
+        if self._crop_controller.is_active():
+            return
+        if self._auto_crop_view_locked:
+            self._reapply_locked_crop_view()
+        elif self._auto_crop_center_locked:
+            self._reapply_locked_crop_center()
 
     @staticmethod
     def _should_log_diag_frame(index: int) -> bool:
@@ -1745,6 +1789,7 @@ class GLImageViewer(QRhiWidget):
                 )
             return
         self._last_render_target_size = QSize(output_size)
+        self._sync_view_transform_for_render_target(output_size)
 
         suppressed = GLImageViewer._presentation_is_suppressed(self)
         suppressed_video_generation = (
@@ -2009,6 +2054,7 @@ class GLImageViewer(QRhiWidget):
         if output_size.isEmpty():
             return
         self._last_render_target_size = QSize(output_size)
+        self._sync_view_transform_for_render_target(output_size)
 
         suppressed = GLImageViewer._presentation_is_suppressed(self)
         suppressed_video_generation = (
@@ -2430,12 +2476,7 @@ class GLImageViewer(QRhiWidget):
         if not self._runtime_ready:
             return
         self._loading_overlay.update_geometry(self.size())
-        if self._auto_crop_view_locked and not self._crop_controller.is_active():
-            self._reapply_locked_crop_view()
-        elif self._auto_crop_center_locked and not self._crop_controller.is_active():
-            self._reapply_locked_crop_center()
-        straighten, rotate_steps, _ = self._rotation_parameters()
-        self._update_cover_scale(straighten, rotate_steps)
+        self.request_viewport_relayout()
         self.viewTransformChanged.emit()
         self.viewportMetricsChanged.emit()
         if sys.platform.startswith("linux"):

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -615,13 +615,17 @@ class GLImageViewer(QRhiWidget):
 
         if reset_view:
             self.reset_zoom()
-            return
-        if self._crop_controller.is_active():
-            return
-        if self._auto_crop_view_locked:
-            self._reapply_locked_crop_view()
-        elif self._auto_crop_center_locked:
-            self._reapply_locked_crop_center()
+        elif not self._crop_controller.is_active():
+            if self._auto_crop_view_locked:
+                self._reapply_locked_crop_view()
+            elif self._auto_crop_center_locked:
+                self._reapply_locked_crop_center()
+
+        # Viewport-coordinate consumers (for example face annotations) must
+        # only observe the transform after the authoritative QRhi target and
+        # every target-dependent crop/cover update agree.
+        self.viewTransformChanged.emit()
+        self.viewportMetricsChanged.emit()
 
     @staticmethod
     def _should_log_diag_frame(index: int) -> bool:
@@ -2491,8 +2495,6 @@ class GLImageViewer(QRhiWidget):
             return
         self._loading_overlay.update_geometry(self.size())
         self.request_viewport_relayout()
-        self.viewTransformChanged.emit()
-        self.viewportMetricsChanged.emit()
         if sys.platform.startswith("linux"):
             _LOGGER.warning(
                 "[diag][gl_viewer] resize widget=%sx%s rt=%sx%s using_video=%s dirty=%s",

--- a/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
+++ b/src/iPhoto/gui/ui/widgets/gl_image_viewer/widget.py
@@ -313,6 +313,7 @@ class GLImageViewer(QRhiWidget):
         # its target, so keep a separate dirty bit and synchronised target
         # size instead of calculating pan against the previous frame here.
         self._viewport_relayout_pending = False
+        self._viewport_reset_pending = False
         self._last_layout_target_size = QSize()
         self._diag_video_frame_set_count = 0
         self._diag_video_render_count = 0
@@ -571,10 +572,18 @@ class GLImageViewer(QRhiWidget):
             float(self._last_render_target_size.height()),
         )
 
-    def request_viewport_relayout(self) -> None:
-        """Rebuild automatic media framing against the next real render target."""
+    def request_viewport_relayout(self, *, reset_view: bool = False) -> None:
+        """Rebuild media framing against the next real render target.
+
+        ``reset_view`` is sticky until the request is consumed so a normal
+        resize event cannot downgrade a fullscreen-exit reset to a transform-
+        preserving relayout.
+        """
 
         self._viewport_relayout_pending = True
+        self._viewport_reset_pending = (
+            self._viewport_reset_pending or bool(reset_view)
+        )
         self.update()
 
     def _sync_view_transform_for_render_target(self, output_size: QSize) -> None:
@@ -596,12 +605,17 @@ class GLImageViewer(QRhiWidget):
         ):
             return
 
+        reset_view = self._viewport_reset_pending
         self._viewport_relayout_pending = False
+        self._viewport_reset_pending = False
         self._last_layout_target_size = target_size
 
         straighten, rotate_steps, _ = self._rotation_parameters()
         self._update_cover_scale(straighten, rotate_steps)
 
+        if reset_view:
+            self.reset_zoom()
+            return
         if self._crop_controller.is_active():
             return
         if self._auto_crop_view_locked:

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -669,6 +669,7 @@ class VideoArea(QWidget):
                 self._edit_viewer.request_viewport_relayout()
         elif reset_view:
             self._renderer.reset_zoom()
+            self._renderer.update()
         else:
             # The direct video renderer derives its fit from every render
             # target and therefore only needs another frame requested.

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -659,6 +659,16 @@ class VideoArea(QWidget):
         else:
             self._renderer.reset_zoom()
 
+    def request_viewport_relayout(self) -> None:
+        """Refresh the active video surface after its real viewport settles."""
+
+        if self._adjusted_preview_enabled:
+            self._edit_viewer.request_viewport_relayout()
+        else:
+            # The direct video renderer derives its fit from every render
+            # target and therefore only needs another frame requested.
+            self._renderer.update()
+
     def zoom_in(self) -> None:
         if self._adjusted_preview_enabled:
             self._edit_viewer.zoom_in()

--- a/src/iPhoto/gui/ui/widgets/video_area.py
+++ b/src/iPhoto/gui/ui/widgets/video_area.py
@@ -659,11 +659,16 @@ class VideoArea(QWidget):
         else:
             self._renderer.reset_zoom()
 
-    def request_viewport_relayout(self) -> None:
+    def request_viewport_relayout(self, *, reset_view: bool = False) -> None:
         """Refresh the active video surface after its real viewport settles."""
 
         if self._adjusted_preview_enabled:
-            self._edit_viewer.request_viewport_relayout()
+            if reset_view:
+                self._edit_viewer.request_viewport_relayout(reset_view=True)
+            else:
+                self._edit_viewer.request_viewport_relayout()
+        elif reset_view:
+            self._renderer.reset_zoom()
         else:
             # The direct video renderer derives its fit from every render
             # target and therefore only needs another frame requested.

--- a/src/iPhoto/gui/ui/widgets/view_transform_controller.py
+++ b/src/iPhoto/gui/ui/widgets/view_transform_controller.py
@@ -345,26 +345,44 @@ class ViewTransformController:
             self._pan_start_pos = event.position()
             self._viewer.setCursor(Qt.CursorShape.ClosedHandCursor)
 
-    def handle_mouse_move(self, event: QMouseEvent) -> None:
+    def handle_mouse_move(self, event: QMouseEvent) -> bool:
+        """Apply an active pan and report whether the transform changed."""
+
         if not self._is_panning:
-            return
+            return False
         delta = event.position() - self._pan_start_pos
         self._pan_start_pos = event.position()
         delta_device = self.viewport_delta_logical_to_device(delta)
-        self.set_pan_pixels(self._pan_px + QPointF(delta_device.x(), -delta_device.y()))
+        target_pan = self._pan_px + QPointF(delta_device.x(), -delta_device.y())
+        if (
+            abs(target_pan.x() - self._pan_px.x()) < 1e-6
+            and abs(target_pan.y() - self._pan_px.y()) < 1e-6
+        ):
+            return False
+        self.set_pan_pixels(target_pan)
+        return True
 
     def handle_mouse_release(self, event: QMouseEvent) -> None:
         if event.button() == Qt.MouseButton.LeftButton:
             self._is_panning = False
             self._viewer.unsetCursor()
 
-    def handle_wheel(self, event: QWheelEvent) -> None:
+    def handle_wheel(self, event: QWheelEvent) -> bool:
+        """Handle zoom/navigation and report whether zoom actually changed."""
+
+        transform_changed = False
         if self._wheel_action == "zoom":
             angle = event.angleDelta().y()
             if angle > 0:
-                self.set_zoom(self._zoom_factor * 1.1, anchor=event.position())
+                transform_changed = self.set_zoom(
+                    self._zoom_factor * 1.1,
+                    anchor=event.position(),
+                )
             elif angle < 0:
-                self.set_zoom(self._zoom_factor / 1.1, anchor=event.position())
+                transform_changed = self.set_zoom(
+                    self._zoom_factor / 1.1,
+                    anchor=event.position(),
+                )
         else:
             delta = event.angleDelta()
             step = delta.y() or delta.x()
@@ -373,6 +391,7 @@ class ViewTransformController:
             elif step > 0 and self._on_prev_item is not None:
                 self._on_prev_item()
         event.accept()
+        return transform_changed
 
     # ------------------------------------------------------------------
     # Coordinate transformation utilities

--- a/src/iPhoto/gui/ui/window_manager.py
+++ b/src/iPhoto/gui/ui/window_manager.py
@@ -375,6 +375,7 @@ class FramelessWindowManager(QObject):
                 self._ui.filmstrip_view.setVisible(self._ui.toggle_filmstrip_action.isChecked())
 
         self._update_fullscreen_button_icon()
+        self._request_media_viewport_relayout()
         self._schedule_playback_header_shadow_restore()
         self._schedule_playback_resume(expect_immersive=False, resume=resume_after_transition)
 
@@ -383,6 +384,14 @@ class FramelessWindowManager(QObject):
 
         if self._immersive_active and not self._window.isFullScreen():
             self._finish_immersive_exit(request_window_change=False)
+
+    def _request_media_viewport_relayout(self) -> None:
+        """Let the active media surface consume the restored QRhi target size."""
+
+        for viewport in (self._ui.image_viewer, self._ui.video_area):
+            request_relayout = getattr(viewport, "request_viewport_relayout", None)
+            if callable(request_relayout):
+                request_relayout()
 
     def is_immersive_active(self) -> bool:
         """Return ``True`` when the window is in immersive full screen mode."""

--- a/src/iPhoto/gui/ui/window_manager.py
+++ b/src/iPhoto/gui/ui/window_manager.py
@@ -375,7 +375,7 @@ class FramelessWindowManager(QObject):
                 self._ui.filmstrip_view.setVisible(self._ui.toggle_filmstrip_action.isChecked())
 
         self._update_fullscreen_button_icon()
-        self._request_media_viewport_relayout()
+        self._request_media_viewport_relayout(reset_view=True)
         self._schedule_playback_header_shadow_restore()
         self._schedule_playback_resume(expect_immersive=False, resume=resume_after_transition)
 
@@ -385,13 +385,16 @@ class FramelessWindowManager(QObject):
         if self._immersive_active and not self._window.isFullScreen():
             self._finish_immersive_exit(request_window_change=False)
 
-    def _request_media_viewport_relayout(self) -> None:
+    def _request_media_viewport_relayout(self, *, reset_view: bool = False) -> None:
         """Let the active media surface consume the restored QRhi target size."""
 
         for viewport in (self._ui.image_viewer, self._ui.video_area):
             request_relayout = getattr(viewport, "request_viewport_relayout", None)
             if callable(request_relayout):
-                request_relayout()
+                if reset_view:
+                    request_relayout(reset_view=True)
+                else:
+                    request_relayout()
 
     def is_immersive_active(self) -> bool:
         """Return ``True`` when the window is in immersive full screen mode."""

--- a/tests/test_gl_image_viewer_input_handler.py
+++ b/tests/test_gl_image_viewer_input_handler.py
@@ -29,6 +29,8 @@ class TestInputEventHandler:
         self.on_fullscreen_exit = Mock()
         self.on_fullscreen_toggle = Mock()
         self.on_cancel_crop_lock = Mock()
+        self.transform_controller.handle_mouse_move.return_value = False
+        self.transform_controller.handle_wheel.return_value = False
 
         self.handler = InputEventHandler(
             crop_controller=self.crop_controller,
@@ -62,7 +64,7 @@ class TestInputEventHandler:
         result = self.handler.handle_mouse_press(event)
         
         assert result is False
-        self.on_cancel_crop_lock.assert_called_once()
+        self.on_cancel_crop_lock.assert_not_called()
         self.transform_controller.handle_mouse_press.assert_called_once_with(event)
 
     def test_replay_mode_triggers_callback(self):
@@ -99,6 +101,16 @@ class TestInputEventHandler:
         assert result is False
         self.transform_controller.handle_mouse_move.assert_called_once_with(event)
 
+    def test_mouse_move_cancels_crop_lock_only_after_pan_changes(self):
+        """A real drag, rather than its preceding press, should unlock framing."""
+        self.crop_controller.is_active.return_value = False
+        self.transform_controller.handle_mouse_move.return_value = True
+        event = Mock()
+
+        self.handler.handle_mouse_move(event)
+
+        self.on_cancel_crop_lock.assert_called_once_with()
+
     def test_wheel_routes_to_crop_when_active(self):
         """Wheel events should route to crop controller when active."""
         self.crop_controller.is_active.return_value = True
@@ -109,14 +121,25 @@ class TestInputEventHandler:
         self.crop_controller.handle_wheel.assert_called_once_with(event)
         self.transform_controller.handle_wheel.assert_not_called()
 
-    def test_wheel_cancels_crop_lock_when_inactive(self):
-        """Wheel events should cancel crop lock when crop inactive."""
+    def test_zoom_wheel_cancels_crop_lock_when_transform_changes(self):
+        """A wheel event should unlock framing only when it changes zoom."""
         self.crop_controller.is_active.return_value = False
+        self.transform_controller.handle_wheel.return_value = True
         
         event = Mock()
         self.handler.handle_wheel(event)
         
         self.on_cancel_crop_lock.assert_called_once()
+        self.transform_controller.handle_wheel.assert_called_once_with(event)
+
+    def test_navigation_wheel_preserves_crop_lock(self):
+        """Item navigation must not turn viewport framing into manual state."""
+        self.crop_controller.is_active.return_value = False
+        event = Mock()
+
+        self.handler.handle_wheel(event)
+
+        self.on_cancel_crop_lock.assert_not_called()
         self.transform_controller.handle_wheel.assert_called_once_with(event)
 
     def test_double_click_with_fullscreen_window(self):
@@ -131,6 +154,22 @@ class TestInputEventHandler:
         
         assert result is True
         self.on_fullscreen_exit.assert_called_once()
+
+    def test_fullscreen_double_click_sequence_preserves_crop_lock(self):
+        """The press preceding Qt's double-click event must not unlock framing."""
+        self.crop_controller.is_active.return_value = False
+        event = Mock()
+        event.button.return_value = Qt.LeftButton
+        window = Mock()
+        window.isFullScreen.return_value = True
+
+        self.handler.handle_mouse_press(event)
+        self.handler.handle_mouse_release(event)
+        result = self.handler.handle_double_click_with_window(event, window)
+
+        assert result is True
+        self.on_cancel_crop_lock.assert_not_called()
+        self.on_fullscreen_exit.assert_called_once_with()
 
     def test_double_click_with_normal_window(self):
         """Double-click should toggle fullscreen when window is normal."""

--- a/tests/ui/controllers/test_edit_fullscreen_manager.py
+++ b/tests/ui/controllers/test_edit_fullscreen_manager.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from PySide6.QtWidgets import QSplitter, QWidget
+
+from iPhoto.gui.ui.controllers.edit_fullscreen_manager import EditFullscreenManager
+
+
+def test_fullscreen_round_trip_resets_and_relayouts_active_video_viewport(qapp) -> None:
+    window = QWidget()
+    splitter = QSplitter()
+    splitter.addWidget(QWidget())
+    splitter.addWidget(QWidget())
+    fallback_still_viewport = Mock()
+    active_video_viewport = Mock()
+    ui = SimpleNamespace(
+        edit_sidebar=QWidget(),
+        window_chrome=QWidget(),
+        menu_bar_container=QWidget(),
+        menu_bar=QWidget(),
+        sidebar=QWidget(),
+        status_bar=QWidget(),
+        edit_header_container=QWidget(),
+        splitter=splitter,
+        edit_image_viewer=fallback_still_viewport,
+    )
+    manager = EditFullscreenManager(
+        ui,
+        window,
+        active_viewport_provider=lambda: active_video_viewport,
+    )
+
+    assert manager.enter_fullscreen_preview() is True
+    assert manager.exit_fullscreen_preview() is True
+
+    active_video_viewport.reset_zoom.assert_called_once_with()
+    assert active_video_viewport.request_viewport_relayout.call_count == 2
+    fallback_still_viewport.reset_zoom.assert_not_called()
+    fallback_still_viewport.request_viewport_relayout.assert_not_called()

--- a/tests/ui/controllers/test_edit_fullscreen_manager.py
+++ b/tests/ui/controllers/test_edit_fullscreen_manager.py
@@ -37,5 +37,9 @@ def test_fullscreen_round_trip_resets_and_relayouts_active_video_viewport(qapp) 
 
     active_video_viewport.reset_zoom.assert_called_once_with()
     assert active_video_viewport.request_viewport_relayout.call_count == 2
+    assert active_video_viewport.request_viewport_relayout.call_args_list[0].kwargs == {}
+    assert active_video_viewport.request_viewport_relayout.call_args_list[1].kwargs == {
+        "reset_view": True
+    }
     fallback_still_viewport.reset_zoom.assert_not_called()
     fallback_still_viewport.request_viewport_relayout.assert_not_called()

--- a/tests/ui/test_window_manager_fullscreen.py
+++ b/tests/ui/test_window_manager_fullscreen.py
@@ -70,8 +70,12 @@ def test_native_exit_restores_playback_without_calling_show_normal() -> None:
     manager._window.restoreGeometry.assert_not_called()
     manager._window.setWindowState.assert_not_called()
     manager._ui.splitter.setSizes.assert_called_once_with([200, 800])
-    manager._ui.image_viewer.request_viewport_relayout.assert_called_once_with()
-    manager._ui.video_area.request_viewport_relayout.assert_called_once_with()
+    manager._ui.image_viewer.request_viewport_relayout.assert_called_once_with(
+        reset_view=True
+    )
+    manager._ui.video_area.request_viewport_relayout.assert_called_once_with(
+        reset_view=True
+    )
     manager._schedule_playback_header_shadow_restore.assert_called_once_with()
 
 

--- a/tests/ui/test_window_manager_fullscreen.py
+++ b/tests/ui/test_window_manager_fullscreen.py
@@ -70,6 +70,8 @@ def test_native_exit_restores_playback_without_calling_show_normal() -> None:
     manager._window.restoreGeometry.assert_not_called()
     manager._window.setWindowState.assert_not_called()
     manager._ui.splitter.setSizes.assert_called_once_with([200, 800])
+    manager._ui.image_viewer.request_viewport_relayout.assert_called_once_with()
+    manager._ui.video_area.request_viewport_relayout.assert_called_once_with()
     manager._schedule_playback_header_shadow_restore.assert_called_once_with()
 
 

--- a/tests/ui/widgets/test_gl_image_viewer_viewport_relayout.py
+++ b/tests/ui/widgets/test_gl_image_viewer_viewport_relayout.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+from PySide6.QtCore import QPointF, QRectF, QSize
+from PySide6.QtGui import QImage
+
+from iPhoto.gui.ui.widgets.gl_image_viewer import GLImageViewer
+
+
+def _make_cropped_viewer(
+    adjustments: Mapping[str, float],
+    *,
+    logical_size: tuple[int, int] = (600, 400),
+    initial_target: tuple[int, int] = (1920, 1080),
+) -> GLImageViewer:
+    viewer = GLImageViewer()
+    viewer.resize(*logical_size)
+    image = QImage(400, 300, QImage.Format.Format_RGBA8888)
+    image.fill(0xFF202020)
+    viewer._image = image
+    viewer._adjustments = dict(adjustments)
+    viewer._last_render_target_size = QSize(*initial_target)
+    viewer._last_layout_target_size = QSize(*initial_target)
+    viewer.reset_zoom()
+    return viewer
+
+
+def _publish_target_and_sync(
+    viewer: GLImageViewer,
+    target: tuple[int, int],
+) -> None:
+    size = QSize(*target)
+    viewer._last_render_target_size = size
+    viewer._sync_view_transform_for_render_target(size)
+
+
+def _crop_viewport_rect(viewer: GLImageViewer) -> QRectF:
+    crop_rect = viewer._compute_crop_rect_pixels()
+    assert crop_rect is not None
+    controller = viewer._transform_controller
+    top_left = controller.convert_image_to_viewport(
+        crop_rect.left(), crop_rect.top()
+    )
+    bottom_right = controller.convert_image_to_viewport(
+        crop_rect.right(), crop_rect.bottom()
+    )
+    return QRectF(top_left, bottom_right).normalized()
+
+
+@pytest.mark.parametrize(
+    "adjustments",
+    [
+        {"Crop_CX": 0.65, "Crop_CY": 0.5, "Crop_W": 0.7, "Crop_H": 1.0},
+        {"Crop_CX": 0.5, "Crop_CY": 0.65, "Crop_W": 1.0, "Crop_H": 0.7},
+        {"Crop_CX": 0.68, "Crop_CY": 0.63, "Crop_W": 0.55, "Crop_H": 0.6},
+        {"Crop_CX": 0.30, "Crop_CY": 0.35, "Crop_W": 0.6, "Crop_H": 0.7},
+        {"Crop_CX": 0.50, "Crop_CY": 0.50, "Crop_W": 0.6, "Crop_H": 0.7},
+    ],
+    ids=["left", "top", "left-top", "right-bottom", "symmetric"],
+)
+def test_render_target_sync_recenters_crop_after_stale_fullscreen_layout(
+    qapp,
+    adjustments: Mapping[str, float],
+) -> None:
+    viewer = _make_cropped_viewer(adjustments)
+    normal_target = (1200, 800)
+    viewer._last_render_target_size = QSize(*normal_target)
+
+    stale_rect = _crop_viewport_rect(viewer)
+    expected_center = QPointF(viewer.width() / 2.0, viewer.height() / 2.0)
+    if adjustments["Crop_CX"] != 0.5 or adjustments["Crop_CY"] != 0.5:
+        assert (
+            abs(stale_rect.center().x() - expected_center.x()) > 1.0
+            or abs(stale_rect.center().y() - expected_center.y()) > 1.0
+        )
+
+    viewer._sync_view_transform_for_render_target(QSize(*normal_target))
+
+    restored_rect = _crop_viewport_rect(viewer)
+    assert restored_rect.center().x() == pytest.approx(expected_center.x(), abs=1.0)
+    assert restored_rect.center().y() == pytest.approx(expected_center.y(), abs=1.0)
+    assert restored_rect.width() <= viewer.width() + 1.0
+    assert restored_rect.height() <= viewer.height() + 1.0
+    assert (
+        restored_rect.width() == pytest.approx(viewer.width(), abs=1.0)
+        or restored_rect.height() == pytest.approx(viewer.height(), abs=1.0)
+    )
+
+
+def test_uncropped_media_keeps_full_frame_fit_after_target_change(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.5, "Crop_CY": 0.5, "Crop_W": 1.0, "Crop_H": 1.0}
+    )
+
+    _publish_target_and_sync(viewer, (1200, 800))
+
+    controller = viewer._transform_controller
+    top_left = controller.convert_image_to_viewport(0.0, 0.0)
+    bottom_right = controller.convert_image_to_viewport(400.0, 300.0)
+    image_rect = QRectF(top_left, bottom_right).normalized()
+    assert viewer._auto_crop_view_locked is False
+    assert image_rect.center().x() == pytest.approx(300.0, abs=1.0)
+    assert image_rect.center().y() == pytest.approx(200.0, abs=1.0)
+    assert image_rect.width() <= viewer.width() + 1.0
+    assert image_rect.height() <= viewer.height() + 1.0
+
+
+def test_playback_crop_center_lock_reflows_against_restored_target(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.70, "Crop_CY": 0.62, "Crop_W": 0.55, "Crop_H": 0.58}
+    )
+    viewer.set_crop_framing_enabled(False)
+    viewer.reset_zoom()
+    assert viewer._auto_crop_center_locked is True
+
+    _publish_target_and_sync(viewer, (1200, 800))
+
+    restored_rect = _crop_viewport_rect(viewer)
+    assert restored_rect.center().x() == pytest.approx(300.0, abs=1.0)
+    assert restored_rect.center().y() == pytest.approx(200.0, abs=1.0)
+
+
+def test_render_target_sync_handles_rotation_and_high_dpi_target(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {
+            "Crop_CX": 0.72,
+            "Crop_CY": 0.34,
+            "Crop_W": 0.5,
+            "Crop_H": 0.6,
+            "Crop_Rotate90": 1.0,
+        },
+        logical_size=(600, 400),
+    )
+
+    _publish_target_and_sync(viewer, (1200, 800))
+
+    restored_rect = _crop_viewport_rect(viewer)
+    assert restored_rect.center().x() == pytest.approx(300.0, abs=1.0)
+    assert restored_rect.center().y() == pytest.approx(200.0, abs=1.0)
+
+
+def test_repeated_fullscreen_round_trips_do_not_accumulate_crop_drift(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.70, "Crop_CY": 0.62, "Crop_W": 0.55, "Crop_H": 0.58}
+    )
+    normal_target = (1200, 800)
+    fullscreen_target = (1920, 1080)
+    restored_rects: list[QRectF] = []
+
+    for _ in range(10):
+        _publish_target_and_sync(viewer, fullscreen_target)
+        _publish_target_and_sync(viewer, normal_target)
+        restored_rects.append(_crop_viewport_rect(viewer))
+
+    baseline = restored_rects[0]
+    for restored in restored_rects[1:]:
+        assert restored.center().x() == pytest.approx(baseline.center().x(), abs=1.0)
+        assert restored.center().y() == pytest.approx(baseline.center().y(), abs=1.0)
+        assert restored.width() == pytest.approx(baseline.width(), abs=1.0)
+        assert restored.height() == pytest.approx(baseline.height(), abs=1.0)
+
+
+def test_viewport_sync_preserves_manual_transform_without_auto_crop_lock(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.70, "Crop_CY": 0.60, "Crop_W": 0.5, "Crop_H": 0.6}
+    )
+    viewer._cancel_auto_crop_lock()
+    viewer._transform_controller.set_zoom_factor_direct(2.25)
+    viewer._transform_controller.set_pan_pixels(QPointF(37.0, -19.0))
+
+    _publish_target_and_sync(viewer, (1200, 800))
+
+    assert viewer._transform_controller.get_zoom_factor() == pytest.approx(2.25)
+    assert viewer._transform_controller.get_pan_pixels() == QPointF(37.0, -19.0)
+
+
+def test_identical_target_is_coalesced_until_relayout_is_requested(qapp, mocker) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.70, "Crop_CY": 0.60, "Crop_W": 0.5, "Crop_H": 0.6}
+    )
+    target = QSize(1200, 800)
+    viewer._last_render_target_size = target
+    reapply = mocker.patch.object(viewer, "_reapply_locked_crop_view")
+
+    viewer._sync_view_transform_for_render_target(target)
+    viewer._sync_view_transform_for_render_target(target)
+    assert reapply.call_count == 1
+
+    viewer.request_viewport_relayout()
+    viewer._sync_view_transform_for_render_target(target)
+    assert reapply.call_count == 2

--- a/tests/ui/widgets/test_gl_image_viewer_viewport_relayout.py
+++ b/tests/ui/widgets/test_gl_image_viewer_viewport_relayout.py
@@ -176,6 +176,32 @@ def test_viewport_sync_preserves_manual_transform_without_auto_crop_lock(qapp) -
     assert viewer._transform_controller.get_pan_pixels() == QPointF(37.0, -19.0)
 
 
+def test_fullscreen_exit_reset_restores_crop_fit_after_lock_was_cleared(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.70, "Crop_CY": 0.62, "Crop_W": 0.55, "Crop_H": 0.58}
+    )
+    viewer._cancel_auto_crop_lock()
+    viewer._transform_controller.set_zoom_factor_direct(2.25)
+    viewer._transform_controller.set_pan_pixels(QPointF(37.0, -19.0))
+
+    viewer.request_viewport_relayout(reset_view=True)
+    # A later resize event may add a preserving request, but must not downgrade
+    # the fullscreen-exit reset before the new render target is available.
+    viewer.request_viewport_relayout()
+    _publish_target_and_sync(viewer, (1200, 800))
+
+    restored_rect = _crop_viewport_rect(viewer)
+    assert viewer._auto_crop_view_locked is True
+    assert restored_rect.center().x() == pytest.approx(300.0, abs=1.0)
+    assert restored_rect.center().y() == pytest.approx(200.0, abs=1.0)
+    assert restored_rect.width() <= viewer.width() + 1.0
+    assert restored_rect.height() <= viewer.height() + 1.0
+    assert (
+        restored_rect.width() == pytest.approx(viewer.width(), abs=1.0)
+        or restored_rect.height() == pytest.approx(viewer.height(), abs=1.0)
+    )
+
+
 def test_identical_target_is_coalesced_until_relayout_is_requested(qapp, mocker) -> None:
     viewer = _make_cropped_viewer(
         {"Crop_CX": 0.70, "Crop_CY": 0.60, "Crop_W": 0.5, "Crop_H": 0.6}

--- a/tests/ui/widgets/test_gl_image_viewer_viewport_relayout.py
+++ b/tests/ui/widgets/test_gl_image_viewer_viewport_relayout.py
@@ -4,7 +4,8 @@ from collections.abc import Mapping
 
 import pytest
 from PySide6.QtCore import QPointF, QRectF, QSize
-from PySide6.QtGui import QImage
+from PySide6.QtGui import QImage, QResizeEvent
+from PySide6.QtTest import QSignalSpy
 
 from iPhoto.gui.ui.widgets.gl_image_viewer import GLImageViewer
 
@@ -107,6 +108,43 @@ def test_uncropped_media_keeps_full_frame_fit_after_target_change(qapp) -> None:
     assert image_rect.height() <= viewer.height() + 1.0
 
 
+def test_resize_notifies_observers_only_after_real_target_is_synchronised(qapp) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.5, "Crop_CY": 0.5, "Crop_W": 1.0, "Crop_H": 1.0}
+    )
+    old_target = QSize(1920, 1080)
+    new_target = QSize(1200, 800)
+    viewer._last_render_target_size = old_target
+    viewer._last_layout_target_size = old_target
+    viewer._viewport_relayout_pending = False
+    observed: list[tuple[tuple[float, float] | None, QRectF]] = []
+    viewer.viewTransformChanged.connect(
+        lambda: observed.append(
+            (
+                viewer._render_target_device_size(),
+                viewer.image_rect_to_viewport(0.0, 0.0, 400.0, 300.0),
+            )
+        )
+    )
+    viewport_spy = QSignalSpy(viewer.viewportMetricsChanged)
+
+    viewer.resizeEvent(QResizeEvent(viewer.size(), viewer.size()))
+
+    assert observed == []
+    assert viewport_spy.count() == 0
+
+    viewer._last_render_target_size = new_target
+    viewer._sync_view_transform_for_render_target(new_target)
+
+    assert len(observed) == 1
+    assert viewport_spy.count() == 1
+    observed_target, image_rect = observed[-1]
+    assert observed_target == (1200.0, 800.0)
+    assert image_rect.center().x() == pytest.approx(300.0, abs=1.0)
+    assert image_rect.center().y() == pytest.approx(200.0, abs=1.0)
+    assert image_rect.height() == pytest.approx(viewer.height(), abs=1.0)
+
+
 def test_playback_crop_center_lock_reflows_against_restored_target(qapp) -> None:
     viewer = _make_cropped_viewer(
         {"Crop_CX": 0.70, "Crop_CY": 0.62, "Crop_W": 0.55, "Crop_H": 0.58}
@@ -183,6 +221,7 @@ def test_fullscreen_exit_reset_restores_crop_fit_after_lock_was_cleared(qapp) ->
     viewer._cancel_auto_crop_lock()
     viewer._transform_controller.set_zoom_factor_direct(2.25)
     viewer._transform_controller.set_pan_pixels(QPointF(37.0, -19.0))
+    viewport_spy = QSignalSpy(viewer.viewportMetricsChanged)
 
     viewer.request_viewport_relayout(reset_view=True)
     # A later resize event may add a preserving request, but must not downgrade
@@ -200,6 +239,23 @@ def test_fullscreen_exit_reset_restores_crop_fit_after_lock_was_cleared(qapp) ->
         restored_rect.width() == pytest.approx(viewer.width(), abs=1.0)
         or restored_rect.height() == pytest.approx(viewer.height(), abs=1.0)
     )
+    assert viewport_spy.count() == 1
+
+
+def test_active_crop_notifies_after_target_sync_without_reframing(qapp, mocker) -> None:
+    viewer = _make_cropped_viewer(
+        {"Crop_CX": 0.70, "Crop_CY": 0.62, "Crop_W": 0.55, "Crop_H": 0.58}
+    )
+    mocker.patch.object(viewer._crop_controller, "is_active", return_value=True)
+    reapply = mocker.patch.object(viewer, "_reapply_locked_crop_view")
+    transform_spy = QSignalSpy(viewer.viewTransformChanged)
+    viewport_spy = QSignalSpy(viewer.viewportMetricsChanged)
+
+    _publish_target_and_sync(viewer, (1200, 800))
+
+    reapply.assert_not_called()
+    assert transform_spy.count() == 1
+    assert viewport_spy.count() == 1
 
 
 def test_identical_target_is_coalesced_until_relayout_is_requested(qapp, mocker) -> None:
@@ -209,11 +265,17 @@ def test_identical_target_is_coalesced_until_relayout_is_requested(qapp, mocker)
     target = QSize(1200, 800)
     viewer._last_render_target_size = target
     reapply = mocker.patch.object(viewer, "_reapply_locked_crop_view")
+    transform_spy = QSignalSpy(viewer.viewTransformChanged)
+    viewport_spy = QSignalSpy(viewer.viewportMetricsChanged)
 
     viewer._sync_view_transform_for_render_target(target)
     viewer._sync_view_transform_for_render_target(target)
     assert reapply.call_count == 1
+    assert transform_spy.count() == 1
+    assert viewport_spy.count() == 1
 
     viewer.request_viewport_relayout()
     viewer._sync_view_transform_for_render_target(target)
     assert reapply.call_count == 2
+    assert transform_spy.count() == 2
+    assert viewport_spy.count() == 2

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -1292,16 +1292,20 @@ class TestVideoArea:
     def test_reset_relayout_resets_direct_video_renderer(self, qapp, mocker):
         """Unadjusted playback should restore its native fit on fullscreen exit."""
         va = VideoArea()
-        renderer_reset = mocker.patch.object(va._renderer, "reset_zoom")
+        va._renderer._zoom_factor = 1.0
+        renderer_update = mocker.patch.object(va._renderer, "update")
         edit_request = mocker.patch.object(
             va._edit_viewer,
             "request_viewport_relayout",
         )
         va._adjusted_preview_enabled = False
 
+        va._renderer.reset_zoom()
+        renderer_update.assert_not_called()
+
         va.request_viewport_relayout(reset_view=True)
 
-        renderer_reset.assert_called_once_with()
+        renderer_update.assert_called_once_with()
         edit_request.assert_not_called()
 
     def test_playback_preview_keeps_crop_framing_disabled(self, qapp):

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -1289,6 +1289,21 @@ class TestVideoArea:
         request_relayout.assert_called_once_with()
         renderer_update.assert_not_called()
 
+    def test_reset_relayout_resets_direct_video_renderer(self, qapp, mocker):
+        """Unadjusted playback should restore its native fit on fullscreen exit."""
+        va = VideoArea()
+        renderer_reset = mocker.patch.object(va._renderer, "reset_zoom")
+        edit_request = mocker.patch.object(
+            va._edit_viewer,
+            "request_viewport_relayout",
+        )
+        va._adjusted_preview_enabled = False
+
+        va.request_viewport_relayout(reset_view=True)
+
+        renderer_reset.assert_called_once_with()
+        edit_request.assert_not_called()
+
     def test_playback_preview_keeps_crop_framing_disabled(self, qapp):
         """Playback should avoid edit-style crop zooming by default."""
         va = VideoArea()

--- a/tests/ui/widgets/test_video_area.py
+++ b/tests/ui/widgets/test_video_area.py
@@ -1274,6 +1274,21 @@ class TestVideoArea:
         va = VideoArea()
         assert va.video_viewport() is va._renderer
 
+    def test_viewport_relayout_routes_to_adjusted_video_viewer(self, qapp, mocker):
+        """Cropped video relayout should use the shared crop-aware viewer."""
+        va = VideoArea()
+        request_relayout = mocker.patch.object(
+            va._edit_viewer,
+            "request_viewport_relayout",
+        )
+        renderer_update = mocker.patch.object(va._renderer, "update")
+        va._adjusted_preview_enabled = True
+
+        va.request_viewport_relayout()
+
+        request_relayout.assert_called_once_with()
+        renderer_update.assert_not_called()
+
     def test_playback_preview_keeps_crop_framing_disabled(self, qapp):
         """Playback should avoid edit-style crop zooming by default."""
         va = VideoArea()

--- a/tests/ui/widgets/test_view_transform_controller.py
+++ b/tests/ui/widgets/test_view_transform_controller.py
@@ -1,5 +1,7 @@
+from unittest.mock import Mock
+
 import pytest
-from PySide6.QtCore import QPointF
+from PySide6.QtCore import QPoint, QPointF, Qt
 
 from iPhoto.gui.ui.widgets.view_transform_controller import ViewTransformController
 
@@ -22,6 +24,12 @@ class FakeViewer:
 
     def update(self) -> None:
         self.update_count += 1
+
+    def setCursor(self, _cursor) -> None:  # noqa: N802 - Qt-compatible test seam
+        return None
+
+    def unsetCursor(self) -> None:  # noqa: N802 - Qt-compatible test seam
+        return None
 
 
 def make_controller(
@@ -90,6 +98,47 @@ def test_zoom_anchor_defaults_to_render_target_center() -> None:
     image_center = controller.convert_viewport_to_image(QPointF(50.0, 50.0))
     assert image_center.x() == pytest.approx(50.0)
     assert image_center.y() == pytest.approx(50.0)
+
+
+def test_pan_reports_change_only_after_nonzero_drag() -> None:
+    viewer = FakeViewer()
+    controller = make_controller(viewer, (200.0, 200.0))
+    press = Mock()
+    press.button.return_value = Qt.MouseButton.LeftButton
+    press.position.return_value = QPointF(25.0, 25.0)
+    stationary_move = Mock()
+    stationary_move.position.return_value = QPointF(25.0, 25.0)
+    drag_move = Mock()
+    drag_move.position.return_value = QPointF(35.0, 30.0)
+
+    controller.handle_mouse_press(press)
+
+    assert controller.handle_mouse_move(stationary_move) is False
+    assert controller.handle_mouse_move(drag_move) is True
+    assert controller.get_pan_pixels() != QPointF()
+
+
+def test_wheel_reports_only_zoom_changes() -> None:
+    viewer = FakeViewer()
+    next_item = Mock()
+    controller = ViewTransformController(
+        viewer,
+        texture_size_provider=lambda: (100, 100),
+        display_texture_size_provider=lambda: (100, 100),
+        device_view_size_provider=lambda: (200.0, 200.0),
+        on_zoom_changed=lambda _zoom: None,
+        on_next_item=next_item,
+    )
+    event = Mock()
+    event.angleDelta.return_value = QPoint(0, -120)
+    event.position.return_value = QPointF(50.0, 50.0)
+
+    controller.set_wheel_action("navigate")
+    assert controller.handle_wheel(event) is False
+    next_item.assert_called_once_with()
+
+    controller.set_wheel_action("zoom")
+    assert controller.handle_wheel(event) is True
 
 
 def test_image_viewport_roundtrip_with_non_square_target_and_pan_zoom() -> None:


### PR DESCRIPTION
This pull request introduces significant improvements to how viewport relayout and crop lock behavior are managed in fullscreen and zoom/pan workflows, with a focus on more robust and predictable handling of user interactions and rendering state. The changes unify relayout triggers, ensure crop lock is only cancelled when transforms actually change, and add comprehensive test coverage for these behaviors.

**Viewport relayout and fullscreen handling improvements:**

* Added a unified `request_viewport_relayout` method to both `GLImageViewer` and `VideoArea`, allowing external callers to trigger a relayout or reset of the viewport state in response to fullscreen transitions or window size changes. This is now used throughout the fullscreen workflow, including immersive exit in `window_manager.py` and edit fullscreen manager. [[1]](diffhunk://#diff-637fdad2e6774763cd9326b6973fc0900b989eead4bc91e831a5a6c2f0b8fd15R575-R625) [[2]](diffhunk://#diff-8992be5fad16c47459ffc750e7cffbba857f510b241973b9d4d27d0ef7606ec3R662-R676) [[3]](diffhunk://#diff-cc34d46a0f0c88213090f539ee541707ed877da33a52c62ad229bd8f94101390L129-R137) [[4]](diffhunk://#diff-cc34d46a0f0c88213090f539ee541707ed877da33a52c62ad229bd8f94101390R177-R206) [[5]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R378) [[6]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R388-R398)

* The relayout logic in `GLImageViewer` is now decoupled from `resizeEvent` and instead synchronizes against the actual render target size, ensuring correct zoom/pan/crop restoration after fullscreen transitions. [[1]](diffhunk://#diff-637fdad2e6774763cd9326b6973fc0900b989eead4bc91e831a5a6c2f0b8fd15R575-R625) [[2]](diffhunk://#diff-637fdad2e6774763cd9326b6973fc0900b989eead4bc91e831a5a6c2f0b8fd15R1806) [[3]](diffhunk://#diff-637fdad2e6774763cd9326b6973fc0900b989eead4bc91e831a5a6c2f0b8fd15R2071) [[4]](diffhunk://#diff-637fdad2e6774763cd9326b6973fc0900b989eead4bc91e831a5a6c2f0b8fd15L2433-R2493)

**Crop lock and transform controller behavior:**

* Crop lock is now only cancelled when a pan or zoom operation actually changes the transform, rather than on every mouse press or wheel event. This is achieved by having `handle_mouse_move` and `handle_wheel` return a boolean indicating whether the transform changed, and only cancelling crop lock if so. [[1]](diffhunk://#diff-7b593666cecb6267bd6e96effbef3ab028c8ac31ac48684f6d6d2e6f9e6bfde2L86) [[2]](diffhunk://#diff-7b593666cecb6267bd6e96effbef3ab028c8ac31ac48684f6d6d2e6f9e6bfde2L104-R105) [[3]](diffhunk://#diff-7b593666cecb6267bd6e96effbef3ab028c8ac31ac48684f6d6d2e6f9e6bfde2R165-L165) [[4]](diffhunk://#diff-ced3901cbbd31c51b8bc4dadeb3a64f9375a9a9ac5ac6e2f2ad88b03325e083eL348-R385) [[5]](diffhunk://#diff-ced3901cbbd31c51b8bc4dadeb3a64f9375a9a9ac5ac6e2f2ad88b03325e083eR394)

**Test coverage enhancements:**

* Added and updated tests in `test_gl_image_viewer_input_handler.py` to verify that crop lock is only cancelled on actual transform changes, that navigation does not unlock crop lock, and that double-click sequences do not spuriously unlock framing. [[1]](diffhunk://#diff-df5d835b80ce4898575c12bd842a00d1cd8f404e20f04dc531fff5c68db1290aR32-R33) [[2]](diffhunk://#diff-df5d835b80ce4898575c12bd842a00d1cd8f404e20f04dc531fff5c68db1290aL65-R67) [[3]](diffhunk://#diff-df5d835b80ce4898575c12bd842a00d1cd8f404e20f04dc531fff5c68db1290aR104-R113) [[4]](diffhunk://#diff-df5d835b80ce4898575c12bd842a00d1cd8f404e20f04dc531fff5c68db1290aL112-R144) [[5]](diffhunk://#diff-df5d835b80ce4898575c12bd842a00d1cd8f404e20f04dc531fff5c68db1290aR158-R173)

**API and interface changes:**

* `EditFullscreenManager` now accepts an `active_viewport_provider` callback to support relayout of the correct viewport, improving flexibility and correctness when managing different media types. [[1]](diffhunk://#diff-ccb942ca1cbe567425906778677904a524e09ea3872644faca8c61986fdb2eb0R165) [[2]](diffhunk://#diff-cc34d46a0f0c88213090f539ee541707ed877da33a52c62ad229bd8f94101390R5) [[3]](diffhunk://#diff-cc34d46a0f0c88213090f539ee541707ed877da33a52c62ad229bd8f94101390R24-R30)

These changes collectively make viewport state management more robust across fullscreen transitions and user interactions, and ensure that crop lock and relayout behaviors are consistent and thoroughly tested.