### PR TITLE
Harden fullscreen compositor transition on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,6 +265,7 @@ jobs:
           tests/gui/test_detail_render_session.py
           tests/ui/controllers/test_player_view_controller_adjustments.py
           tests/ui/controllers/test_player_view_init_cover.py
+          tests/ui/test_window_manager_fullscreen.py
           tests/ui/widgets/test_gl_image_viewer_post_load_signal.py
           tests/ui/widgets/test_still_texture_residency.py
           tests/ui/widgets/test_video_area.py

--- a/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
+++ b/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
@@ -83,6 +83,20 @@ end with `post_submit_deadline` followed by `surface_revealed` with
 repetition matrix can determine whether this preserves the user-visible
 first-frame leak fix.
 
+Fullscreen traces must keep one transaction id from
+`fullscreen_enter_requested` through `fullscreen_native_state_confirmed` and
+`fullscreen_updates_resumed`. Re-enabling QWidget updates implicitly queues the
+only top-level update; the trace must attribute it as
+`fullscreen_update_requested` and then emit `fullscreen_transition_finished`
+with `reason=final_update_observed`. If the request cannot be observed within
+250 ms, `fullscreen_final_update_unobserved` is diagnostic-only and must not
+exit an already confirmed fullscreen state. A preparation/native failure must
+instead emit `fullscreen_enter_rollback` and restore painting.
+
+Also test a playing video with `enter→exit→enter→exit`, keeping every interval
+below 120 ms. Stale resume callbacks must not play during an intermediate state;
+the newest callback must restore playback exactly once after the final exit.
+
 Transition traces must show `presentation_suppressed` before the exposed
 surface's `video_surface_blank_requested`/blank submission and
 `presentation_resumed` only after matching new content is installed. A rapid

--- a/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
+++ b/docs/WINDOWS_SCAN_PLAYBACK_DIAGNOSTICS.md
@@ -86,12 +86,16 @@ first-frame leak fix.
 Fullscreen traces must keep one transaction id from
 `fullscreen_enter_requested` through `fullscreen_native_state_confirmed` and
 `fullscreen_updates_resumed`. Re-enabling QWidget updates implicitly queues the
-only top-level update; the trace must attribute it as
-`fullscreen_update_requested` and then emit `fullscreen_transition_finished`
-with `reason=final_update_observed`. If the request cannot be observed within
-250 ms, `fullscreen_final_update_unobserved` is diagnostic-only and must not
-exit an already confirmed fullscreen state. A preparation/native failure must
-instead emit `fullscreen_enter_rollback` and restore painting.
+expected final top-level update; the trace must attribute at least one such
+request as `fullscreen_update_requested` and then emit
+`fullscreen_transition_finished` with `reason=final_update_observed`. If the
+request cannot be observed within 250 ms, `fullscreen_final_update_unobserved`
+is diagnostic-only and must not exit an already confirmed fullscreen state.
+The trace does not prove the exact number of Qt update requests because Qt may
+coalesce them. A preflight failure resumes suspended playback and re-raises
+without creating a window transaction; an in-transaction preparation/native
+failure instead emits
+`fullscreen_enter_rollback` and restores painting.
 
 Also test a playing video with `enter→exit→enter→exit`, keeping every interval
 below 120 ms. Stale resume callbacks must not play during an intermediate state;

--- a/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
+++ b/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
@@ -61,14 +61,21 @@ The production OpenGL path keeps top-level updates disabled while Windows
 applies the native fullscreen state. Chrome visibility, splitter geometry, and
 the immersive backdrop are changed within that transaction; updates resume
 only after a confirmed `WindowStateChange`, followed by one viewport relayout
-and one final top-level update. A one-second deadline either completes an
-already-landed fullscreen state or rolls the UI back to its saved windowed
-state, so a missing native event cannot leave painting disabled.
+and the implicit `UpdateRequest` produced by re-enabling QWidget updates. No
+additional `window.update()` is issued. A one-second deadline either completes
+an already-landed fullscreen state or rolls the UI back to its saved windowed
+state, so a missing native event cannot leave painting disabled. Exceptions
+in the preparation, native request, or diagnostics paths also converge through
+a best-effort rollback whose final step restores the original updates state.
 
 When Detail profiling is enabled, the `fullscreen_*` timeline records the
 transaction id, window state and geometry, update state, selected backend, and
 known render-target sizes. A packaged Windows run must compare `opengl` and
 `d3d11` on the same host and retain both the timeline and a screen recording.
+The transition remains attributable until the implicit final update is
+observed, or until a 250 ms diagnostic-only observation deadline records
+`fullscreen_final_update_unobserved`. Playback resume callbacks use a separate
+generation and preserve the original resume intent across rapid toggles.
 The A/B result is diagnostic only: D3D11 remains experimental and cannot become
 the production default until the application-wide graphics and Maps contract
 below is complete.

--- a/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
+++ b/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
@@ -55,6 +55,24 @@ The following pieces exist and are covered by code-level contracts:
 This is sufficient for focused Detail compositor A/B experiments. It is not a
 complete application graphics contract.
 
+### Playback fullscreen compositor hotfix
+
+The production OpenGL path keeps top-level updates disabled while Windows
+applies the native fullscreen state. Chrome visibility, splitter geometry, and
+the immersive backdrop are changed within that transaction; updates resume
+only after a confirmed `WindowStateChange`, followed by one viewport relayout
+and one final top-level update. A one-second deadline either completes an
+already-landed fullscreen state or rolls the UI back to its saved windowed
+state, so a missing native event cannot leave painting disabled.
+
+When Detail profiling is enabled, the `fullscreen_*` timeline records the
+transaction id, window state and geometry, update state, selected backend, and
+known render-target sizes. A packaged Windows run must compare `opengl` and
+`d3d11` on the same host and retain both the timeline and a screen recording.
+The A/B result is diagnostic only: D3D11 remains experimental and cannot become
+the production default until the application-wide graphics and Maps contract
+below is complete.
+
 ### Guarantee boundary of the extra submission
 
 The Windows reveal workaround proves that Qt/QRhi submitted an additional

--- a/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
+++ b/docs/misc/WINDOWS_D3D11_QRHI_STATUS.md
@@ -61,12 +61,14 @@ The production OpenGL path keeps top-level updates disabled while Windows
 applies the native fullscreen state. Chrome visibility, splitter geometry, and
 the immersive backdrop are changed within that transaction; updates resume
 only after a confirmed `WindowStateChange`, followed by one viewport relayout
-and the implicit `UpdateRequest` produced by re-enabling QWidget updates. No
+and an expected final `UpdateRequest` produced by re-enabling QWidget updates. No
 additional `window.update()` is issued. A one-second deadline either completes
 an already-landed fullscreen state or rolls the UI back to its saved windowed
 state, so a missing native event cannot leave painting disabled. Exceptions
 in the preparation, native request, or diagnostics paths also converge through
 a best-effort rollback whose final step restores the original updates state.
+Failures before the window transaction exists resume any suspended playback and
+re-raise; they do not manufacture a rollback transaction or diagnostic id.
 
 When Detail profiling is enabled, the `fullscreen_*` timeline records the
 transaction id, window state and geometry, update state, selected backend, and

--- a/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
+++ b/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
@@ -47,8 +47,9 @@ Windows Playback fullscreen 样本还必须保留同一 `transition_id` 下的
 `fullscreen_enter_timeout`，并收敛为完成或 `fullscreen_enter_rollback`。确认前不得
 恢复顶层 updates，确认后每个 transaction 只允许一次 viewport relayout。恢复
 updates 时不得再显式调用 `window.update()`；Qt 隐式排队的最终请求必须记录为
-`fullscreen_update_requested` 并归属于同一 transaction。250 ms 内未观察到该事件时
-记录 `fullscreen_final_update_unobserved`，但不得回滚已确认的 fullscreen。
+`fullscreen_update_requested` 并归属于同一 transaction。这只能证明至少观察到一个
+预期的最终请求；Qt 可能合并请求，timeline 不用于断言请求总数恰好为一。
+250 ms 内未观察到该事件时记录 `fullscreen_final_update_unobserved`，但不得回滚已确认的 fullscreen。
 两条路径最终都记录 `fullscreen_transition_finished` 及原因；`fullscreen_resize`
 只用于关联 DWM/Qt 事件数量，不得当作 terminal event。
 

--- a/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
+++ b/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
@@ -38,6 +38,17 @@ surface 与 GPU residency；sidecar/edit-done 也只修改临时副本。
 baseline 必须在只加入同一 benchmark instrumentation、尚未实施 Phase 5 render/backend 清理的提交构建；candidate
 使用最终代码。两者必须使用相同机器、packaged 配置、manifest、重复次数和缓存场景。
 
+Windows Playback fullscreen 样本还必须保留同一 `transition_id` 下的
+`fullscreen_enter_requested`、`fullscreen_updates_suspended`、
+`fullscreen_backdrop_applied`、`fullscreen_native_state_requested`、
+`fullscreen_native_state_confirmed`、`fullscreen_viewport_relayout_requested` 和
+`fullscreen_updates_resumed`。播放中的视频随后应出现
+`fullscreen_playback_resumed`；若 native state event 丢失，必须出现有界的
+`fullscreen_enter_timeout`，并收敛为完成或 `fullscreen_enter_rollback`。确认前不得
+恢复顶层 updates，确认后每个 transaction 只允许一次 viewport relayout 和一次顶层
+update。`fullscreen_resize` 与 `fullscreen_update_requested` 用于关联 DWM/Qt 事件数量，
+不得当作 terminal event。
+
 启动应用前指定结构化输出文件：
 
 ```bash
@@ -154,6 +165,12 @@ JPEG、PNG、HEIC、RAW 每种格式、每个平台至少采集 30 次。汇总�
 - JPEG/PNG/HEIC/RAW，MP4/MOV/MKV，H.264/H.265，4K/HDR、旋转、trim、adjusted video 与 Live Photo。
 
 source/offscreen 数据只作回归趋势，不作为正式性能证据。门槛采用实施计划中的普通/重型媒体绝对 P95，并要求 P50 至少改善 40%、P95 至少改善 25%。
+
+Windows fullscreen compositor 回归必须使用 packaged `auto/opengl` 连续完成至少
+30 次 normal→fullscreen→normal，并覆盖静态图、播放/暂停视频、Live Photo、
+maximized、125%/150% DPI 与双显示器。屏幕录像中不得出现桌面暴露、透明帧、
+黑屏与媒体画面交替或播放恢复造成的整窗闪烁；最多允许一次正常系统级状态过渡。
+同机 `opengl`/`d3d11` 只作为根因 A/B，不能替代生产 OpenGL 通过记录。
 
 任何失败组必须保留原 events/summary/validation，按 queue、surface cache、decode、GPU upload、draw 定位；修正后
 先重跑失败组，再完整重跑该平台矩阵。不得用删除失败样本、合并取消事务或降低重复次数的方式通过门槛。

--- a/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
+++ b/docs/requirements/DETAIL_OPEN_BENCHMARK_RUNBOOK.md
@@ -45,9 +45,12 @@ Windows Playback fullscreen 样本还必须保留同一 `transition_id` 下的
 `fullscreen_updates_resumed`。播放中的视频随后应出现
 `fullscreen_playback_resumed`；若 native state event 丢失，必须出现有界的
 `fullscreen_enter_timeout`，并收敛为完成或 `fullscreen_enter_rollback`。确认前不得
-恢复顶层 updates，确认后每个 transaction 只允许一次 viewport relayout 和一次顶层
-update。`fullscreen_resize` 与 `fullscreen_update_requested` 用于关联 DWM/Qt 事件数量，
-不得当作 terminal event。
+恢复顶层 updates，确认后每个 transaction 只允许一次 viewport relayout。恢复
+updates 时不得再显式调用 `window.update()`；Qt 隐式排队的最终请求必须记录为
+`fullscreen_update_requested` 并归属于同一 transaction。250 ms 内未观察到该事件时
+记录 `fullscreen_final_update_unobserved`，但不得回滚已确认的 fullscreen。
+两条路径最终都记录 `fullscreen_transition_finished` 及原因；`fullscreen_resize`
+只用于关联 DWM/Qt 事件数量，不得当作 terminal event。
 
 启动应用前指定结构化输出文件：
 
@@ -171,6 +174,9 @@ Windows fullscreen compositor 回归必须使用 packaged `auto/opengl` 连续�
 maximized、125%/150% DPI 与双显示器。屏幕录像中不得出现桌面暴露、透明帧、
 黑屏与媒体画面交替或播放恢复造成的整窗闪烁；最多允许一次正常系统级状态过渡。
 同机 `opengl`/`d3d11` 只作为根因 A/B，不能替代生产 OpenGL 通过记录。
+另以正在播放的视频执行 `enter→exit→enter→exit` 快速序列，每步间隔小于 120 ms；
+过期 resume callback 必须全部被 generation 拒绝，最终只恢复一次播放且播放状态与
+首次切换前一致。
 
 任何失败组必须保留原 events/summary/validation，按 queue、surface cache、decode、GPU upload、draw 定位；修正后
 先重跑失败组，再完整重跑该平台矩阵。不得用删除失败样本、合并取消事务或降低重复次数的方式通过门槛。

--- a/src/iPhoto/gui/ui/window_manager.py
+++ b/src/iPhoto/gui/ui/window_manager.py
@@ -319,13 +319,24 @@ class FramelessWindowManager(QObject):
             return
 
         playback_generation, resume_after_transition = self._begin_playback_transition()
-        ready = self._detail_coordinator.prepare_fullscreen_asset()
-        if not ready:
-            self._detail_coordinator.show_placeholder_in_viewer()
+        try:
+            ready = self._detail_coordinator.prepare_fullscreen_asset()
+            if not ready:
+                self._detail_coordinator.show_placeholder_in_viewer()
 
-        self._previous_geometry = self._window.saveGeometry()
-        self._previous_window_state = self._window.windowState()
-        self._splitter_sizes = self._ui.splitter.sizes()
+            self._previous_geometry = self._window.saveGeometry()
+            self._previous_window_state = self._window.windowState()
+            self._splitter_sizes = self._ui.splitter.sizes()
+        except Exception:
+            # No native/window transaction exists yet, but playback may have
+            # been paused. Preserve the original resume intent and let the
+            # generation guard reject this callback if another transition wins.
+            self._schedule_playback_resume(
+                expect_immersive=False,
+                resume=resume_after_transition,
+                playback_generation=playback_generation,
+            )
+            raise
 
         if sys.platform == "win32":
             self._begin_windows_fullscreen_enter(

--- a/src/iPhoto/gui/ui/window_manager.py
+++ b/src/iPhoto/gui/ui/window_manager.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum, auto
 from typing import TYPE_CHECKING, cast
 
 from PySide6.QtCore import QCoreApplication, QEvent, QObject, QPoint, QSize, Qt, QTimer
@@ -47,9 +50,28 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type checking
 # changes.
 PLAYBACK_RESUME_DELAY_MS = 120
 FULLSCREEN_ENTER_TIMEOUT_MS = 1000
+FULLSCREEN_FINAL_UPDATE_TIMEOUT_MS = 250
 _MIN_WINDOW_WIDTH = 900
 _MIN_WINDOW_HEIGHT = 640
 _SCREEN_CLAMP_MARGIN = 40
+_LOGGER = logging.getLogger(__name__)
+
+
+class _FullscreenTransitionPhase(Enum):
+    PREPARING = auto()
+    AWAITING_NATIVE = auto()
+    AWAITING_FINAL_UPDATE = auto()
+    ROLLING_BACK = auto()
+
+
+@dataclass(slots=True)
+class _WindowsFullscreenTransition:
+    transition_id: int
+    phase: _FullscreenTransitionPhase
+    updates_enabled_before: bool
+    playback_generation: int
+    resume_playback: bool
+    deadline_timer: QTimer | None = None
 
 
 def _is_wayland() -> bool:
@@ -110,11 +132,9 @@ class FramelessWindowManager(QObject):
         self._immersive_visibility_targets = self._build_immersive_targets()
         self._shadow_restore_generation = 0
         self._fullscreen_transition_generation = 0
-        self._fullscreen_enter_pending: int | None = None
-        self._fullscreen_enter_updates_enabled_before: bool | None = None
-        self._fullscreen_enter_resume = False
-        self._fullscreen_enter_timeout_timer: QTimer | None = None
-        self._fullscreen_transition_backend = "unknown"
+        self._fullscreen_transition: _WindowsFullscreenTransition | None = None
+        self._playback_transition_generation = 0
+        self._playback_resume_pending = False
 
         self._qmenu_stylesheet: str = ""
         self._global_menu_stylesheet: str | None = None
@@ -162,7 +182,7 @@ class FramelessWindowManager(QObject):
                 if app.property("floatingToolTipFilter") == self._tooltip_filter:
                     app.setProperty("floatingToolTipFilter", None)
         self._tooltip_filter = None
-        self._cancel_fullscreen_enter_timeout()
+        self._cancel_fullscreen_transition_deadline(self._fullscreen_transition)
         self._window_tooltip.hide_tooltip()
         self._snap_helper.cleanup()
 
@@ -298,7 +318,7 @@ class FramelessWindowManager(QObject):
         if self._detail_coordinator is None:
             return
 
-        resume_after_transition = self._detail_coordinator.suspend_playback_for_transition()
+        playback_generation, resume_after_transition = self._begin_playback_transition()
         ready = self._detail_coordinator.prepare_fullscreen_asset()
         if not ready:
             self._detail_coordinator.show_placeholder_in_viewer()
@@ -308,7 +328,10 @@ class FramelessWindowManager(QObject):
         self._splitter_sizes = self._ui.splitter.sizes()
 
         if sys.platform == "win32":
-            self._begin_windows_fullscreen_enter(resume_after_transition)
+            self._begin_windows_fullscreen_enter(
+                resume_after_transition,
+                playback_generation=playback_generation,
+            )
             return
 
         self._suppress_playback_header_shadow()
@@ -326,43 +349,86 @@ class FramelessWindowManager(QObject):
         self._immersive_active = True
         self._window.showFullScreen()
         self._update_fullscreen_button_icon()
-        self._schedule_playback_resume(expect_immersive=True, resume=resume_after_transition)
+        self._schedule_playback_resume(
+            expect_immersive=True,
+            resume=resume_after_transition,
+            playback_generation=playback_generation,
+        )
 
-    def _begin_windows_fullscreen_enter(self, resume_after_transition: bool) -> None:
+    def _begin_windows_fullscreen_enter(
+        self,
+        resume_after_transition: bool,
+        *,
+        playback_generation: int,
+    ) -> None:
         """Request one atomic Windows fullscreen presentation transaction."""
 
         self._fullscreen_transition_generation += 1
-        transition_id = self._fullscreen_transition_generation
-        self._fullscreen_enter_pending = transition_id
-        self._fullscreen_enter_updates_enabled_before = self._window.updatesEnabled()
-        self._fullscreen_enter_resume = bool(resume_after_transition)
-        self._fullscreen_transition_backend = selected_rhi_backend_name()
-        self._emit_fullscreen_transition_event("fullscreen_enter_requested", transition_id)
-
-        self._window.setUpdatesEnabled(False)
-        self._emit_fullscreen_transition_event("fullscreen_updates_suspended", transition_id)
-
-        splitter_signals_blocked = self._ui.splitter.signalsBlocked()
-        self._ui.splitter.blockSignals(True)
+        transition = _WindowsFullscreenTransition(
+            transition_id=self._fullscreen_transition_generation,
+            phase=_FullscreenTransitionPhase.PREPARING,
+            updates_enabled_before=self._window.updatesEnabled(),
+            playback_generation=int(playback_generation),
+            resume_playback=bool(resume_after_transition),
+        )
+        self._fullscreen_transition = transition
+        splitter_signals_blocked: bool | None = None
         try:
-            self._suppress_playback_header_shadow()
-            self._hidden_widget_states = self._override_visibility(
-                self._immersive_visibility_targets, visible=False
+            self._emit_fullscreen_transition_event(
+                "fullscreen_enter_requested", transition.transition_id
             )
+            self._window.setUpdatesEnabled(False)
+            self._start_fullscreen_transition_deadline(
+                transition,
+                timeout_ms=FULLSCREEN_ENTER_TIMEOUT_MS,
+                callback=self._handle_fullscreen_enter_timeout,
+            )
+            self._emit_fullscreen_transition_event(
+                "fullscreen_updates_suspended", transition.transition_id
+            )
+
+            splitter_signals_blocked = self._ui.splitter.signalsBlocked()
+            self._ui.splitter.blockSignals(True)
+            self._suppress_playback_header_shadow()
+            self._hidden_widget_states = [
+                (widget, widget.isVisible()) for widget in self._immersive_visibility_targets
+            ]
+            for widget, _was_visible in self._hidden_widget_states:
+                widget.setVisible(False)
             self._video_controls_enabled_before = self._ui.video_area.controls_enabled()
             self._ui.video_area.hide_controls(animate=False)
             self._ui.splitter.setSizes([0, sum(self._splitter_sizes or [self._window.width()])])
             self._apply_immersive_backdrop()
-            self._emit_fullscreen_transition_event("fullscreen_backdrop_applied", transition_id)
+            self._emit_fullscreen_transition_event(
+                "fullscreen_backdrop_applied", transition.transition_id
+            )
             self._immersive_active = True
+            transition.phase = _FullscreenTransitionPhase.AWAITING_NATIVE
             self._window.showFullScreen()
             self._emit_fullscreen_transition_event(
-                "fullscreen_native_state_requested", transition_id
+                "fullscreen_native_state_requested", transition.transition_id
             )
+        except Exception:
+            self._rollback_windows_fullscreen_enter(
+                transition,
+                request_window_change=True,
+            )
+            self._schedule_playback_resume(
+                expect_immersive=False,
+                resume=transition.resume_playback,
+                playback_generation=transition.playback_generation,
+                transition_id=transition.transition_id,
+            )
+            raise
         finally:
-            self._ui.splitter.blockSignals(splitter_signals_blocked)
-
-        self._start_fullscreen_enter_timeout(transition_id)
+            if splitter_signals_blocked is not None:
+                try:
+                    self._ui.splitter.blockSignals(splitter_signals_blocked)
+                except Exception:
+                    _LOGGER.debug(
+                        "Failed to restore splitter signals after fullscreen enter",
+                        exc_info=True,
+                    )
 
     def exit_fullscreen(self) -> None:
         """Restore the normal window chrome and previously visible widgets."""
@@ -376,7 +442,7 @@ class FramelessWindowManager(QObject):
             edit_controller.exit_fullscreen_preview()
             return
 
-        if not self._immersive_active:
+        if not self._immersive_active and getattr(self, "_fullscreen_transition", None) is None:
             return
         if self._detail_coordinator is None:
             return
@@ -386,19 +452,34 @@ class FramelessWindowManager(QObject):
     def _finish_immersive_exit(self, *, request_window_change: bool) -> None:
         """Converge Playback immersive state after app or native fullscreen exit."""
 
-        if not self._immersive_active:
+        transition = getattr(self, "_fullscreen_transition", None)
+        if not self._immersive_active and transition is None:
             return
         if self._detail_coordinator is None:
             return
 
-        pending_transition = getattr(self, "_fullscreen_enter_pending", None)
-        pending_windows_enter = pending_transition is not None
-        if pending_windows_enter:
-            resume_after_transition = bool(self._fullscreen_enter_resume)
-            self._cancel_fullscreen_enter_timeout()
-            self._fullscreen_enter_pending = None
-        else:
-            resume_after_transition = self._detail_coordinator.suspend_playback_for_transition()
+        playback_generation, resume_after_transition = self._begin_playback_transition()
+        if transition is not None and transition.phase in {
+            _FullscreenTransitionPhase.PREPARING,
+            _FullscreenTransitionPhase.AWAITING_NATIVE,
+        }:
+            self._rollback_windows_fullscreen_enter(
+                transition,
+                request_window_change=request_window_change,
+            )
+            self._schedule_playback_resume(
+                expect_immersive=False,
+                resume=resume_after_transition,
+                playback_generation=playback_generation,
+                transition_id=transition.transition_id,
+            )
+            return
+        if transition is not None:
+            self._finish_fullscreen_transition_observation(
+                transition,
+                reason="fullscreen_exit",
+            )
+
         self._immersive_active = False
         self._restore_default_backdrop()
         if request_window_change:
@@ -434,23 +515,23 @@ class FramelessWindowManager(QObject):
 
         self._update_fullscreen_button_icon()
         self._request_media_viewport_relayout(reset_view=True)
-        if pending_windows_enter:
-            self._emit_fullscreen_transition_event("fullscreen_enter_rollback", pending_transition)
-            self._restore_fullscreen_enter_updates(pending_transition)
         self._schedule_playback_header_shadow_restore()
         self._schedule_playback_resume(
             expect_immersive=False,
             resume=resume_after_transition,
-            transition_id=pending_transition if pending_windows_enter else None,
+            playback_generation=playback_generation,
         )
 
     def _reconcile_playback_fullscreen_state(self) -> None:
         """Restore stale Playback immersive state after a native fullscreen exit."""
 
-        pending_transition = getattr(self, "_fullscreen_enter_pending", None)
-        if pending_transition is not None:
+        transition = getattr(self, "_fullscreen_transition", None)
+        if transition is not None and transition.phase in {
+            _FullscreenTransitionPhase.PREPARING,
+            _FullscreenTransitionPhase.AWAITING_NATIVE,
+        }:
             if self._window.isFullScreen():
-                self._complete_windows_fullscreen_enter(pending_transition)
+                self._complete_windows_fullscreen_enter(transition.transition_id)
             return
         if self._immersive_active and not self._window.isFullScreen():
             self._finish_immersive_exit(request_window_change=False)
@@ -458,64 +539,248 @@ class FramelessWindowManager(QObject):
     def _complete_windows_fullscreen_enter(self, transition_id: int) -> None:
         """Publish the first stable frame after Windows confirms fullscreen."""
 
-        if transition_id != getattr(self, "_fullscreen_enter_pending", None):
+        transition = getattr(self, "_fullscreen_transition", None)
+        if transition is None or transition.transition_id != transition_id:
+            return
+        if transition.phase not in {
+            _FullscreenTransitionPhase.PREPARING,
+            _FullscreenTransitionPhase.AWAITING_NATIVE,
+        }:
             return
         if not self._window.isFullScreen():
             return
 
-        self._cancel_fullscreen_enter_timeout()
-        self._emit_fullscreen_transition_event("fullscreen_native_state_confirmed", transition_id)
-        self._request_media_viewport_relayout()
-        self._emit_fullscreen_transition_event(
-            "fullscreen_viewport_relayout_requested", transition_id
-        )
-        resume_after_transition = bool(self._fullscreen_enter_resume)
-        self._fullscreen_enter_pending = None
-        self._update_fullscreen_button_icon()
-        self._restore_fullscreen_enter_updates(transition_id)
+        try:
+            self._cancel_fullscreen_transition_deadline(transition)
+            self._emit_fullscreen_transition_event(
+                "fullscreen_native_state_confirmed", transition_id
+            )
+            self._request_media_viewport_relayout()
+            self._emit_fullscreen_transition_event(
+                "fullscreen_viewport_relayout_requested", transition_id
+            )
+            transition.phase = _FullscreenTransitionPhase.AWAITING_FINAL_UPDATE
+            self._update_fullscreen_button_icon()
+            self._restore_windows_fullscreen_updates(transition)
+        except Exception:
+            self._rollback_windows_fullscreen_enter(
+                transition,
+                request_window_change=True,
+            )
+            self._schedule_playback_resume(
+                expect_immersive=False,
+                resume=transition.resume_playback,
+                playback_generation=transition.playback_generation,
+                transition_id=transition.transition_id,
+            )
+            raise
+
         self._schedule_playback_resume(
             expect_immersive=True,
-            resume=resume_after_transition,
+            resume=transition.resume_playback,
+            playback_generation=transition.playback_generation,
             transition_id=transition_id,
         )
 
-    def _start_fullscreen_enter_timeout(self, transition_id: int) -> None:
-        self._cancel_fullscreen_enter_timeout()
+        if (
+            transition.updates_enabled_before
+            and getattr(self, "_fullscreen_transition", None) is transition
+        ):
+            try:
+                self._start_fullscreen_transition_deadline(
+                    transition,
+                    timeout_ms=FULLSCREEN_FINAL_UPDATE_TIMEOUT_MS,
+                    callback=self._handle_fullscreen_final_update_timeout,
+                )
+            except Exception:
+                _LOGGER.debug(
+                    "Failed to observe the final fullscreen UpdateRequest",
+                    exc_info=True,
+                )
+                self._finish_fullscreen_transition_observation(
+                    transition,
+                    reason="final_update_observer_failed",
+                )
+        else:
+            self._finish_fullscreen_transition_observation(
+                transition,
+                reason="updates_remained_disabled",
+            )
+
+    def _start_fullscreen_transition_deadline(
+        self,
+        transition: _WindowsFullscreenTransition,
+        *,
+        timeout_ms: int,
+        callback,
+    ) -> None:
+        self._cancel_fullscreen_transition_deadline(transition)
         timer = QTimer(self)
         timer.setSingleShot(True)
         timer.timeout.connect(
-            lambda transaction=transition_id: self._handle_fullscreen_enter_timeout(transaction)
+            lambda transaction_id=transition.transition_id: callback(transaction_id)
         )
-        self._fullscreen_enter_timeout_timer = timer
-        timer.start(FULLSCREEN_ENTER_TIMEOUT_MS)
+        transition.deadline_timer = timer
+        timer.start(int(timeout_ms))
 
-    def _cancel_fullscreen_enter_timeout(self) -> None:
-        timer = getattr(self, "_fullscreen_enter_timeout_timer", None)
-        self._fullscreen_enter_timeout_timer = None
+    @staticmethod
+    def _cancel_fullscreen_transition_deadline(
+        transition: _WindowsFullscreenTransition | None,
+    ) -> None:
+        timer = transition.deadline_timer if transition is not None else None
+        if transition is not None:
+            transition.deadline_timer = None
         if timer is None:
             return
         timer.stop()
         timer.deleteLater()
 
     def _handle_fullscreen_enter_timeout(self, transition_id: int) -> None:
-        if transition_id != getattr(self, "_fullscreen_enter_pending", None):
+        transition = getattr(self, "_fullscreen_transition", None)
+        if transition is None or transition.transition_id != transition_id:
+            return
+        if transition.phase not in {
+            _FullscreenTransitionPhase.PREPARING,
+            _FullscreenTransitionPhase.AWAITING_NATIVE,
+        }:
             return
         self._emit_fullscreen_transition_event("fullscreen_enter_timeout", transition_id)
         if self._window.isFullScreen():
             self._complete_windows_fullscreen_enter(transition_id)
             return
-        self._finish_immersive_exit(request_window_change=True)
+        self._rollback_windows_fullscreen_enter(transition, request_window_change=True)
+        self._schedule_playback_resume(
+            expect_immersive=False,
+            resume=transition.resume_playback,
+            playback_generation=transition.playback_generation,
+            transition_id=transition.transition_id,
+        )
 
-    def _restore_fullscreen_enter_updates(self, transition_id: int) -> None:
-        updates_enabled = getattr(self, "_fullscreen_enter_updates_enabled_before", None)
-        self._fullscreen_enter_updates_enabled_before = None
-        self._fullscreen_enter_resume = False
-        if updates_enabled is None:
+    def _handle_fullscreen_final_update_timeout(self, transition_id: int) -> None:
+        transition = getattr(self, "_fullscreen_transition", None)
+        if transition is None or transition.transition_id != transition_id:
             return
-        self._window.setUpdatesEnabled(updates_enabled)
-        if updates_enabled:
-            self._window.update()
-        self._emit_fullscreen_transition_event("fullscreen_updates_resumed", transition_id)
+        if transition.phase is not _FullscreenTransitionPhase.AWAITING_FINAL_UPDATE:
+            return
+        self._emit_fullscreen_transition_event("fullscreen_final_update_unobserved", transition_id)
+        self._finish_fullscreen_transition_observation(
+            transition,
+            reason="final_update_timeout",
+        )
+
+    def _restore_windows_fullscreen_updates(
+        self,
+        transition: _WindowsFullscreenTransition,
+    ) -> None:
+        self._window.setUpdatesEnabled(transition.updates_enabled_before)
+        self._emit_fullscreen_transition_event(
+            "fullscreen_updates_resumed", transition.transition_id
+        )
+
+    def _finish_fullscreen_transition_observation(
+        self,
+        transition: _WindowsFullscreenTransition,
+        *,
+        reason: str,
+    ) -> None:
+        if getattr(self, "_fullscreen_transition", None) is not transition:
+            return
+        try:
+            self._cancel_fullscreen_transition_deadline(transition)
+        except Exception:
+            _LOGGER.debug(
+                "Failed to cancel fullscreen transition deadline",
+                exc_info=True,
+            )
+        finally:
+            if getattr(self, "_fullscreen_transition", None) is transition:
+                self._fullscreen_transition = None
+        self._emit_fullscreen_transition_event(
+            "fullscreen_transition_finished",
+            transition.transition_id,
+            reason=reason,
+        )
+
+    def _rollback_windows_fullscreen_enter(
+        self,
+        transition: _WindowsFullscreenTransition,
+        *,
+        request_window_change: bool,
+    ) -> None:
+        """Best-effort rollback that always attempts to restore window updates."""
+
+        if getattr(self, "_fullscreen_transition", None) is not transition:
+            return
+        transition.phase = _FullscreenTransitionPhase.ROLLING_BACK
+        self._emit_fullscreen_transition_event(
+            "fullscreen_enter_rollback", transition.transition_id
+        )
+        self._immersive_active = False
+        try:
+            self._best_effort_fullscreen_restore(
+                "transition deadline",
+                lambda: self._cancel_fullscreen_transition_deadline(transition),
+            )
+            self._best_effort_fullscreen_restore("backdrop", self._restore_default_backdrop)
+            if request_window_change:
+                self._best_effort_fullscreen_restore("normal window state", self._window.showNormal)
+                if self._previous_geometry is not None:
+                    self._best_effort_fullscreen_restore(
+                        "window geometry",
+                        lambda: self._window.restoreGeometry(self._previous_geometry),
+                    )
+                if self._previous_window_state is not None:
+                    self._best_effort_fullscreen_restore(
+                        "window state",
+                        lambda: self._window.setWindowState(self._previous_window_state),
+                    )
+            if self._splitter_sizes:
+                self._best_effort_fullscreen_restore(
+                    "splitter sizes",
+                    lambda: self._ui.splitter.setSizes(self._splitter_sizes),
+                )
+            for widget, was_visible in self._hidden_widget_states:
+                self._best_effort_fullscreen_restore(
+                    "widget visibility",
+                    lambda target=widget, visible=was_visible: target.setVisible(visible),
+                )
+            self._hidden_widget_states = []
+            self._best_effort_fullscreen_restore(
+                "video controls enabled",
+                lambda: self._ui.video_area.set_controls_enabled(
+                    self._video_controls_enabled_before
+                ),
+            )
+            if self._video_controls_enabled_before and self._ui.video_area.isVisible():
+                self._best_effort_fullscreen_restore(
+                    "video controls visibility",
+                    lambda: self._ui.video_area.show_controls(animate=False),
+                )
+            self._best_effort_fullscreen_restore(
+                "fullscreen button", self._update_fullscreen_button_icon
+            )
+            self._best_effort_fullscreen_restore(
+                "media viewport",
+                lambda: self._request_media_viewport_relayout(reset_view=True),
+            )
+            self._best_effort_fullscreen_restore(
+                "header shadow",
+                self._schedule_playback_header_shadow_restore,
+            )
+        finally:
+            self._best_effort_fullscreen_restore(
+                "window updates",
+                lambda: self._restore_windows_fullscreen_updates(transition),
+            )
+            if getattr(self, "_fullscreen_transition", None) is transition:
+                self._fullscreen_transition = None
+
+    @staticmethod
+    def _best_effort_fullscreen_restore(label: str, callback) -> None:
+        try:
+            callback()
+        except Exception:
+            _LOGGER.debug("Failed to restore fullscreen %s", label, exc_info=True)
 
     def _request_media_viewport_relayout(self, *, reset_view: bool = False) -> None:
         """Let the active media surface consume the restored QRhi target size."""
@@ -548,12 +813,19 @@ class FramelessWindowManager(QObject):
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:  # type: ignore[override]
         """Handle title-bar dragging and badge positioning."""
 
-        if (
-            watched is self._window
-            and event.type() == QEvent.Type.UpdateRequest
-            and getattr(self, "_fullscreen_enter_pending", None) is not None
-        ):
-            self._emit_fullscreen_transition_event("fullscreen_update_requested")
+        transition = getattr(self, "_fullscreen_transition", None)
+        if watched is self._window and event.type() == QEvent.Type.UpdateRequest:
+            if (
+                transition is not None
+                and transition.phase is _FullscreenTransitionPhase.AWAITING_FINAL_UPDATE
+            ):
+                self._emit_fullscreen_transition_event(
+                    "fullscreen_update_requested", transition.transition_id
+                )
+                self._finish_fullscreen_transition_observation(
+                    transition,
+                    reason="final_update_observed",
+                )
 
         if watched in self._drag_sources:
             if self._handle_title_bar_drag(event):
@@ -845,6 +1117,10 @@ class FramelessWindowManager(QObject):
         self._window_shell_stylesheet = self._ui.window_shell.styleSheet()
         self._player_container_stylesheet = self._ui.player_container.styleSheet()
         self._player_stack_stylesheet = self._ui.player_stack.styleSheet()
+        # Mark the backdrop recoverable before the first visual mutation. If a
+        # Qt/style adapter raises mid-transaction, rollback must still restore
+        # every surface that may already have changed.
+        self._immersive_background_applied = True
 
         self._rounded_shell.set_corner_radius(0)
         self._rounded_shell.set_override_color(QColor("#000000"))
@@ -853,7 +1129,6 @@ class FramelessWindowManager(QObject):
         self._ui.player_stack.setStyleSheet("background-color: #000000;")
         self._ui.image_viewer.set_immersive_background(True)
         self._ui.video_area.set_immersive_background(True)
-        self._immersive_background_applied = True
 
     def _restore_default_backdrop(self) -> None:
         if not self._immersive_background_applied:
@@ -891,57 +1166,100 @@ class FramelessWindowManager(QObject):
 
         QTimer.singleShot(PLAYBACK_RESUME_DELAY_MS, _restore)
 
+    def _begin_playback_transition(self) -> tuple[int, bool]:
+        """Start a generation and preserve the first pending resume intent."""
+
+        self._playback_transition_generation += 1
+        generation = self._playback_transition_generation
+        if self._playback_resume_pending:
+            return generation, True
+        if self._detail_coordinator is None:
+            return generation, False
+        resume = bool(self._detail_coordinator.suspend_playback_for_transition())
+        self._playback_resume_pending = resume
+        return generation, resume
+
     def _schedule_playback_resume(
         self,
         *,
         expect_immersive: bool,
         resume: bool,
+        playback_generation: int | None = None,
         transition_id: int | None = None,
     ) -> None:
         if not resume:
             return
         if self._detail_coordinator is None:
             return
+        expected_generation = (
+            self._playback_transition_generation
+            if playback_generation is None
+            else int(playback_generation)
+        )
 
         def _resume() -> None:
+            if expected_generation != self._playback_transition_generation:
+                return
             if self._immersive_active != expect_immersive:
                 return
             self._detail_coordinator.resume_playback_after_transition()
+            self._playback_resume_pending = False
             if transition_id is not None:
                 self._emit_fullscreen_transition_event("fullscreen_playback_resumed", transition_id)
 
         QTimer.singleShot(PLAYBACK_RESUME_DELAY_MS, _resume)
 
     def _emit_fullscreen_transition_event(
-        self, stage: str, transition_id: int | None = None
+        self,
+        stage: str,
+        transition_id: int | None = None,
+        **details: object,
     ) -> None:
         """Emit privacy-safe fullscreen compositor diagnostics when enabled."""
 
-        if not detail_profile_enabled():
-            return
-        active_transition = (
-            transition_id
-            if transition_id is not None
-            else getattr(self, "_fullscreen_enter_pending", None)
-        )
-        if active_transition is None:
-            return
+        try:
+            if not detail_profile_enabled():
+                return
+            transition = getattr(self, "_fullscreen_transition", None)
+            active_transition = (
+                transition_id
+                if transition_id is not None
+                else transition.transition_id
+                if transition is not None
+                else None
+            )
+            if active_transition is None:
+                return
 
-        geometry = self._window.geometry()
-        window_state = self._window.windowState()
-        state_name = getattr(window_state, "name", None) or str(window_state)
-        emit_detail_event(
-            stage,
-            generation=0,
-            transition_id=int(active_transition),
-            geometry=(geometry.x(), geometry.y(), geometry.width(), geometry.height()),
-            window_state=state_name,
-            is_fullscreen=bool(self._window.isFullScreen()),
-            updates_enabled=bool(self._window.updatesEnabled()),
-            backend=getattr(self, "_fullscreen_transition_backend", "unknown"),
-            image_render_target=self._render_target_size(self._ui.image_viewer),
-            video_render_target=self._render_target_size(self._active_video_surface()),
-        )
+            geometry = self._window.geometry()
+            window_state = self._window.windowState()
+            state_name = getattr(window_state, "name", None) or str(window_state)
+            backend_name = getattr(self._ui.image_viewer, "render_backend_name", None)
+            backend = str(backend_name()) if callable(backend_name) else selected_rhi_backend_name()
+            emit_detail_event(
+                stage,
+                generation=0,
+                transition_id=int(active_transition),
+                geometry=(
+                    geometry.x(),
+                    geometry.y(),
+                    geometry.width(),
+                    geometry.height(),
+                ),
+                window_state=state_name,
+                is_fullscreen=bool(self._window.isFullScreen()),
+                updates_enabled=bool(self._window.updatesEnabled()),
+                backend=backend,
+                image_render_target=self._render_target_size(self._ui.image_viewer),
+                video_render_target=self._render_target_size(self._active_video_surface()),
+                **details,
+            )
+        except Exception:
+            _LOGGER.debug(
+                "Failed to emit fullscreen transition diagnostic %s",
+                stage,
+                exc_info=True,
+            )
 
     def _active_video_surface(self) -> object | None:
         accessor = getattr(self._ui.video_area, "video_viewport", None)

--- a/src/iPhoto/gui/ui/window_manager.py
+++ b/src/iPhoto/gui/ui/window_manager.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterable, Iterator, cast
+from typing import TYPE_CHECKING, cast
 
-from PySide6.QtCore import Property, QCoreApplication, QEvent, QObject, QPoint, QSize, Qt, QTimer
+from PySide6.QtCore import QCoreApplication, QEvent, QObject, QPoint, QSize, Qt, QTimer
 from PySide6.QtGui import (
     QColor,
     QMouseEvent,
-    QPainter,
-    QPainterPath,
-    QPaintEvent,
     QPalette,
 )
 from PySide6.QtWidgets import (
@@ -24,7 +22,9 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from ..detail_profile import detail_profile_enabled, emit_detail_event
 from ..i18n.font_policy import sync_widget_language_font
+from ..render_backend import selected_rhi_backend_name
 from .icon import load_icon
 from .styles import modern_scrollbar_style
 from .widgets.custom_tooltip import FloatingToolTip, ToolTipEventFilter
@@ -34,8 +34,8 @@ from .window_snap import EdgeSnapHelper
 if TYPE_CHECKING:  # pragma: no cover - used only for type checking
     from PySide6.QtGui import QResizeEvent
 
-    from ..coordinators.edit_coordinator import EditCoordinator
     from ..coordinators.contracts import ImmersiveDetailPort
+    from ..coordinators.edit_coordinator import EditCoordinator
     from .ui_main_window import Ui_MainWindow
 
 
@@ -46,6 +46,7 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type checking
 # visibly on macOS and Windows when the compositor is still applying the size
 # changes.
 PLAYBACK_RESUME_DELAY_MS = 120
+FULLSCREEN_ENTER_TIMEOUT_MS = 1000
 _MIN_WINDOW_WIDTH = 900
 _MIN_WINDOW_HEIGHT = 640
 _SCREEN_CLAMP_MARGIN = 40
@@ -108,6 +109,12 @@ class FramelessWindowManager(QObject):
         self._immersive_background_applied = False
         self._immersive_visibility_targets = self._build_immersive_targets()
         self._shadow_restore_generation = 0
+        self._fullscreen_transition_generation = 0
+        self._fullscreen_enter_pending: int | None = None
+        self._fullscreen_enter_updates_enabled_before: bool | None = None
+        self._fullscreen_enter_resume = False
+        self._fullscreen_enter_timeout_timer: QTimer | None = None
+        self._fullscreen_transition_backend = "unknown"
 
         self._qmenu_stylesheet: str = ""
         self._global_menu_stylesheet: str | None = None
@@ -116,6 +123,7 @@ class FramelessWindowManager(QObject):
         self._install_tooltip_filter()
         self._configure_window_controls()
         self._configure_drag_sources()
+        self._window.installEventFilter(self)
         self._apply_menu_styles()
         self.position_live_badge()
         self.position_resize_widgets()
@@ -154,6 +162,7 @@ class FramelessWindowManager(QObject):
                 if app.property("floatingToolTipFilter") == self._tooltip_filter:
                     app.setProperty("floatingToolTipFilter", None)
         self._tooltip_filter = None
+        self._cancel_fullscreen_enter_timeout()
         self._window_tooltip.hide_tooltip()
         self._snap_helper.cleanup()
 
@@ -185,6 +194,7 @@ class FramelessWindowManager(QObject):
         """Reposition overlays whenever the window geometry changes."""
 
         _ = event  # ``QResizeEvent`` is unused but kept for signature clarity.
+        self._emit_fullscreen_transition_event("fullscreen_resize")
         self.position_live_badge()
         self.position_resize_widgets()
         self._clamp_window_to_current_screen()
@@ -293,10 +303,15 @@ class FramelessWindowManager(QObject):
         if not ready:
             self._detail_coordinator.show_placeholder_in_viewer()
 
-        self._suppress_playback_header_shadow()
         self._previous_geometry = self._window.saveGeometry()
         self._previous_window_state = self._window.windowState()
         self._splitter_sizes = self._ui.splitter.sizes()
+
+        if sys.platform == "win32":
+            self._begin_windows_fullscreen_enter(resume_after_transition)
+            return
+
+        self._suppress_playback_header_shadow()
         with self._suspend_layout_updates():
             self._hidden_widget_states = self._override_visibility(
                 self._immersive_visibility_targets, visible=False
@@ -312,6 +327,42 @@ class FramelessWindowManager(QObject):
         self._window.showFullScreen()
         self._update_fullscreen_button_icon()
         self._schedule_playback_resume(expect_immersive=True, resume=resume_after_transition)
+
+    def _begin_windows_fullscreen_enter(self, resume_after_transition: bool) -> None:
+        """Request one atomic Windows fullscreen presentation transaction."""
+
+        self._fullscreen_transition_generation += 1
+        transition_id = self._fullscreen_transition_generation
+        self._fullscreen_enter_pending = transition_id
+        self._fullscreen_enter_updates_enabled_before = self._window.updatesEnabled()
+        self._fullscreen_enter_resume = bool(resume_after_transition)
+        self._fullscreen_transition_backend = selected_rhi_backend_name()
+        self._emit_fullscreen_transition_event("fullscreen_enter_requested", transition_id)
+
+        self._window.setUpdatesEnabled(False)
+        self._emit_fullscreen_transition_event("fullscreen_updates_suspended", transition_id)
+
+        splitter_signals_blocked = self._ui.splitter.signalsBlocked()
+        self._ui.splitter.blockSignals(True)
+        try:
+            self._suppress_playback_header_shadow()
+            self._hidden_widget_states = self._override_visibility(
+                self._immersive_visibility_targets, visible=False
+            )
+            self._video_controls_enabled_before = self._ui.video_area.controls_enabled()
+            self._ui.video_area.hide_controls(animate=False)
+            self._ui.splitter.setSizes([0, sum(self._splitter_sizes or [self._window.width()])])
+            self._apply_immersive_backdrop()
+            self._emit_fullscreen_transition_event("fullscreen_backdrop_applied", transition_id)
+            self._immersive_active = True
+            self._window.showFullScreen()
+            self._emit_fullscreen_transition_event(
+                "fullscreen_native_state_requested", transition_id
+            )
+        finally:
+            self._ui.splitter.blockSignals(splitter_signals_blocked)
+
+        self._start_fullscreen_enter_timeout(transition_id)
 
     def exit_fullscreen(self) -> None:
         """Restore the normal window chrome and previously visible widgets."""
@@ -340,7 +391,14 @@ class FramelessWindowManager(QObject):
         if self._detail_coordinator is None:
             return
 
-        resume_after_transition = self._detail_coordinator.suspend_playback_for_transition()
+        pending_transition = getattr(self, "_fullscreen_enter_pending", None)
+        pending_windows_enter = pending_transition is not None
+        if pending_windows_enter:
+            resume_after_transition = bool(self._fullscreen_enter_resume)
+            self._cancel_fullscreen_enter_timeout()
+            self._fullscreen_enter_pending = None
+        else:
+            resume_after_transition = self._detail_coordinator.suspend_playback_for_transition()
         self._immersive_active = False
         self._restore_default_backdrop()
         if request_window_change:
@@ -376,14 +434,88 @@ class FramelessWindowManager(QObject):
 
         self._update_fullscreen_button_icon()
         self._request_media_viewport_relayout(reset_view=True)
+        if pending_windows_enter:
+            self._emit_fullscreen_transition_event("fullscreen_enter_rollback", pending_transition)
+            self._restore_fullscreen_enter_updates(pending_transition)
         self._schedule_playback_header_shadow_restore()
-        self._schedule_playback_resume(expect_immersive=False, resume=resume_after_transition)
+        self._schedule_playback_resume(
+            expect_immersive=False,
+            resume=resume_after_transition,
+            transition_id=pending_transition if pending_windows_enter else None,
+        )
 
     def _reconcile_playback_fullscreen_state(self) -> None:
         """Restore stale Playback immersive state after a native fullscreen exit."""
 
+        pending_transition = getattr(self, "_fullscreen_enter_pending", None)
+        if pending_transition is not None:
+            if self._window.isFullScreen():
+                self._complete_windows_fullscreen_enter(pending_transition)
+            return
         if self._immersive_active and not self._window.isFullScreen():
             self._finish_immersive_exit(request_window_change=False)
+
+    def _complete_windows_fullscreen_enter(self, transition_id: int) -> None:
+        """Publish the first stable frame after Windows confirms fullscreen."""
+
+        if transition_id != getattr(self, "_fullscreen_enter_pending", None):
+            return
+        if not self._window.isFullScreen():
+            return
+
+        self._cancel_fullscreen_enter_timeout()
+        self._emit_fullscreen_transition_event("fullscreen_native_state_confirmed", transition_id)
+        self._request_media_viewport_relayout()
+        self._emit_fullscreen_transition_event(
+            "fullscreen_viewport_relayout_requested", transition_id
+        )
+        resume_after_transition = bool(self._fullscreen_enter_resume)
+        self._fullscreen_enter_pending = None
+        self._update_fullscreen_button_icon()
+        self._restore_fullscreen_enter_updates(transition_id)
+        self._schedule_playback_resume(
+            expect_immersive=True,
+            resume=resume_after_transition,
+            transition_id=transition_id,
+        )
+
+    def _start_fullscreen_enter_timeout(self, transition_id: int) -> None:
+        self._cancel_fullscreen_enter_timeout()
+        timer = QTimer(self)
+        timer.setSingleShot(True)
+        timer.timeout.connect(
+            lambda transaction=transition_id: self._handle_fullscreen_enter_timeout(transaction)
+        )
+        self._fullscreen_enter_timeout_timer = timer
+        timer.start(FULLSCREEN_ENTER_TIMEOUT_MS)
+
+    def _cancel_fullscreen_enter_timeout(self) -> None:
+        timer = getattr(self, "_fullscreen_enter_timeout_timer", None)
+        self._fullscreen_enter_timeout_timer = None
+        if timer is None:
+            return
+        timer.stop()
+        timer.deleteLater()
+
+    def _handle_fullscreen_enter_timeout(self, transition_id: int) -> None:
+        if transition_id != getattr(self, "_fullscreen_enter_pending", None):
+            return
+        self._emit_fullscreen_transition_event("fullscreen_enter_timeout", transition_id)
+        if self._window.isFullScreen():
+            self._complete_windows_fullscreen_enter(transition_id)
+            return
+        self._finish_immersive_exit(request_window_change=True)
+
+    def _restore_fullscreen_enter_updates(self, transition_id: int) -> None:
+        updates_enabled = getattr(self, "_fullscreen_enter_updates_enabled_before", None)
+        self._fullscreen_enter_updates_enabled_before = None
+        self._fullscreen_enter_resume = False
+        if updates_enabled is None:
+            return
+        self._window.setUpdatesEnabled(updates_enabled)
+        if updates_enabled:
+            self._window.update()
+        self._emit_fullscreen_transition_event("fullscreen_updates_resumed", transition_id)
 
     def _request_media_viewport_relayout(self, *, reset_view: bool = False) -> None:
         """Let the active media surface consume the restored QRhi target size."""
@@ -401,7 +533,7 @@ class FramelessWindowManager(QObject):
 
         return self._immersive_active
 
-    def _edit_controller(self) -> "EditCoordinator | None":
+    def _edit_controller(self) -> EditCoordinator | None:
         """Return the edit coordinator exposed by the Detail domain."""
 
         if self._detail_coordinator is None:
@@ -415,6 +547,13 @@ class FramelessWindowManager(QObject):
     # QObject overrides
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:  # type: ignore[override]
         """Handle title-bar dragging and badge positioning."""
+
+        if (
+            watched is self._window
+            and event.type() == QEvent.Type.UpdateRequest
+            and getattr(self, "_fullscreen_enter_pending", None) is not None
+        ):
+            self._emit_fullscreen_transition_event("fullscreen_update_requested")
 
         if watched in self._drag_sources:
             if self._handle_title_bar_drag(event):
@@ -752,7 +891,13 @@ class FramelessWindowManager(QObject):
 
         QTimer.singleShot(PLAYBACK_RESUME_DELAY_MS, _restore)
 
-    def _schedule_playback_resume(self, *, expect_immersive: bool, resume: bool) -> None:
+    def _schedule_playback_resume(
+        self,
+        *,
+        expect_immersive: bool,
+        resume: bool,
+        transition_id: int | None = None,
+    ) -> None:
         if not resume:
             return
         if self._detail_coordinator is None:
@@ -762,8 +907,55 @@ class FramelessWindowManager(QObject):
             if self._immersive_active != expect_immersive:
                 return
             self._detail_coordinator.resume_playback_after_transition()
+            if transition_id is not None:
+                self._emit_fullscreen_transition_event("fullscreen_playback_resumed", transition_id)
 
         QTimer.singleShot(PLAYBACK_RESUME_DELAY_MS, _resume)
+
+    def _emit_fullscreen_transition_event(
+        self, stage: str, transition_id: int | None = None
+    ) -> None:
+        """Emit privacy-safe fullscreen compositor diagnostics when enabled."""
+
+        if not detail_profile_enabled():
+            return
+        active_transition = (
+            transition_id
+            if transition_id is not None
+            else getattr(self, "_fullscreen_enter_pending", None)
+        )
+        if active_transition is None:
+            return
+
+        geometry = self._window.geometry()
+        window_state = self._window.windowState()
+        state_name = getattr(window_state, "name", None) or str(window_state)
+        emit_detail_event(
+            stage,
+            generation=0,
+            transition_id=int(active_transition),
+            geometry=(geometry.x(), geometry.y(), geometry.width(), geometry.height()),
+            window_state=state_name,
+            is_fullscreen=bool(self._window.isFullScreen()),
+            updates_enabled=bool(self._window.updatesEnabled()),
+            backend=getattr(self, "_fullscreen_transition_backend", "unknown"),
+            image_render_target=self._render_target_size(self._ui.image_viewer),
+            video_render_target=self._render_target_size(self._active_video_surface()),
+        )
+
+    def _active_video_surface(self) -> object | None:
+        accessor = getattr(self._ui.video_area, "video_viewport", None)
+        return accessor() if callable(accessor) else self._ui.video_area
+
+    @staticmethod
+    def _render_target_size(viewport: object | None) -> tuple[int, int] | None:
+        accessor = getattr(viewport, "_render_target_device_size", None)
+        if not callable(accessor):
+            return None
+        size = accessor()
+        if size is None:
+            return None
+        return (int(size[0]), int(size[1]))
 
     @contextmanager
     def _suspend_layout_updates(self) -> Iterator[None]:

--- a/tests/ui/test_window_manager_fullscreen.py
+++ b/tests/ui/test_window_manager_fullscreen.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import QWidget
 from iPhoto.gui.ui.window_manager import (
     FULLSCREEN_ENTER_TIMEOUT_MS,
     FULLSCREEN_FINAL_UPDATE_TIMEOUT_MS,
+    PLAYBACK_RESUME_DELAY_MS,
     FramelessWindowManager,
     _FullscreenTransitionPhase,
     _WindowsFullscreenTransition,
@@ -157,6 +158,55 @@ def test_stale_shadow_restore_is_ignored_after_fullscreen_reentry() -> None:
     callbacks[0]()
 
     manager._set_playback_header_shadow_suppressed.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "failure_stage",
+    ("asset", "placeholder", "geometry", "window_state", "splitter"),
+)
+def test_enter_preflight_failure_resumes_suspended_playback(
+    failure_stage: str,
+) -> None:
+    manager = _make_windows_enter_manager()
+    manager._detail_coordinator.suspend_playback_for_transition.return_value = True
+    manager._detail_coordinator.prepare_fullscreen_asset.return_value = True
+    error = RuntimeError(failure_stage)
+    callbacks: list[Callable[[], None]] = []
+    single_shot = MagicMock(side_effect=lambda _delay, callback: callbacks.append(callback))
+
+    if failure_stage == "asset":
+        manager._detail_coordinator.prepare_fullscreen_asset.side_effect = error
+    elif failure_stage == "placeholder":
+        manager._detail_coordinator.prepare_fullscreen_asset.return_value = False
+        manager._detail_coordinator.show_placeholder_in_viewer.side_effect = error
+    elif failure_stage == "geometry":
+        manager._window.saveGeometry.side_effect = error
+    elif failure_stage == "window_state":
+        manager._window.windowState.side_effect = error
+    else:
+        manager._ui.splitter.sizes.side_effect = error
+
+    with (
+        patch("iPhoto.gui.ui.window_manager.sys.platform", "win32"),
+        patch(
+            "iPhoto.gui.ui.window_manager.QTimer.singleShot",
+            single_shot,
+        ),
+        pytest.raises(RuntimeError, match=failure_stage),
+    ):
+        manager.enter_fullscreen()
+
+    assert manager._fullscreen_transition is None
+    assert manager._playback_resume_pending is True
+    manager._window.setUpdatesEnabled.assert_not_called()
+    manager._window.showFullScreen.assert_not_called()
+    assert len(callbacks) == 1
+    assert single_shot.call_args.args[0] == PLAYBACK_RESUME_DELAY_MS
+
+    callbacks[0]()
+
+    manager._detail_coordinator.resume_playback_after_transition.assert_called_once_with()
+    assert manager._playback_resume_pending is False
 
 
 def test_windows_enter_suppresses_updates_before_visible_mutations() -> None:

--- a/tests/ui/test_window_manager_fullscreen.py
+++ b/tests/ui/test_window_manager_fullscreen.py
@@ -4,11 +4,37 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextlib import nullcontext
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
-from PySide6.QtCore import QEvent
+import pytest
+from PySide6.QtCore import QCoreApplication, QEvent, QObject
+from PySide6.QtWidgets import QWidget
 
-from iPhoto.gui.ui.window_manager import FramelessWindowManager
+from iPhoto.gui.ui.window_manager import (
+    FULLSCREEN_ENTER_TIMEOUT_MS,
+    FULLSCREEN_FINAL_UPDATE_TIMEOUT_MS,
+    FramelessWindowManager,
+    _FullscreenTransitionPhase,
+    _WindowsFullscreenTransition,
+)
+
+
+def _transition(
+    transition_id: int,
+    *,
+    phase: _FullscreenTransitionPhase = _FullscreenTransitionPhase.AWAITING_NATIVE,
+    updates_enabled_before: bool = True,
+    playback_generation: int = 1,
+    resume_playback: bool = True,
+) -> _WindowsFullscreenTransition:
+    return _WindowsFullscreenTransition(
+        transition_id=transition_id,
+        phase=phase,
+        updates_enabled_before=updates_enabled_before,
+        playback_generation=playback_generation,
+        resume_playback=resume_playback,
+    )
 
 
 def _make_windows_enter_manager() -> FramelessWindowManager:
@@ -19,27 +45,38 @@ def _make_windows_enter_manager() -> FramelessWindowManager:
     manager._ui = MagicMock()
     manager._ui.splitter.signalsBlocked.return_value = False
     manager._ui.video_area.controls_enabled.return_value = True
-    manager._immersive_visibility_targets = (MagicMock(),)
+    target = MagicMock()
+    target.isVisible.return_value = True
+    manager._immersive_visibility_targets = (target,)
     manager._splitter_sizes = [200, 800]
+    manager._previous_geometry = MagicMock()
+    manager._previous_window_state = MagicMock()
     manager._hidden_widget_states = []
+    manager._video_controls_enabled_before = False
     manager._immersive_active = False
+    manager._immersive_background_applied = False
     manager._fullscreen_transition_generation = 0
-    manager._fullscreen_enter_pending = None
-    manager._fullscreen_enter_updates_enabled_before = None
-    manager._fullscreen_enter_resume = False
-    manager._fullscreen_enter_timeout_timer = None
-    manager._fullscreen_transition_backend = "unknown"
+    manager._fullscreen_transition = None
+    manager._playback_transition_generation = 0
+    manager._playback_resume_pending = False
+    manager._shadow_restore_generation = 0
+    manager._detail_coordinator = MagicMock()
+    manager._edit_controller = MagicMock(return_value=None)
     manager._suppress_playback_header_shadow = MagicMock()
-    manager._override_visibility = MagicMock(return_value=[])
     manager._apply_immersive_backdrop = MagicMock()
+    manager._restore_default_backdrop = MagicMock()
+    manager._update_fullscreen_button_icon = MagicMock()
+    manager._request_media_viewport_relayout = MagicMock()
+    manager._schedule_playback_header_shadow_restore = MagicMock()
     manager._emit_fullscreen_transition_event = MagicMock()
-    manager._start_fullscreen_enter_timeout = MagicMock()
+    manager._start_fullscreen_transition_deadline = MagicMock()
     return manager
 
 
 def test_reconcile_native_exit_finishes_playback_without_requesting_window_change() -> None:
     manager = FramelessWindowManager.__new__(FramelessWindowManager)
     manager._immersive_active = True
+    manager._fullscreen_transition = None
     manager._window = MagicMock()
     manager._window.isFullScreen.return_value = False
     manager._finish_immersive_exit = MagicMock()
@@ -64,6 +101,7 @@ def test_window_state_change_defers_playback_reconciliation() -> None:
 def test_reconcile_does_not_adopt_non_playback_fullscreen() -> None:
     manager = FramelessWindowManager.__new__(FramelessWindowManager)
     manager._immersive_active = False
+    manager._fullscreen_transition = None
     manager._window = MagicMock()
     manager._window.isFullScreen.return_value = True
     manager._finish_immersive_exit = MagicMock()
@@ -74,19 +112,12 @@ def test_reconcile_does_not_adopt_non_playback_fullscreen() -> None:
 
 
 def test_native_exit_restores_playback_without_calling_show_normal() -> None:
-    manager = FramelessWindowManager.__new__(FramelessWindowManager)
+    manager = _make_windows_enter_manager()
     manager._immersive_active = True
-    manager._detail_coordinator = MagicMock()
     manager._detail_coordinator.suspend_playback_for_transition.return_value = False
-    manager._window = MagicMock()
     manager._window.updatesEnabled.return_value = True
-    manager._ui = MagicMock()
-    manager._splitter_sizes = [200, 800]
-    manager._hidden_widget_states = []
-    manager._video_controls_enabled_before = False
-    manager._restore_default_backdrop = MagicMock()
-    manager._update_fullscreen_button_icon = MagicMock()
-    manager._schedule_playback_header_shadow_restore = MagicMock()
+    manager._ui.view_stack.currentWidget.return_value = object()
+    manager._suspend_layout_updates = MagicMock(return_value=nullcontext())
     manager._schedule_playback_resume = MagicMock()
 
     manager._finish_immersive_exit(request_window_change=False)
@@ -97,9 +128,13 @@ def test_native_exit_restores_playback_without_calling_show_normal() -> None:
     manager._window.restoreGeometry.assert_not_called()
     manager._window.setWindowState.assert_not_called()
     manager._ui.splitter.setSizes.assert_called_once_with([200, 800])
-    manager._ui.image_viewer.request_viewport_relayout.assert_called_once_with(reset_view=True)
-    manager._ui.video_area.request_viewport_relayout.assert_called_once_with(reset_view=True)
+    manager._request_media_viewport_relayout.assert_called_once_with(reset_view=True)
     manager._schedule_playback_header_shadow_restore.assert_called_once_with()
+    manager._schedule_playback_resume.assert_called_once_with(
+        expect_immersive=False,
+        resume=False,
+        playback_generation=1,
+    )
 
 
 def test_stale_shadow_restore_is_ignored_after_fullscreen_reentry() -> None:
@@ -127,157 +162,367 @@ def test_stale_shadow_restore_is_ignored_after_fullscreen_reentry() -> None:
 def test_windows_enter_suppresses_updates_before_visible_mutations() -> None:
     manager = _make_windows_enter_manager()
     events: list[str] = []
+    target = manager._immersive_visibility_targets[0]
     manager._window.setUpdatesEnabled.side_effect = lambda enabled: events.append(
         f"updates:{enabled}"
     )
-    manager._suppress_playback_header_shadow.side_effect = lambda: events.append("shadow")
-    manager._override_visibility.side_effect = lambda *_args, **_kwargs: (
-        events.append("visibility") or []
+    manager._start_fullscreen_transition_deadline.side_effect = lambda *_args, **_kwargs: (
+        events.append("deadline")
     )
+    manager._suppress_playback_header_shadow.side_effect = lambda: events.append("shadow")
+    target.setVisible.side_effect = lambda _visible: events.append("visibility")
     manager._apply_immersive_backdrop.side_effect = lambda: events.append("backdrop")
     manager._window.showFullScreen.side_effect = lambda: events.append("fullscreen")
 
-    with patch(
-        "iPhoto.gui.ui.window_manager.selected_rhi_backend_name",
-        return_value="opengl",
-    ):
-        manager._begin_windows_fullscreen_enter(True)
+    manager._begin_windows_fullscreen_enter(True, playback_generation=4)
 
     assert events == [
         "updates:False",
+        "deadline",
         "shadow",
         "visibility",
         "backdrop",
         "fullscreen",
     ]
-    assert manager._fullscreen_enter_pending == 1
-    assert manager._fullscreen_enter_resume is True
-    assert manager._fullscreen_transition_backend == "opengl"
+    transition = manager._fullscreen_transition
+    assert transition is not None
+    assert transition.transition_id == 1
+    assert transition.phase is _FullscreenTransitionPhase.AWAITING_NATIVE
+    assert transition.playback_generation == 4
+    assert transition.resume_playback is True
     assert manager._immersive_active is True
     manager._window.update.assert_not_called()
-    manager._start_fullscreen_enter_timeout.assert_called_once_with(1)
+    manager._start_fullscreen_transition_deadline.assert_called_once_with(
+        transition,
+        timeout_ms=FULLSCREEN_ENTER_TIMEOUT_MS,
+        callback=manager._handle_fullscreen_enter_timeout,
+    )
     assert manager._ui.splitter.blockSignals.call_args_list == [call(True), call(False)]
 
 
-def test_windows_enter_completes_once_after_fullscreen_confirmation() -> None:
+@pytest.mark.parametrize(
+    "failure_stage",
+    (
+        "updates",
+        "deadline",
+        "shadow",
+        "visibility",
+        "controls",
+        "splitter",
+        "backdrop",
+        "native",
+    ),
+)
+def test_windows_enter_restores_updates_when_mutation_raises(failure_stage: str) -> None:
     manager = _make_windows_enter_manager()
-    events: list[str] = []
-    manager._fullscreen_enter_pending = 7
-    manager._fullscreen_enter_updates_enabled_before = True
-    manager._fullscreen_enter_resume = True
+    target = manager._immersive_visibility_targets[0]
+    error = RuntimeError(failure_stage)
+
+    if failure_stage == "updates":
+        manager._window.setUpdatesEnabled.side_effect = lambda enabled: (
+            (_ for _ in ()).throw(error) if not enabled else None
+        )
+    elif failure_stage == "deadline":
+        manager._start_fullscreen_transition_deadline.side_effect = error
+    elif failure_stage == "shadow":
+        manager._suppress_playback_header_shadow.side_effect = error
+    elif failure_stage == "visibility":
+        target.setVisible.side_effect = error
+    elif failure_stage == "controls":
+        manager._ui.video_area.hide_controls.side_effect = error
+    elif failure_stage == "splitter":
+        manager._ui.splitter.setSizes.side_effect = error
+    elif failure_stage == "backdrop":
+        manager._apply_immersive_backdrop.side_effect = error
+    else:
+        manager._window.showFullScreen.side_effect = error
+
+    with pytest.raises(RuntimeError, match=failure_stage):
+        manager._begin_windows_fullscreen_enter(True, playback_generation=3)
+
+    assert manager._fullscreen_transition is None
+    assert manager._immersive_active is False
+    assert manager._window.setUpdatesEnabled.call_args_list[-1] == call(True)
+    manager._window.showNormal.assert_called_once_with()
+
+
+def test_windows_completion_restores_updates_when_relayout_raises() -> None:
+    manager = _make_windows_enter_manager()
+    transition = _transition(6)
+    manager._fullscreen_transition = transition
     manager._immersive_active = True
     manager._window.isFullScreen.return_value = True
-    manager._cancel_fullscreen_enter_timeout = MagicMock()
-    manager._request_media_viewport_relayout = MagicMock()
-    manager._update_fullscreen_button_icon = MagicMock()
-    manager._schedule_playback_resume = MagicMock()
-    manager._request_media_viewport_relayout.side_effect = lambda: events.append("relayout")
-    manager._update_fullscreen_button_icon.side_effect = lambda: events.append("icon")
-    manager._window.setUpdatesEnabled.side_effect = lambda enabled: events.append(
-        f"updates:{enabled}"
+    manager._request_media_viewport_relayout.side_effect = RuntimeError("relayout")
+
+    with pytest.raises(RuntimeError, match="relayout"):
+        manager._complete_windows_fullscreen_enter(6)
+
+    assert manager._fullscreen_transition is None
+    assert manager._immersive_active is False
+    manager._window.setUpdatesEnabled.assert_called_with(True)
+    manager._window.showNormal.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "failure_source",
+    ("enabled", "geometry", "backend", "render_target", "writer"),
+)
+def test_fullscreen_diagnostics_are_best_effort(failure_source: str) -> None:
+    manager = _make_windows_enter_manager()
+    manager._fullscreen_transition = _transition(12)
+    manager._emit_fullscreen_transition_event = (
+        FramelessWindowManager._emit_fullscreen_transition_event.__get__(manager)
     )
-    manager._window.update.side_effect = lambda: events.append("update")
 
-    manager._reconcile_playback_fullscreen_state()
-    manager._reconcile_playback_fullscreen_state()
+    enabled = MagicMock(return_value=True)
+    writer = MagicMock()
+    if failure_source == "enabled":
+        enabled.side_effect = RuntimeError("enabled")
+    elif failure_source == "geometry":
+        manager._window.geometry.side_effect = RuntimeError("geometry")
+    elif failure_source == "backend":
+        manager._ui.image_viewer.render_backend_name.side_effect = RuntimeError("backend")
+    elif failure_source == "render_target":
+        manager._ui.image_viewer._render_target_device_size.side_effect = RuntimeError(
+            "render_target"
+        )
+    else:
+        writer.side_effect = RuntimeError("writer")
 
-    assert manager._fullscreen_enter_pending is None
-    manager._cancel_fullscreen_enter_timeout.assert_called_once_with()
+    with (
+        patch("iPhoto.gui.ui.window_manager.detail_profile_enabled", enabled),
+        patch("iPhoto.gui.ui.window_manager.emit_detail_event", writer),
+    ):
+        manager._emit_fullscreen_transition_event("fullscreen_test", 12)
+
+
+def test_windows_enter_survives_diagnostic_writer_failure() -> None:
+    manager = _make_windows_enter_manager()
+    manager._emit_fullscreen_transition_event = (
+        FramelessWindowManager._emit_fullscreen_transition_event.__get__(manager)
+    )
+
+    with (
+        patch(
+            "iPhoto.gui.ui.window_manager.detail_profile_enabled",
+            return_value=True,
+        ),
+        patch(
+            "iPhoto.gui.ui.window_manager.emit_detail_event",
+            side_effect=RuntimeError("writer"),
+        ),
+    ):
+        manager._begin_windows_fullscreen_enter(True, playback_generation=2)
+        transition = manager._fullscreen_transition
+        assert transition is not None
+        manager._window.isFullScreen.return_value = True
+        manager._complete_windows_fullscreen_enter(transition.transition_id)
+
+    assert manager._fullscreen_transition is transition
+    assert transition.phase is _FullscreenTransitionPhase.AWAITING_FINAL_UPDATE
+    manager._window.setUpdatesEnabled.assert_called_with(True)
+
+
+def test_windows_enter_waits_for_implicit_final_update() -> None:
+    manager = _make_windows_enter_manager()
+    transition = _transition(7, playback_generation=5)
+    manager._fullscreen_transition = transition
+    manager._fullscreen_transition_generation = 7
+    manager._immersive_active = True
+    manager._window.isFullScreen.return_value = True
+    manager._schedule_playback_resume = MagicMock()
+
+    manager._complete_windows_fullscreen_enter(7)
+    manager._complete_windows_fullscreen_enter(7)
+
+    assert manager._fullscreen_transition is transition
+    assert transition.phase is _FullscreenTransitionPhase.AWAITING_FINAL_UPDATE
     manager._request_media_viewport_relayout.assert_called_once_with()
     manager._window.setUpdatesEnabled.assert_called_once_with(True)
-    manager._window.update.assert_called_once_with()
+    manager._window.update.assert_not_called()
     manager._update_fullscreen_button_icon.assert_called_once_with()
     manager._schedule_playback_resume.assert_called_once_with(
         expect_immersive=True,
         resume=True,
+        playback_generation=5,
         transition_id=7,
     )
-    assert events == ["relayout", "icon", "updates:True", "update"]
+    manager._start_fullscreen_transition_deadline.assert_called_once_with(
+        transition,
+        timeout_ms=FULLSCREEN_FINAL_UPDATE_TIMEOUT_MS,
+        callback=manager._handle_fullscreen_final_update_timeout,
+    )
 
 
-def test_windows_enter_ignores_stale_timeout() -> None:
+def test_final_update_timeout_cannot_finish_new_transition() -> None:
     manager = _make_windows_enter_manager()
-    manager._fullscreen_enter_pending = 8
-    manager._complete_windows_fullscreen_enter = MagicMock()
-    manager._finish_immersive_exit = MagicMock()
+    old_transition = _transition(
+        8,
+        phase=_FullscreenTransitionPhase.AWAITING_FINAL_UPDATE,
+    )
+    manager._fullscreen_transition = _transition(9)
+    manager._finish_fullscreen_transition_observation = MagicMock()
 
-    manager._handle_fullscreen_enter_timeout(7)
+    manager._handle_fullscreen_final_update_timeout(old_transition.transition_id)
 
-    manager._complete_windows_fullscreen_enter.assert_not_called()
-    manager._finish_immersive_exit.assert_not_called()
+    manager._finish_fullscreen_transition_observation.assert_not_called()
 
 
-def test_windows_enter_timeout_completes_when_native_state_landed() -> None:
+def test_final_update_timeout_is_diagnostic_only() -> None:
     manager = _make_windows_enter_manager()
-    manager._fullscreen_enter_pending = 8
-    manager._window.isFullScreen.return_value = True
-    manager._complete_windows_fullscreen_enter = MagicMock()
+    transition = _transition(
+        8,
+        phase=_FullscreenTransitionPhase.AWAITING_FINAL_UPDATE,
+    )
+    manager._fullscreen_transition = transition
+    manager._immersive_active = True
 
-    manager._handle_fullscreen_enter_timeout(8)
+    manager._handle_fullscreen_final_update_timeout(8)
 
-    manager._complete_windows_fullscreen_enter.assert_called_once_with(8)
+    assert manager._fullscreen_transition is None
+    assert manager._immersive_active is True
+    manager._window.showNormal.assert_not_called()
+    manager._emit_fullscreen_transition_event.assert_any_call(
+        "fullscreen_final_update_unobserved",
+        8,
+    )
+
+
+def test_qt_event_loop_attributes_implicit_update_to_transition(qapp) -> None:
+    window = QWidget()
+    manager = FramelessWindowManager.__new__(FramelessWindowManager)
+    QObject.__init__(manager, window)
+    manager._window = window
+    manager._ui = SimpleNamespace(badge_host=None)
+    manager._drag_sources = set()
+    transition = _transition(
+        10,
+        phase=_FullscreenTransitionPhase.AWAITING_FINAL_UPDATE,
+    )
+    manager._fullscreen_transition = transition
+    manager._emit_fullscreen_transition_event = MagicMock()
+    window.installEventFilter(manager)
+    window.resize(160, 90)
+    window.show()
+    qapp.processEvents()
+
+    window.setUpdatesEnabled(False)
+    manager._restore_windows_fullscreen_updates(transition)
+    QCoreApplication.sendPostedEvents(window, QEvent.Type.UpdateRequest)
+    qapp.processEvents()
+
+    assert manager._fullscreen_transition is None
+    assert call("fullscreen_update_requested", 10) in (
+        manager._emit_fullscreen_transition_event.call_args_list
+    )
+    manager._emit_fullscreen_transition_event.assert_any_call(
+        "fullscreen_transition_finished",
+        10,
+        reason="final_update_observed",
+    )
+    window.close()
 
 
 def test_windows_enter_timeout_rolls_back_when_native_state_failed() -> None:
     manager = _make_windows_enter_manager()
-    manager._fullscreen_enter_pending = 8
+    transition = _transition(8, playback_generation=3)
+    manager._fullscreen_transition = transition
     manager._window.isFullScreen.return_value = False
-    manager._finish_immersive_exit = MagicMock()
+    manager._schedule_playback_resume = MagicMock()
 
     manager._handle_fullscreen_enter_timeout(8)
 
-    manager._finish_immersive_exit.assert_called_once_with(request_window_change=True)
+    assert manager._fullscreen_transition is None
+    assert manager._immersive_active is False
+    manager._window.setUpdatesEnabled.assert_called_with(True)
+    manager._schedule_playback_resume.assert_called_once_with(
+        expect_immersive=False,
+        resume=True,
+        playback_generation=3,
+        transition_id=8,
+    )
 
 
-def test_exit_during_pending_windows_enter_restores_updates_once() -> None:
+def test_exit_during_pending_windows_enter_uses_rollback() -> None:
     manager = _make_windows_enter_manager()
+    transition = _transition(9, playback_generation=1)
+    manager._fullscreen_transition = transition
     manager._immersive_active = True
-    manager._fullscreen_enter_pending = 9
-    manager._fullscreen_enter_updates_enabled_before = True
-    manager._fullscreen_enter_resume = True
-    manager._detail_coordinator = MagicMock()
-    manager._edit_controller = MagicMock(return_value=None)
+    manager._playback_resume_pending = True
     manager._window.updatesEnabled.return_value = False
-    manager._previous_geometry = MagicMock()
-    manager._previous_window_state = MagicMock()
-    manager._hidden_widget_states = [(MagicMock(), True)]
-    manager._video_controls_enabled_before = True
-    manager._restore_default_backdrop = MagicMock()
-    manager._cancel_fullscreen_enter_timeout = MagicMock()
-    manager._update_fullscreen_button_icon = MagicMock()
-    manager._request_media_viewport_relayout = MagicMock()
-    manager._schedule_playback_header_shadow_restore = MagicMock()
-    manager._schedule_playback_resume = MagicMock()
     manager._ui.view_stack.currentWidget.return_value = object()
+    manager._schedule_playback_resume = MagicMock()
 
     manager.exit_fullscreen()
 
-    assert manager._fullscreen_enter_pending is None
+    assert manager._fullscreen_transition is None
     assert manager._immersive_active is False
-    manager._cancel_fullscreen_enter_timeout.assert_called_once_with()
     manager._window.showNormal.assert_called_once_with()
-    assert manager._window.setUpdatesEnabled.call_args_list[-1] == call(True)
-    manager._window.update.assert_called_once_with()
-    manager._request_media_viewport_relayout.assert_called_once_with(reset_view=True)
+    manager._window.setUpdatesEnabled.assert_called_with(True)
     manager._detail_coordinator.suspend_playback_for_transition.assert_not_called()
     manager._schedule_playback_resume.assert_called_once_with(
         expect_immersive=False,
         resume=True,
+        playback_generation=1,
         transition_id=9,
     )
 
 
+def test_exit_after_confirmation_finishes_observation_without_rollback() -> None:
+    manager = _make_windows_enter_manager()
+    transition = _transition(
+        11,
+        phase=_FullscreenTransitionPhase.AWAITING_FINAL_UPDATE,
+    )
+    manager._fullscreen_transition = transition
+    manager._immersive_active = True
+    manager._playback_resume_pending = True
+    manager._ui.view_stack.currentWidget.return_value = object()
+    manager._suspend_layout_updates = MagicMock(return_value=nullcontext())
+    manager._rollback_windows_fullscreen_enter = MagicMock()
+    manager._schedule_playback_resume = MagicMock()
+
+    manager.exit_fullscreen()
+
+    manager._rollback_windows_fullscreen_enter.assert_not_called()
+    assert manager._fullscreen_transition is None
+    manager._window.showNormal.assert_called_once_with()
+
+
+def test_rapid_fullscreen_toggles_only_latest_callback_resumes_playback() -> None:
+    manager = _make_windows_enter_manager()
+    manager._detail_coordinator.suspend_playback_for_transition.return_value = True
+    callbacks: list[Callable[[], None]] = []
+
+    with patch(
+        "iPhoto.gui.ui.window_manager.QTimer.singleShot",
+        side_effect=lambda _delay, callback: callbacks.append(callback),
+    ):
+        for expect_immersive in (True, False, True, False):
+            generation, resume = manager._begin_playback_transition()
+            manager._schedule_playback_resume(
+                expect_immersive=expect_immersive,
+                resume=resume,
+                playback_generation=generation,
+            )
+
+    manager._immersive_active = False
+    for callback in callbacks:
+        callback()
+
+    manager._detail_coordinator.suspend_playback_for_transition.assert_called_once_with()
+    manager._detail_coordinator.resume_playback_after_transition.assert_called_once_with()
+    assert manager._playback_resume_pending is False
+
+
 def test_non_windows_enter_keeps_existing_eager_update_path() -> None:
     manager = _make_windows_enter_manager()
-    manager._detail_coordinator = MagicMock()
     manager._detail_coordinator.suspend_playback_for_transition.return_value = True
     manager._detail_coordinator.prepare_fullscreen_asset.return_value = True
-    manager._edit_controller = MagicMock(return_value=None)
     manager._window.saveGeometry.return_value = MagicMock()
     manager._window.windowState.return_value = MagicMock()
     manager._ui.splitter.sizes.return_value = [200, 800]
     manager._suspend_layout_updates = MagicMock(return_value=nullcontext())
-    manager._update_fullscreen_button_icon = MagicMock()
     manager._schedule_playback_resume = MagicMock()
     manager._begin_windows_fullscreen_enter = MagicMock()
 
@@ -290,4 +535,5 @@ def test_non_windows_enter_keeps_existing_eager_update_path() -> None:
     manager._schedule_playback_resume.assert_called_once_with(
         expect_immersive=True,
         resume=True,
+        playback_generation=1,
     )

--- a/tests/ui/test_window_manager_fullscreen.py
+++ b/tests/ui/test_window_manager_fullscreen.py
@@ -3,11 +3,38 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from unittest.mock import MagicMock, patch
+from contextlib import nullcontext
+from unittest.mock import MagicMock, call, patch
 
 from PySide6.QtCore import QEvent
 
 from iPhoto.gui.ui.window_manager import FramelessWindowManager
+
+
+def _make_windows_enter_manager() -> FramelessWindowManager:
+    manager = FramelessWindowManager.__new__(FramelessWindowManager)
+    manager._window = MagicMock()
+    manager._window.updatesEnabled.return_value = True
+    manager._window.isFullScreen.return_value = False
+    manager._ui = MagicMock()
+    manager._ui.splitter.signalsBlocked.return_value = False
+    manager._ui.video_area.controls_enabled.return_value = True
+    manager._immersive_visibility_targets = (MagicMock(),)
+    manager._splitter_sizes = [200, 800]
+    manager._hidden_widget_states = []
+    manager._immersive_active = False
+    manager._fullscreen_transition_generation = 0
+    manager._fullscreen_enter_pending = None
+    manager._fullscreen_enter_updates_enabled_before = None
+    manager._fullscreen_enter_resume = False
+    manager._fullscreen_enter_timeout_timer = None
+    manager._fullscreen_transition_backend = "unknown"
+    manager._suppress_playback_header_shadow = MagicMock()
+    manager._override_visibility = MagicMock(return_value=[])
+    manager._apply_immersive_backdrop = MagicMock()
+    manager._emit_fullscreen_transition_event = MagicMock()
+    manager._start_fullscreen_enter_timeout = MagicMock()
+    return manager
 
 
 def test_reconcile_native_exit_finishes_playback_without_requesting_window_change() -> None:
@@ -70,12 +97,8 @@ def test_native_exit_restores_playback_without_calling_show_normal() -> None:
     manager._window.restoreGeometry.assert_not_called()
     manager._window.setWindowState.assert_not_called()
     manager._ui.splitter.setSizes.assert_called_once_with([200, 800])
-    manager._ui.image_viewer.request_viewport_relayout.assert_called_once_with(
-        reset_view=True
-    )
-    manager._ui.video_area.request_viewport_relayout.assert_called_once_with(
-        reset_view=True
-    )
+    manager._ui.image_viewer.request_viewport_relayout.assert_called_once_with(reset_view=True)
+    manager._ui.video_area.request_viewport_relayout.assert_called_once_with(reset_view=True)
     manager._schedule_playback_header_shadow_restore.assert_called_once_with()
 
 
@@ -99,3 +122,172 @@ def test_stale_shadow_restore_is_ignored_after_fullscreen_reentry() -> None:
     callbacks[0]()
 
     manager._set_playback_header_shadow_suppressed.assert_not_called()
+
+
+def test_windows_enter_suppresses_updates_before_visible_mutations() -> None:
+    manager = _make_windows_enter_manager()
+    events: list[str] = []
+    manager._window.setUpdatesEnabled.side_effect = lambda enabled: events.append(
+        f"updates:{enabled}"
+    )
+    manager._suppress_playback_header_shadow.side_effect = lambda: events.append("shadow")
+    manager._override_visibility.side_effect = lambda *_args, **_kwargs: (
+        events.append("visibility") or []
+    )
+    manager._apply_immersive_backdrop.side_effect = lambda: events.append("backdrop")
+    manager._window.showFullScreen.side_effect = lambda: events.append("fullscreen")
+
+    with patch(
+        "iPhoto.gui.ui.window_manager.selected_rhi_backend_name",
+        return_value="opengl",
+    ):
+        manager._begin_windows_fullscreen_enter(True)
+
+    assert events == [
+        "updates:False",
+        "shadow",
+        "visibility",
+        "backdrop",
+        "fullscreen",
+    ]
+    assert manager._fullscreen_enter_pending == 1
+    assert manager._fullscreen_enter_resume is True
+    assert manager._fullscreen_transition_backend == "opengl"
+    assert manager._immersive_active is True
+    manager._window.update.assert_not_called()
+    manager._start_fullscreen_enter_timeout.assert_called_once_with(1)
+    assert manager._ui.splitter.blockSignals.call_args_list == [call(True), call(False)]
+
+
+def test_windows_enter_completes_once_after_fullscreen_confirmation() -> None:
+    manager = _make_windows_enter_manager()
+    events: list[str] = []
+    manager._fullscreen_enter_pending = 7
+    manager._fullscreen_enter_updates_enabled_before = True
+    manager._fullscreen_enter_resume = True
+    manager._immersive_active = True
+    manager._window.isFullScreen.return_value = True
+    manager._cancel_fullscreen_enter_timeout = MagicMock()
+    manager._request_media_viewport_relayout = MagicMock()
+    manager._update_fullscreen_button_icon = MagicMock()
+    manager._schedule_playback_resume = MagicMock()
+    manager._request_media_viewport_relayout.side_effect = lambda: events.append("relayout")
+    manager._update_fullscreen_button_icon.side_effect = lambda: events.append("icon")
+    manager._window.setUpdatesEnabled.side_effect = lambda enabled: events.append(
+        f"updates:{enabled}"
+    )
+    manager._window.update.side_effect = lambda: events.append("update")
+
+    manager._reconcile_playback_fullscreen_state()
+    manager._reconcile_playback_fullscreen_state()
+
+    assert manager._fullscreen_enter_pending is None
+    manager._cancel_fullscreen_enter_timeout.assert_called_once_with()
+    manager._request_media_viewport_relayout.assert_called_once_with()
+    manager._window.setUpdatesEnabled.assert_called_once_with(True)
+    manager._window.update.assert_called_once_with()
+    manager._update_fullscreen_button_icon.assert_called_once_with()
+    manager._schedule_playback_resume.assert_called_once_with(
+        expect_immersive=True,
+        resume=True,
+        transition_id=7,
+    )
+    assert events == ["relayout", "icon", "updates:True", "update"]
+
+
+def test_windows_enter_ignores_stale_timeout() -> None:
+    manager = _make_windows_enter_manager()
+    manager._fullscreen_enter_pending = 8
+    manager._complete_windows_fullscreen_enter = MagicMock()
+    manager._finish_immersive_exit = MagicMock()
+
+    manager._handle_fullscreen_enter_timeout(7)
+
+    manager._complete_windows_fullscreen_enter.assert_not_called()
+    manager._finish_immersive_exit.assert_not_called()
+
+
+def test_windows_enter_timeout_completes_when_native_state_landed() -> None:
+    manager = _make_windows_enter_manager()
+    manager._fullscreen_enter_pending = 8
+    manager._window.isFullScreen.return_value = True
+    manager._complete_windows_fullscreen_enter = MagicMock()
+
+    manager._handle_fullscreen_enter_timeout(8)
+
+    manager._complete_windows_fullscreen_enter.assert_called_once_with(8)
+
+
+def test_windows_enter_timeout_rolls_back_when_native_state_failed() -> None:
+    manager = _make_windows_enter_manager()
+    manager._fullscreen_enter_pending = 8
+    manager._window.isFullScreen.return_value = False
+    manager._finish_immersive_exit = MagicMock()
+
+    manager._handle_fullscreen_enter_timeout(8)
+
+    manager._finish_immersive_exit.assert_called_once_with(request_window_change=True)
+
+
+def test_exit_during_pending_windows_enter_restores_updates_once() -> None:
+    manager = _make_windows_enter_manager()
+    manager._immersive_active = True
+    manager._fullscreen_enter_pending = 9
+    manager._fullscreen_enter_updates_enabled_before = True
+    manager._fullscreen_enter_resume = True
+    manager._detail_coordinator = MagicMock()
+    manager._edit_controller = MagicMock(return_value=None)
+    manager._window.updatesEnabled.return_value = False
+    manager._previous_geometry = MagicMock()
+    manager._previous_window_state = MagicMock()
+    manager._hidden_widget_states = [(MagicMock(), True)]
+    manager._video_controls_enabled_before = True
+    manager._restore_default_backdrop = MagicMock()
+    manager._cancel_fullscreen_enter_timeout = MagicMock()
+    manager._update_fullscreen_button_icon = MagicMock()
+    manager._request_media_viewport_relayout = MagicMock()
+    manager._schedule_playback_header_shadow_restore = MagicMock()
+    manager._schedule_playback_resume = MagicMock()
+    manager._ui.view_stack.currentWidget.return_value = object()
+
+    manager.exit_fullscreen()
+
+    assert manager._fullscreen_enter_pending is None
+    assert manager._immersive_active is False
+    manager._cancel_fullscreen_enter_timeout.assert_called_once_with()
+    manager._window.showNormal.assert_called_once_with()
+    assert manager._window.setUpdatesEnabled.call_args_list[-1] == call(True)
+    manager._window.update.assert_called_once_with()
+    manager._request_media_viewport_relayout.assert_called_once_with(reset_view=True)
+    manager._detail_coordinator.suspend_playback_for_transition.assert_not_called()
+    manager._schedule_playback_resume.assert_called_once_with(
+        expect_immersive=False,
+        resume=True,
+        transition_id=9,
+    )
+
+
+def test_non_windows_enter_keeps_existing_eager_update_path() -> None:
+    manager = _make_windows_enter_manager()
+    manager._detail_coordinator = MagicMock()
+    manager._detail_coordinator.suspend_playback_for_transition.return_value = True
+    manager._detail_coordinator.prepare_fullscreen_asset.return_value = True
+    manager._edit_controller = MagicMock(return_value=None)
+    manager._window.saveGeometry.return_value = MagicMock()
+    manager._window.windowState.return_value = MagicMock()
+    manager._ui.splitter.sizes.return_value = [200, 800]
+    manager._suspend_layout_updates = MagicMock(return_value=nullcontext())
+    manager._update_fullscreen_button_icon = MagicMock()
+    manager._schedule_playback_resume = MagicMock()
+    manager._begin_windows_fullscreen_enter = MagicMock()
+
+    with patch("iPhoto.gui.ui.window_manager.sys.platform", "linux"):
+        manager.enter_fullscreen()
+
+    manager._begin_windows_fullscreen_enter.assert_not_called()
+    manager._apply_immersive_backdrop.assert_called_once_with()
+    manager._window.showFullScreen.assert_called_once_with()
+    manager._schedule_playback_resume.assert_called_once_with(
+        expect_immersive=True,
+        resume=True,
+    )


### PR DESCRIPTION
This pull request implements a robust, diagnostic-safe fullscreen compositor transition for Windows in the application's window manager. It introduces a transactional approach to entering and exiting fullscreen mode, with detailed timeline event emission for profiling and a failsafe timeout to ensure UI consistency. The changes are primarily focused on improving the reliability of fullscreen transitions, especially for A/B experiments comparing OpenGL and D3D11 backends, and on enhancing profiling and diagnostics.

**Fullscreen Compositor Transition and Diagnostics (Windows):**

- Adds a transactional, event-driven fullscreen entry/exit path for Windows, including state tracking, atomic UI changes, and a one-second timeout to prevent UI lockup if native events are missing. This ensures that UI updates are resumed or rolled back reliably after fullscreen transitions. [[1]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R112-R117) [[2]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R331-R366) [[3]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R394-R400) [[4]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R437-R519)
- Emits detailed, privacy-safe diagnostic events at each stage of the fullscreen transition (e.g., requested, updates suspended/resumed, native state confirmed, relayout requested, playback resumed, timeout, rollback) for profiling and benchmarking. [[1]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R197) [[2]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R551-R557) [[3]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39L755-R900) [[4]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R910-R959)
- Integrates backend identification and render target size reporting into the diagnostics, supporting A/B comparison between OpenGL and D3D11. [[1]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R331-R366) [[2]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39L755-R900)

**Supporting Documentation and Benchmarking:**

- Updates the Windows D3D11 QRHI status documentation to describe the new fullscreen compositor hotfix, diagnostic requirements, and experimental status of D3D11.
- Expands the benchmark runbook to specify required timeline events and validation steps for Windows fullscreen playback scenarios, ensuring comprehensive coverage and reproducibility in performance tests. [[1]](diffhunk://#diff-64a33dc47755c9f71d4c45a0d986f7946feb291d98b174c0e4f869d12154841cR41-R51) [[2]](diffhunk://#diff-64a33dc47755c9f71d4c45a0d986f7946feb291d98b174c0e4f869d12154841cR169-R174)

**Codebase Maintenance and Type Improvements:**

- Refactors imports and type annotations for clarity and maintainability in `window_manager.py`. [[1]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R6-L15) [[2]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39R25-R27) [[3]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39L37-R38) [[4]](diffhunk://#diff-ef8fc7e662f24d2b8aadab1edb05fa212539f98c56d4b27564e55a0f8dfb4b39L404-R536)

These changes collectively make fullscreen transitions on Windows more robust, easier to diagnose, and safer for production experimentation, while establishing a clear contract for future backend improvements and performance validation.